### PR TITLE
Test if new horology and string functions registered

### DIFF
--- a/presto-product-tests/src/test/resources/sql-tests/testcases/horology_functions/checkHorologyFunctionsRegistered.result
+++ b/presto-product-tests/src/test/resources/sql-tests/testcases/horology_functions/checkHorologyFunctionsRegistered.result
@@ -87,3 +87,8 @@
  yow                             | timestamp                                                                      | bigint                   | scalar        | true
  yow                             | timestamp with time zone                                                       | bigint                   | scalar        | true
  yow                             | date                                                                           | bigint                   | scalar        | true
+ to_iso8601                      | timestamp                                                                      | varchar                  | scalar        | true
+ to_iso8601                      | timestamp with time zone                                                       | varchar                  | scalar        | true
+ to_iso8601                      | date                                                                           | varchar                  | scalar        | true
+ from_iso8601_timestamp          | varchar                                                                        | timestamp with time zone | scalar        | true
+ from_iso8601_date               | varchar                                                                        | date                     | scalar        | true

--- a/presto-product-tests/src/test/resources/sql-tests/testcases/string_functions/checkStringFunctionsRegistered.result
+++ b/presto-product-tests/src/test/resources/sql-tests/testcases/string_functions/checkStringFunctionsRegistered.result
@@ -1,18 +1,24 @@
 -- delimiter: |; ignoreOrder: true; ignoreExcessRows: true; trimValues:true
-chr        | bigint                    | varchar        | scalar  | true
-concat     | varchar                   | varchar        | scalar  | true
-length     | varchar                   | bigint         | scalar  | true
-lower      | varchar                   | varchar        | scalar  | true
-ltrim      | varchar                   | varchar        | scalar  | true
-replace    | varchar, varchar          | varchar        | scalar  | true
-replace    | varchar, varchar, varchar | varchar        | scalar  | true
-reverse    | varchar                   | varchar        | scalar  | true
-rtrim      | varchar                   | varchar        | scalar  | true
-split      | varchar, varchar          | array<varchar> | scalar  | true
-split      | varchar, varchar, bigint  | array<varchar> | scalar  | true
-split_part | varchar, varchar, bigint  | varchar        | scalar  | true
-strpos     | varchar, varchar          | bigint         | scalar  | true
-substr     | varchar, bigint           | varchar        | scalar  | true
-substr     | varchar, bigint, bigint   | varchar        | scalar  | true
-trim       | varchar                   | varchar        | scalar  | true
-upper      | varchar                   | varchar        | scalar  | true
+chr                   | bigint                               | varchar        | scalar  | true
+concat                | varchar                              | varchar        | scalar  | true
+length                | varchar                              | bigint         | scalar  | true
+lower                 | varchar                              | varchar        | scalar  | true
+ltrim                 | varchar                              | varchar        | scalar  | true
+replace               | varchar, varchar                     | varchar        | scalar  | true
+replace               | varchar, varchar, varchar            | varchar        | scalar  | true
+reverse               | varchar                              | varchar        | scalar  | true
+rtrim                 | varchar                              | varchar        | scalar  | true
+split                 | varchar, varchar                     | array<varchar> | scalar  | true
+split                 | varchar, varchar, bigint             | array<varchar> | scalar  | true
+split_part            | varchar, varchar, bigint             | varchar        | scalar  | true
+strpos                | varchar, varchar                     | bigint         | scalar  | true
+substr                | varchar, bigint                      | varchar        | scalar  | true
+substr                | varchar, bigint, bigint              | varchar        | scalar  | true
+trim                  | varchar                              | varchar        | scalar  | true
+upper                 | varchar                              | varchar        | scalar  | true
+index                 | varchar, varchar                     | bigint         | scalar  | true
+char2hexint           | varchar                              | varchar        | scalar  | true
+to_date               | varchar, varchar                     | date           | scalar  | true
+to_timestamp          | varchar, varchar                     | timestamp      | scalar  | true
+to_char               | timestamp with time zone, varchar    | varchar        | scalar  | true
+normalize             | varchar, varchar                     | varchar        | scalar  | true


### PR DESCRIPTION
Verify if following functions are registered and available during
runtime:
- index
- char2hexint
- to_date
- to_timestamp
- to_char
- normalize
- to_iso8601
- from_iso8601_timestamp
- from_iso8601_date
