### PR TITLE
Test UNION on partitioned tables

### DIFF
--- a/presto-product-tests/src/test/java/com/facebook/presto/tests/hive/TestTablePartitioningSelect.java
+++ b/presto-product-tests/src/test/java/com/facebook/presto/tests/hive/TestTablePartitioningSelect.java
@@ -104,6 +104,23 @@ public class TestTablePartitioningSelect
         assertProcessedLinesCountEquals(selectFromOnePartitionsSql, onePartitionQueryResult, 1);
     }
 
+    @Test(groups = HIVE_CONNECTOR)
+    public void testUnionPartitionedHiveTableDifferentFormats()
+            throws SQLException
+    {
+        String tableNameInDatabase = tablesState.get(TABLE_NAME).getNameInDatabase();
+
+        String selectFromAllPartitionsSql = "SELECT * FROM " + tableNameInDatabase + " UNION ALL SELECT * FROM " + tableNameInDatabase;
+        QueryResult allPartitionsQueryResult = query(selectFromAllPartitionsSql);
+        assertThat(allPartitionsQueryResult).containsOnly(row(42, 1), row(42, 2), row(42, 1), row(42, 2));
+        assertProcessedLinesCountEquals(selectFromAllPartitionsSql, allPartitionsQueryResult, 4);
+
+        String selectFromOnePartitionsSql = "SELECT * FROM " + tableNameInDatabase + " WHERE part_col = 2 UNION ALL SELECT * FROM " + tableNameInDatabase;
+        QueryResult onePartitionQueryResult = query(selectFromOnePartitionsSql);
+        assertThat(onePartitionQueryResult).containsOnly(row(42, 2), row(42, 1), row(42, 2));
+        assertProcessedLinesCountEquals(selectFromOnePartitionsSql, onePartitionQueryResult, 3);
+    }
+
     private static final long GET_PROCESSED_LINES_COUNT_RETRY_SLEEP = 500;
 
     private void assertProcessedLinesCountEquals(String sqlStatement, QueryResult allPartitionsQueryResult, int expected)


### PR DESCRIPTION
UNION runs partitioned if the plan is partitioned, so make sure that
UNION queries behave as expected on partitioned tables.

Testing: ran test
