### PR TITLE
presto-product-tests: download hive-jdbc-fat.jar only if it is needed

### DIFF
--- a/presto-product-tests/libs/download.sh
+++ b/presto-product-tests/libs/download.sh
@@ -3,8 +3,17 @@
 HIVE_JDBC_DOWNLOAD_URL='http://bdch-ftp.td.teradata.com:8081/nexus/service/local/artifact/maven/redirect?r=test-framework&g=org.apache.hive&a=hive-jdbc-all&v=1.0-SNAPSHOT&e=jar'
 HIVE_JDBC_JAR_NAME='test-framework-hive-jdbc-all.jar'
 
-if [ ! -f ${HIVE_JDBC_JAR_NAME} ]; then
+# when jar doesn't exist yet, or the jar is just empty file (previous download was failed)
+if [[ (! -f ${HIVE_JDBC_JAR_NAME}) || (! -s ${HIVE_JDBC_JAR_NAME})  ]]; then
+    rm -rf ${HIVE_JDBC_JAR_NAME}
+    echo "Downloading ${HIVE_JDBC_JAR_NAME} ..."
     wget ${HIVE_JDBC_DOWNLOAD_URL} -O ${HIVE_JDBC_JAR_NAME}
+    if [ $? -ne 0 ]; then
+        echo "Download ${HIVE_JDBC_JAR_NAME} failed."
+        rm -rf ${HIVE_JDBC_JAR_NAME}
+    else
+        echo "${HIVE_JDBC_JAR_NAME} has been successfully downloaded."
+    fi
 else
     echo "File ${HIVE_JDBC_JAR_NAME} already downloaded"
 fi

--- a/presto-product-tests/pom.xml
+++ b/presto-product-tests/pom.xml
@@ -14,7 +14,6 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <skip.product.tests>true</skip.product.tests>
     </properties>
 
     <dependencies>
@@ -83,41 +82,6 @@
                 </executions>
             </plugin>
 
-            <!-- download hive JDBC -->
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>1.4.0</version>
-                <executions>
-                    <execution>
-                        <id>download-ugly-libs</id>
-                        <phase>generate-test-resources</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <executable>./download.sh</executable>
-                    <workingDirectory>libs</workingDirectory>
-                </configuration>
-            </plugin>
-
-            <!-- run product tests -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <environmentVariables>
-                        <PRESTO_PRODUCT_TESTS_ROOT>${project.basedir}/</PRESTO_PRODUCT_TESTS_ROOT>
-                    </environmentVariables>
-                    <suiteXmlFiles>
-                        <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
-                    </suiteXmlFiles>
-                    <skipTests>${skip.product.tests}</skipTests>
-                </configuration>
-            </plugin>
-
             <!-- exclude conflicting dependencies -->
             <plugin>
                 <groupId>com.ning.maven.plugins</groupId>
@@ -169,9 +133,43 @@
     <profiles>
         <profile>
             <id>productTests</id>
-            <properties>
-                <skip.product.tests>false</skip.product.tests>
-            </properties>
+            <build>
+                <plugins>
+                    <!-- download hive JDBC -->
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>1.4.0</version>
+                        <executions>
+                            <execution>
+                                <id>download-ugly-libs</id>
+                                <phase>generate-test-resources</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <executable>./download.sh</executable>
+                            <workingDirectory>libs</workingDirectory>
+                        </configuration>
+                    </plugin>
+
+                    <!-- run product tests -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <environmentVariables>
+                                <PRESTO_PRODUCT_TESTS_ROOT>${project.basedir}/</PRESTO_PRODUCT_TESTS_ROOT>
+                            </environmentVariables>
+                            <suiteXmlFiles>
+                                <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
+                            </suiteXmlFiles>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Hive jdbc jar was dowloaded for each presto build, even when productTest profile was not activated.
Also download.sh was not checking whether the jar download had been finished succesfully.

Testing: manual
