### PR TITLE
Update redline rpm plugin version

### DIFF
--- a/presto-server-rpm/pom.xml
+++ b/presto-server-rpm/pom.xml
@@ -33,143 +33,159 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <!-- Untar presto-server tgz to target build folder -->
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack</id>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <skip>false</skip>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>com.facebook.presto</groupId>
+                                    <artifactId>presto-server</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>tar.gz</type>
+                                    <outputDirectory>${project.build.outputDirectory}
+                                    </outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Build presto-server rpm using the untarred artifacts -->
+            <plugin>
+                <groupId>uk.co.codezen</groupId>
+                <artifactId>redlinerpm-maven-plugin</artifactId>
+                <version>2.0</version>
+                <extensions>true</extensions>
+
+                <configuration>
+                    <performCheckingForExtraFiles>false</performCheckingForExtraFiles>
+
+                    <packages>
+                        <package>
+                            <name>presto-server-rpm</name>
+                            <version>${project.version}</version>
+                            <release>1</release>
+
+                            <group>Applications/Databases</group>
+                            <description>Presto Server RPM Package.</description>
+                            <architecture>x86_64</architecture>
+                            <preInstallScriptFile>src/main/rpm/preinstall</preInstallScriptFile>
+                            <postInstallScriptFile>src/main/rpm/postinstall</postInstallScriptFile>
+                            <postUninstallScriptFile>src/main/rpm/postremove
+                            </postUninstallScriptFile>
+
+                            <dependencies>
+                                <dependency>
+                                    <name>python</name>
+                                    <version>[2.4,)</version>
+                                </dependency>
+                                <dependency>
+                                    <name>/usr/sbin/useradd</name>
+                                </dependency>
+                                <dependency>
+                                    <name>/usr/sbin/groupadd</name>
+                                </dependency>
+                            </dependencies>
+
+                            <rules>
+                                <rule>
+                                    <destination>/usr/lib/presto/bin</destination>
+                                    <base>${server.tar.package}/bin</base>
+                                    <!-- make sure launcher scripts are executable -->
+                                    <fileMode>0755</fileMode>
+                                    <includes>
+                                        <include>*</include>
+                                    </includes>
+                                </rule>
+
+                                <rule>
+                                    <destination>/etc/init.d</destination>
+                                    <base>dist/etc/init.d</base>
+                                    <!-- make sure init.d scripts are executable -->
+                                    <fileMode>0755</fileMode>
+                                    <includes>
+                                        <include>*</include>
+                                    </includes>
+                                </rule>
+
+                                <rule>
+                                    <!-- This should go to just /usr/lib/presto eventually. But that needs modifying
+                                    launcher.py in airlift, to have a configurable option for install_path -->
+                                    <destination>/usr/lib/presto/lib</destination>
+                                    <base>${server.tar.package}/lib</base>
+                                    <includes>
+                                        <include>*</include>
+                                    </includes>
+                                </rule>
+
+                                <rule>
+                                    <destination>/usr/lib/presto/lib/plugin</destination>
+                                    <base>${server.tar.package}/plugin</base>
+                                    <includes>
+                                        <include>*/*</include>
+                                    </includes>
+                                </rule>
+
+                                <rule>
+                                    <destination>/etc/presto</destination>
+                                    <base>dist/config</base>
+                                    <includes>
+                                        <include>*</include>
+                                    </includes>
+                                </rule>
+
+                                <rule>
+                                    <destination>/usr/shared/doc/presto</destination>
+                                    <base>${server.tar.package}</base>
+                                    <includes>
+                                        <include>README.txt</include>
+                                    </includes>
+                                </rule>
+
+                                <!-- Add these rules so that .spec knows these dirs are to be removed too on rpm -e -->
+                                <rule>
+                                    <destination>/usr/lib/presto</destination>
+                                </rule>
+                                <rule>
+                                    <destination>/usr/lib/presto/lib</destination>
+                                </rule>
+
+                            </rules>
+                        </package>
+                    </packages>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     <profiles>
         <profile>
-            <id>rpmbuild</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
+            <!-- This profile builds an rpm that works on versions of rpm earlier than 4.6.
+            Later versions of redline-rpm use 64bit integers, which isn't
+            supported before version 4.6 of rpm -->
+            <id>old-rpm</id>
             <build>
-                <!-- Untar presto-server tgz to target build folder -->
                 <plugins>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-dependency-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>unpack</id>
-                                <goals>
-                                    <goal>unpack</goal>
-                                </goals>
-                                <configuration>
-                                    <skip>false</skip>
-                                    <artifactItems>
-                                        <artifactItem>
-                                            <groupId>com.facebook.presto</groupId>
-                                            <artifactId>presto-server</artifactId>
-                                            <version>${project.version}</version>
-                                            <type>tar.gz</type>
-                                            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
-                                        </artifactItem>
-                                    </artifactItems>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <!-- Build presto-server rpm using the untarred artifacts -->
-                    <plugin>
-                        <groupId>uk.co.codezen</groupId>
                         <artifactId>redlinerpm-maven-plugin</artifactId>
-                        <version>1.0</version>
-                        <extensions>true</extensions>
-
-			            <configuration>
-                            <performCheckingForExtraFiles>false</performCheckingForExtraFiles>
-
-                            <packages>
-                                <package>
-                                    <name>presto-server-rpm</name>
-                                    <version>${project.version}</version>
-                                    <release>1</release>
-
-                                    <group>Applications/Databases</group>
-                                    <description>Presto Server RPM Package.</description>
-                                    <architecture>x86_64</architecture>
-
-                                    <preInstallScriptFile>src/main/rpm/preinstall</preInstallScriptFile>
-                                    <postInstallScriptFile>src/main/rpm/postinstall</postInstallScriptFile>
-                                    <postUninstallScriptFile>src/main/rpm/postremove</postUninstallScriptFile>
-
-                                    <dependencies>
-                                        <dependency>
-                                            <name>python</name>
-                                            <version>[2.4,)</version>
-                                        </dependency>
-                                        <dependency>
-                                            <name>/usr/sbin/useradd</name>
-                                        </dependency>
-                                        <dependency>
-                                            <name>/usr/sbin/groupadd</name>
-                                        </dependency>
-                                    </dependencies>
-
-                                    <rules>
-                                        <rule>
-                                            <destination>/usr/lib/presto/bin</destination>
-                                            <base>${server.tar.package}/bin</base>
-                                            <!-- make sure launcher scripts are executable -->
-                                            <fileMode>0755</fileMode>
-                                            <includes>
-                                                <include>*</include>
-                                            </includes>
-                                        </rule>
-
-                                        <rule>
-                                            <destination>/etc/init.d</destination>
-                                            <base>dist/etc/init.d</base>
-                                            <!-- make sure init.d scripts are executable -->
-                                            <fileMode>0755</fileMode>
-                                            <includes>
-                                                <include>*</include>
-                                            </includes>
-                                        </rule>
-
-                                        <rule>
-                                            <!-- This should go to just /usr/lib/presto eventually. But that needs modifying
-                                            launcher.py in airlift, to have a configurable option for install_path -->
-                                            <destination>/usr/lib/presto/lib</destination>
-                                            <base>${server.tar.package}/lib</base>
-                                            <includes>
-                                                <include>*</include>
-                                            </includes>
-                                        </rule>
-
-                                        <rule>
-                                            <destination>/usr/lib/presto/lib/plugin</destination>
-                                            <base>${server.tar.package}/plugin</base>
-                                            <includes>
-                                                <include>*/*</include>
-                                            </includes>
-                                        </rule>
-
-                                        <rule>
-                                            <destination>/etc/presto</destination>
-                                            <base>dist/config</base>
-                                            <includes>
-                                                <include>*</include>
-                                            </includes>
-                                        </rule>
-
-                                        <rule>
-                                            <destination>/usr/shared/doc/presto</destination>
-                                            <base>${server.tar.package}</base>
-                                            <includes>
-                                                <include>README.txt</include>
-                                            </includes>
-                                        </rule>
-
-                                        <!-- Add these rules so that .spec knows these dirs are to be removed too on rpm -e -->
-                                        <rule>
-                                            <destination>/usr/lib/presto</destination>
-                                        </rule>
-                                        <rule>
-                                            <destination>/usr/lib/presto/lib</destination>
-                                        </rule>
-
-                                    </rules>
-                                </package>
-                            </packages>
-                        </configuration>
+                        <groupId>uk.co.codezen</groupId>
+                        <dependencies>
+                            <dependency>
+                                <artifactId>redline</artifactId>
+                                <groupId>org.redline-rpm</groupId>
+                                <version>1.2.1</version>
+                            </dependency>
+                        </dependencies>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
Update the version fo redlinerpm-maven-plugin to the latest.  This fixes
the error that occured if a build was attempted when artifacts existed.
Now it will always overwrite existing artifacts.

This version of redlinerpm-maven-plugin also brings in the latest version
of redline-rpm, which has some fixes for compatiblity with later versions
of the rpm library.  One of those fixes- supporting large inode values -
is not compatible with versions of rpm before 4.6.
Add a profile that builds the rpm using the older version of redline-rpm

Testing: confirmed could build multiple times. Confirmed inode type in
rpm header is 32bit int for sles profile and 64bit int for the default.
