### PR TITLE
Increase sleep in TestTablePartitioningSelect

### DIFF
--- a/presto-product-tests/src/test/java/com/facebook/presto/tests/hive/TestTablePartitioningSelect.java
+++ b/presto-product-tests/src/test/java/com/facebook/presto/tests/hive/TestTablePartitioningSelect.java
@@ -121,7 +121,7 @@ public class TestTablePartitioningSelect
         assertProcessedLinesCountEquals(selectFromOnePartitionSql, onePartitionQueryResult, 3);
     }
 
-    private static final long GET_PROCESSED_LINES_COUNT_RETRY_SLEEP = 500;
+    private static final long GET_PROCESSED_LINES_COUNT_RETRY_SLEEP = 1000;
 
     private void assertProcessedLinesCountEquals(String sqlStatement, QueryResult allPartitionsQueryResult, int expected)
             throws SQLException


### PR DESCRIPTION
We were having intermittent issues with the processed line count being lower
than the expected value, even though the right results were returned for
the query. This may be due to the QueryInfoClient not being up-to-date
yet, so we increase the sleep.
