### PR TITLE
Generalized parametric types

### DIFF
--- a/presto-client/src/main/java/com/facebook/presto/client/ClientTypeParameterSignature.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/ClientTypeParameterSignature.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.client;
+
+import com.facebook.presto.spi.type.TypeParameterSignature;
+import com.facebook.presto.spi.type.TypeSignature;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.Objects;
+import java.util.Optional;
+
+@Immutable
+public class ClientTypeParameterSignature
+{
+    private final Optional<ClientTypeSignature> typeSignature;
+    private final Optional<Long> longLiteral;
+
+    public ClientTypeParameterSignature(TypeParameterSignature typeParameterSignature)
+    {
+        Optional<TypeSignature> typeSignature = typeParameterSignature.getTypeSignature();
+        if (typeSignature.isPresent()) {
+            this.typeSignature = Optional.of(new ClientTypeSignature(typeSignature.get()));
+        }
+        else {
+            this.typeSignature = Optional.empty();
+        }
+        longLiteral = typeParameterSignature.getLongLiteral();
+    }
+
+    @JsonCreator
+    public ClientTypeParameterSignature(
+            @JsonProperty("typeSignature") Optional<ClientTypeSignature> typeSignature,
+            @JsonProperty("longLiteral") Optional<Long> longLiteral)
+    {
+        this.typeSignature = typeSignature;
+        this.longLiteral = longLiteral;
+    }
+
+    @JsonProperty
+    public Optional<ClientTypeSignature> getTypeSignature()
+    {
+        return typeSignature;
+    }
+
+    @JsonProperty
+    public Optional<Long> getLongLiteral()
+    {
+        return longLiteral;
+    }
+
+    @Override
+    public String toString()
+    {
+        if (typeSignature.isPresent()) {
+            return typeSignature.get().toString();
+        }
+        else {
+            return longLiteral.get().toString();
+        }
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ClientTypeParameterSignature other = (ClientTypeParameterSignature) o;
+
+        return Objects.equals(this.typeSignature, other.typeSignature) &&
+                Objects.equals(this.longLiteral, other.longLiteral);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(typeSignature, longLiteral);
+    }
+}

--- a/presto-client/src/main/java/com/facebook/presto/client/ClientTypeSignature.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/ClientTypeSignature.java
@@ -41,7 +41,7 @@ public class ClientTypeSignature
     {
         this(
                 typeSignature.getBase(),
-                Lists.transform(typeSignature.getParameters(), ClientTypeSignature::new),
+                Lists.transform(typeSignature.getTypeSignaturesAndAssertNoLiterals(), ClientTypeSignature::new),
                 typeSignature.getLiteralParameters());
     }
 

--- a/presto-client/src/main/java/com/facebook/presto/client/ClientTypeSignature.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/ClientTypeSignature.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.client;
 
+import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.TypeSignature;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -34,21 +35,21 @@ public class ClientTypeSignature
 {
     private static final Pattern PATTERN = Pattern.compile(".*[<>,].*");
     private final String rawType;
-    private final List<ClientTypeSignature> typeArguments;
+    private final List<ClientTypeParameterSignature> typeArguments;
     private final List<Object> literalArguments;
 
     public ClientTypeSignature(TypeSignature typeSignature)
     {
         this(
                 typeSignature.getBase(),
-                Lists.transform(typeSignature.getTypeSignaturesAndAssertNoLiterals(), ClientTypeSignature::new),
+                Lists.transform(typeSignature.getTypeParameters(), ClientTypeParameterSignature::new),
                 typeSignature.getLiteralParameters());
     }
 
     @JsonCreator
     public ClientTypeSignature(
             @JsonProperty("rawType") String rawType,
-            @JsonProperty("typeArguments") List<ClientTypeSignature> typeArguments,
+            @JsonProperty("typeArguments") List<ClientTypeParameterSignature> typeArguments,
             @JsonProperty("literalArguments") List<Object> literalArguments)
     {
         checkArgument(rawType != null, "rawType is null");
@@ -71,7 +72,7 @@ public class ClientTypeSignature
     }
 
     @JsonProperty
-    public List<ClientTypeSignature> getTypeArguments()
+    public List<ClientTypeParameterSignature> getTypeArguments()
     {
         return typeArguments;
     }
@@ -85,18 +86,34 @@ public class ClientTypeSignature
     @Override
     public String toString()
     {
+        if (rawType.equals(StandardTypes.ROW)) {
+            return rowToString();
+        }
+        else {
+            return toString("(", ")");
+        }
+    }
+
+    @Deprecated
+    private String rowToString()
+    {
+        return toString("<", ">");
+    }
+
+    private String toString(String leftParamBracket, String rightParamBracket)
+    {
         StringBuilder typeName = new StringBuilder(rawType);
         if (!typeArguments.isEmpty()) {
-            typeName.append("<");
+            typeName.append(leftParamBracket);
             boolean first = true;
-            for (ClientTypeSignature argument : typeArguments) {
+            for (ClientTypeParameterSignature argument : typeArguments) {
                 if (!first) {
                     typeName.append(",");
                 }
                 first = false;
                 typeName.append(argument.toString());
             }
-            typeName.append(">");
+            typeName.append(rightParamBracket);
         }
         if (!literalArguments.isEmpty()) {
             typeName.append("(");

--- a/presto-client/src/main/java/com/facebook/presto/client/QueryResults.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/QueryResults.java
@@ -224,13 +224,13 @@ public class QueryResults
         if (signature.getBase().equals(ARRAY)) {
             List<Object> fixedValue = new ArrayList<>();
             for (Object object : List.class.cast(value)) {
-                fixedValue.add(fixValue(signature.getParameters().get(0).toString(), object));
+                fixedValue.add(fixValue(signature.getTypeSignaturesAndAssertNoLiterals().get(0).toString(), object));
             }
             return fixedValue;
         }
         if (signature.getBase().equals(MAP)) {
-            String keyType = signature.getParameters().get(0).toString();
-            String valueType = signature.getParameters().get(1).toString();
+            String keyType = signature.getTypeSignaturesAndAssertNoLiterals().get(0).toString();
+            String valueType = signature.getTypeSignaturesAndAssertNoLiterals().get(1).toString();
             Map<Object, Object> fixedValue = new HashMap<>();
             for (Map.Entry<?, ?> entry : (Set<Map.Entry<?, ?>>) Map.class.cast(value).entrySet()) {
                 fixedValue.put(fixValue(keyType, entry.getKey()), fixValue(valueType, entry.getValue()));
@@ -243,7 +243,7 @@ public class QueryResults
             checkArgument(listValue.size() == signature.getLiteralParameters().size(), "Mismatched data values and row type");
             for (int i = 0; i < listValue.size(); i++) {
                 String key = (String) signature.getLiteralParameters().get(i);
-                fixedValue.put(key, fixValue(signature.getParameters().get(i).toString(), listValue.get(i)));
+                fixedValue.put(key, fixValue(signature.getTypeSignaturesAndAssertNoLiterals().get(i).toString(), listValue.get(i)));
             }
             return fixedValue;
         }

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ColumnInfo.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ColumnInfo.java
@@ -88,7 +88,7 @@ class ColumnInfo
     {
         builder.setColumnType(getType(type));
         ImmutableList.Builder<Integer> parameterTypes = ImmutableList.builder();
-        for (TypeSignature parameter : type.getParameters()) {
+        for (TypeSignature parameter : type.getTypeSignaturesAndAssertNoLiterals()) {
             parameterTypes.add(getType(parameter));
         }
         builder.setColumnParameterTypes(parameterTypes.build());

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ColumnInfo.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ColumnInfo.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.jdbc;
 
+import com.facebook.presto.spi.type.TypeParameterSignature;
 import com.facebook.presto.spi.type.TypeSignature;
 import com.google.common.collect.ImmutableList;
 
@@ -88,7 +89,7 @@ class ColumnInfo
     {
         builder.setColumnType(getType(type));
         ImmutableList.Builder<Integer> parameterTypes = ImmutableList.builder();
-        for (TypeSignature parameter : type.getTypeSignaturesAndAssertNoLiterals()) {
+        for (TypeParameterSignature parameter : type.getTypeParameters()) {
             parameterTypes.add(getType(parameter));
         }
         builder.setColumnParameterTypes(parameterTypes.build());
@@ -155,6 +156,16 @@ class ColumnInfo
             case "interval day to second":
                 builder.setColumnDisplaySize(TIMESTAMP_MAX);
                 break;
+        }
+    }
+
+    private static int getType(TypeParameterSignature typeParameter)
+    {
+        if (typeParameter.getTypeSignature().isPresent()) {
+            return getType(typeParameter.getTypeSignature().get());
+        }
+        else {
+            return Types.JAVA_OBJECT;
         }
     }
 

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoResultSet.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoResultSet.java
@@ -1139,7 +1139,7 @@ public class PrestoResultSet
         }
 
         ColumnInfo columnInfo = columnInfo(columnIndex);
-        String elementTypeName = getOnlyElement(columnInfo.getColumnTypeSignature().getTypeSignaturesAndAssertNoLiterals()).toString();
+        String elementTypeName = getOnlyElement(columnInfo.getColumnTypeSignature().getTypeParameters()).toString();
         int elementType = getOnlyElement(columnInfo.getColumnParameterTypes());
         return new PrestoArray(elementTypeName, elementType, (List<?>) value);
     }

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoResultSet.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoResultSet.java
@@ -1139,7 +1139,7 @@ public class PrestoResultSet
         }
 
         ColumnInfo columnInfo = columnInfo(columnIndex);
-        String elementTypeName = getOnlyElement(columnInfo.getColumnTypeSignature().getParameters()).toString();
+        String elementTypeName = getOnlyElement(columnInfo.getColumnTypeSignature().getTypeSignaturesAndAssertNoLiterals()).toString();
         int elementType = getOnlyElement(columnInfo.getColumnParameterTypes());
         return new PrestoArray(elementTypeName, elementType, (List<?>) value);
     }

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaPlugin.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaPlugin.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.Node;
 import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.TypeParameterSignature;
 import com.facebook.presto.spi.type.TypeSignature;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -68,6 +69,12 @@ public class TestKafkaPlugin
     {
         @Override
         public Type getType(TypeSignature signature)
+        {
+            return null;
+        }
+
+        @Override
+        public Type getParameterizedType(String baseTypeName, List<TypeParameterSignature> typeParameters)
         {
             return null;
         }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -408,10 +408,10 @@ public class FunctionRegistry
 
     private static TypeSignature bindParameters(TypeSignature typeSignature, Map<String, Type> boundParameters)
     {
-        List<TypeSignature> parameters = typeSignature.getParameters().stream().map(signature -> bindParameters(signature, boundParameters)).collect(toImmutableList());
+        List<TypeSignature> parameters = typeSignature.getTypeSignaturesAndAssertNoLiterals().stream().map(signature -> bindParameters(signature, boundParameters)).collect(toImmutableList());
         String base = typeSignature.getBase();
         if (boundParameters.containsKey(base)) {
-            verify(typeSignature.getLiteralParameters().isEmpty() && typeSignature.getParameters().isEmpty(), "Type parameters cannot have parameters");
+            verify(typeSignature.getLiteralParameters().isEmpty() && typeSignature.getTypeSignaturesAndAssertNoLiterals().isEmpty(), "Type parameters cannot have parameters");
             return boundParameters.get(base).getTypeSignature();
         }
         return new TypeSignature(base, parameters, typeSignature.getLiteralParameters());

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -213,7 +213,6 @@ import static com.facebook.presto.util.ImmutableCollectors.toImmutableSet;
 import static com.facebook.presto.util.Types.checkType;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.base.Verify.verify;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -390,10 +389,10 @@ public class FunctionRegistry
         }
         ImmutableList.Builder<TypeSignature> boundArguments = ImmutableList.builder();
         for (int i = 0; i < argumentTypes.size() - 1; i++) {
-            boundArguments.add(bindParameters(argumentTypes.get(i), boundParameters));
+            boundArguments.add(argumentTypes.get(i).bindParameters(boundParameters));
         }
         if (!argumentTypes.isEmpty()) {
-            TypeSignature lastArgument = bindParameters(argumentTypes.get(argumentTypes.size() - 1), boundParameters);
+            TypeSignature lastArgument = argumentTypes.get(argumentTypes.size() - 1).bindParameters(boundParameters);
             if (signature.isVariableArity()) {
                 for (int i = 0; i < types.size() - (argumentTypes.size() - 1); i++) {
                     boundArguments.add(lastArgument);
@@ -403,18 +402,7 @@ public class FunctionRegistry
                 boundArguments.add(lastArgument);
             }
         }
-        return new Signature(signature.getName(), signature.getKind(), bindParameters(signature.getReturnType(), boundParameters), boundArguments.build());
-    }
-
-    private static TypeSignature bindParameters(TypeSignature typeSignature, Map<String, Type> boundParameters)
-    {
-        List<TypeSignature> parameters = typeSignature.getTypeSignaturesAndAssertNoLiterals().stream().map(signature -> bindParameters(signature, boundParameters)).collect(toImmutableList());
-        String base = typeSignature.getBase();
-        if (boundParameters.containsKey(base)) {
-            verify(typeSignature.getLiteralParameters().isEmpty() && typeSignature.getTypeSignaturesAndAssertNoLiterals().isEmpty(), "Type parameters cannot have parameters");
-            return boundParameters.get(base).getTypeSignature();
-        }
-        return new TypeSignature(base, parameters, typeSignature.getLiteralParameters());
+        return new Signature(signature.getName(), signature.getKind(), signature.getReturnType().bindParameters(boundParameters), boundArguments.build());
     }
 
     public final synchronized void addFunctions(List<? extends SqlFunction> functions)

--- a/presto-main/src/main/java/com/facebook/presto/metadata/OperatorType.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/OperatorType.java
@@ -158,11 +158,11 @@ public enum OperatorType
                     checkArgument(argumentTypes.get(0).getBase().equals(StandardTypes.ARRAY) || argumentTypes.get(0).getBase().equals(StandardTypes.MAP), "First argument must be an ARRAY or MAP");
                     if (argumentTypes.get(0).getBase().equals(StandardTypes.ARRAY)) {
                         checkArgument(argumentTypes.get(1).getBase().equals(StandardTypes.BIGINT), "Second argument must be a BIGINT");
-                        TypeSignature elementType = argumentTypes.get(0).getParameters().get(0);
+                        TypeSignature elementType = argumentTypes.get(0).getTypeSignaturesAndAssertNoLiterals().get(0);
                         checkArgument(returnType.equals(elementType), "[] return type does not match ARRAY element type");
                     }
                     else {
-                        TypeSignature valueType = argumentTypes.get(0).getParameters().get(1);
+                        TypeSignature valueType = argumentTypes.get(0).getTypeSignaturesAndAssertNoLiterals().get(1);
                         checkArgument(returnType.equals(valueType), "[] return type does not match MAP value type");
                     }
                 }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Signature.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Signature.java
@@ -295,7 +295,7 @@ public final class Signature
     {
         // If this parameter is already bound, then match (with coercion)
         if (boundParameters.containsKey(parameter.getBase())) {
-            checkArgument(parameter.getParameters().isEmpty(), "Unexpected parameteric type");
+            checkArgument(parameter.getTypeSignaturesAndAssertNoLiterals().isEmpty(), "Unexpected parameteric type");
             if (allowCoercion) {
                 if (canCoerce(type, boundParameters.get(parameter.getBase()))) {
                     return true;
@@ -313,13 +313,13 @@ public final class Signature
         }
 
         // Recurse into component types
-        if (!parameter.getParameters().isEmpty()) {
-            if (type.getTypeParameters().size() != parameter.getParameters().size()) {
+        if (!parameter.getTypeSignaturesAndAssertNoLiterals().isEmpty()) {
+            if (type.getTypeParameters().size() != parameter.getTypeSignaturesAndAssertNoLiterals().size()) {
                 return false;
             }
-            for (int i = 0; i < parameter.getParameters().size(); i++) {
+            for (int i = 0; i < parameter.getTypeSignaturesAndAssertNoLiterals().size(); i++) {
                 Type componentType = type.getTypeParameters().get(i);
-                TypeSignature componentSignature = parameter.getParameters().get(i);
+                TypeSignature componentSignature = parameter.getTypeSignaturesAndAssertNoLiterals().get(i);
                 if (!matchAndBind(boundParameters, typeParameters, componentSignature, componentType, allowCoercion, typeManager)) {
                     return false;
                 }
@@ -337,7 +337,7 @@ public final class Signature
         }
 
         // We've already checked all the components, so just match the base type
-        if (!parameter.getParameters().isEmpty()) {
+        if (!parameter.getTypeSignaturesAndAssertNoLiterals().isEmpty()) {
             return type.getTypeSignature().getBase().equals(parameter.getBase());
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Signature.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Signature.java
@@ -293,9 +293,11 @@ public final class Signature
 
     private static boolean matchAndBind(Map<String, Type> boundParameters, Map<String, TypeParameter> typeParameters, TypeSignature parameter, Type type, boolean allowCoercion, TypeManager typeManager)
     {
+        // TODO: add literals to Types and switch to TypeParameterSignature
+        List<TypeSignature> typeSignatures = parameter.getTypeSignaturesAndAssertNoLiterals();
         // If this parameter is already bound, then match (with coercion)
         if (boundParameters.containsKey(parameter.getBase())) {
-            checkArgument(parameter.getTypeSignaturesAndAssertNoLiterals().isEmpty(), "Unexpected parameteric type");
+            checkArgument(typeSignatures.isEmpty(), "Unexpected parameteric type");
             if (allowCoercion) {
                 if (canCoerce(type, boundParameters.get(parameter.getBase()))) {
                     return true;
@@ -313,13 +315,13 @@ public final class Signature
         }
 
         // Recurse into component types
-        if (!parameter.getTypeSignaturesAndAssertNoLiterals().isEmpty()) {
-            if (type.getTypeParameters().size() != parameter.getTypeSignaturesAndAssertNoLiterals().size()) {
+        if (!typeSignatures.isEmpty()) {
+            if (type.getTypeParameters().size() != typeSignatures.size()) {
                 return false;
             }
-            for (int i = 0; i < parameter.getTypeSignaturesAndAssertNoLiterals().size(); i++) {
+            for (int i = 0; i < typeSignatures.size(); i++) {
                 Type componentType = type.getTypeParameters().get(i);
-                TypeSignature componentSignature = parameter.getTypeSignaturesAndAssertNoLiterals().get(i);
+                TypeSignature componentSignature = typeSignatures.get(i);
                 if (!matchAndBind(boundParameters, typeParameters, componentSignature, componentType, allowCoercion, typeManager)) {
                     return false;
                 }
@@ -337,7 +339,7 @@ public final class Signature
         }
 
         // We've already checked all the components, so just match the base type
-        if (!parameter.getTypeSignaturesAndAssertNoLiterals().isEmpty()) {
+        if (!typeSignatures.isEmpty()) {
             return type.getTypeSignature().getBase().equals(parameter.getBase());
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/StatementResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/StatementResource.java
@@ -361,7 +361,7 @@ public class StatementResource
                     exchangeClient.close();
 
                     // Return a single value for clients that require a result.
-                    columns = ImmutableList.of(new Column("result", "boolean", new ClientTypeSignature(StandardTypes.BOOLEAN, ImmutableList.<ClientTypeSignature>of(), ImmutableList.of())));
+                    columns = ImmutableList.of(new Column("result", "boolean", new ClientTypeSignature(StandardTypes.BOOLEAN, ImmutableList.of(), ImmutableList.of())));
                     data = ImmutableSet.<List<Object>>of(ImmutableList.<Object>of(true));
                 }
             }

--- a/presto-main/src/main/java/com/facebook/presto/type/TypeRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TypeRegistry.java
@@ -131,7 +131,7 @@ public final class TypeRegistry
     private Type instantiateParametricType(TypeSignature signature)
     {
         ImmutableList.Builder<Type> parameterTypes = ImmutableList.builder();
-        for (TypeSignature parameter : signature.getParameters()) {
+        for (TypeSignature parameter : signature.getTypeSignaturesAndAssertNoLiterals()) {
             Type parameterType = getType(parameter);
             if (parameterType == null) {
                 return null;

--- a/presto-main/src/main/java/com/facebook/presto/type/TypeRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TypeRegistry.java
@@ -131,6 +131,7 @@ public final class TypeRegistry
     private Type instantiateParametricType(TypeSignature signature)
     {
         ImmutableList.Builder<Type> parameterTypes = ImmutableList.builder();
+        // TODO: add literals to Types and switch to TypeParameterSignature
         for (TypeSignature parameter : signature.getTypeSignaturesAndAssertNoLiterals()) {
             Type parameterType = getType(parameter);
             if (parameterType == null) {

--- a/presto-main/src/main/java/com/facebook/presto/type/TypeRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TypeRegistry.java
@@ -15,6 +15,7 @@ package com.facebook.presto.type;
 
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.TypeParameterSignature;
 import com.facebook.presto.spi.type.TypeSignature;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -115,6 +116,13 @@ public final class TypeRegistry
     }
 
     @Override
+    public Type getParameterizedType(String baseTypeName, List<TypeParameterSignature> typeParameters)
+    {
+        return getType(new TypeSignature(baseTypeName, typeParameters));
+    }
+
+    @Override
+    @Deprecated
     public Type getParameterizedType(String baseTypeName, List<TypeSignature> typeParameters, List<Object> literalParameters)
     {
         return getType(new TypeSignature(baseTypeName, typeParameters, literalParameters));

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -221,7 +221,7 @@ valueExpression
 primaryExpression
     : NULL                                                                           #nullLiteral
     | interval                                                                       #intervalLiteral
-    | identifier STRING                                                              #typeConstructor
+    | type STRING                                                                    #typeConstructor
     | number                                                                         #numericLiteral
     | booleanValue                                                                   #booleanLiteral
     | STRING                                                                         #stringLiteral
@@ -277,10 +277,14 @@ type
     : type ARRAY
     | ARRAY '<' type '>'
     | MAP '<' type ',' type '>'
-    | simpleType
+    | baseType ('(' typeParameter (',' typeParameter)* ')')?
     ;
 
-simpleType
+typeParameter
+    : INTEGER_VALUE | type
+    ;
+
+baseType
     : TIME_WITH_TIME_ZONE
     | TIMESTAMP_WITH_TIME_ZONE
     | identifier
@@ -342,7 +346,7 @@ number
 nonReserved
     : SHOW | TABLES | COLUMNS | COLUMN | PARTITIONS | FUNCTIONS | SCHEMAS | CATALOGS | SESSION
     | ADD
-    | OVER | PARTITION | RANGE | ROWS | PRECEDING | FOLLOWING | CURRENT | ROW | MAP
+    | OVER | PARTITION | RANGE | ROWS | PRECEDING | FOLLOWING | CURRENT | ROW | MAP | ARRAY
     | DATE | TIME | TIMESTAMP | INTERVAL | ZONE
     | YEAR | MONTH | DAY | HOUR | MINUTE | SECOND
     | EXPLAIN | FORMAT | TYPE | TEXT | GRAPHVIZ | LOGICAL | DISTRIBUTED

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -138,6 +138,17 @@ public class TestSqlParser
         assertGenericLiteral("BOOLEAN");
         assertGenericLiteral("DATE");
         assertGenericLiteral("foo");
+
+        assertExpression("VARCHAR(42)" + " 'abc'", new GenericLiteral("VARCHAR(42)", "abc"));
+        assertExpression("FOO(42, 55)" + " 'abc'", new GenericLiteral("FOO(42,55)", "abc"));
+
+        assertExpression("ARRAY(BIGINT)" + " 'abc'", new GenericLiteral("ARRAY(BIGINT)", "abc"));
+        assertExpression(
+                "MAP(BIGINT, VARCHAR)" + " 'abc'",
+                new GenericLiteral("MAP(BIGINT,VARCHAR)", "abc"));
+        assertExpression(
+                "FOO(VARCHAR(42), ARRAY(BIGINT))" + " 'abc'",
+                new GenericLiteral("FOO(VARCHAR(42),ARRAY(BIGINT))", "abc"));
     }
 
     public static void assertGenericLiteral(String type)
@@ -211,6 +222,7 @@ public class TestSqlParser
     public void testCast()
             throws Exception
     {
+        assertCast("foo(42, 55) ARRAY", "ARRAY(foo(42,55))");
         assertCast("varchar");
         assertCast("bigint");
         assertCast("BIGINT");
@@ -225,15 +237,34 @@ public class TestSqlParser
         assertCast("foo");
         assertCast("FOO");
 
-        assertCast("ARRAY<bigint>");
-        assertCast("ARRAY<BIGINT>");
-        assertCast("array<bigint>");
-        assertCast("array < bigint  >", "ARRAY<bigint>");
-        assertCast("array<array<bigint>>");
-        assertCast("foo ARRAY", "ARRAY<foo>");
-        assertCast("boolean array  array ARRAY", "ARRAY<ARRAY<ARRAY<boolean>>>");
-        assertCast("boolean ARRAY ARRAY ARRAY", "ARRAY<ARRAY<ARRAY<boolean>>>");
-        assertCast("ARRAY<boolean> ARRAY ARRAY", "ARRAY<ARRAY<ARRAY<boolean>>>");
+        assertCast("ARRAY<bigint>", "ARRAY(bigint)");
+        assertCast("ARRAY<BIGINT>", "ARRAY(BIGINT)");
+        assertCast("array<bigint>", "array(bigint)");
+        assertCast("array < bigint  >", "ARRAY(bigint)");
+
+        assertCast("ARRAY(bigint)");
+        assertCast("ARRAY(BIGINT)");
+        assertCast("array(bigint)");
+        assertCast("array ( bigint  )", "ARRAY(bigint)");
+
+        assertCast("array<array<bigint>>", "array(array(bigint))");
+        assertCast("array(array(bigint))");
+
+        assertCast("foo ARRAY", "ARRAY(foo)");
+        assertCast("boolean array  array ARRAY", "ARRAY(ARRAY(ARRAY(boolean)))");
+        assertCast("boolean ARRAY ARRAY ARRAY", "ARRAY(ARRAY(ARRAY(boolean)))");
+        assertCast("ARRAY<boolean> ARRAY ARRAY", "ARRAY(ARRAY(ARRAY(boolean)))");
+
+        assertCast("map(BIGINT,array(VARCHAR))");
+        assertCast("map<BIGINT,array<VARCHAR>>", "map(BIGINT,array(VARCHAR))");
+
+        assertCast("varchar(42)");
+        assertCast("foo(42,55)");
+        assertCast("foo(BIGINT,array(VARCHAR))");
+        assertCast("ARRAY<varchar(42)>", "ARRAY(varchar(42))");
+        assertCast("ARRAY<foo(42,55)>", "ARRAY(foo(42,55))");
+        assertCast("varchar(42) ARRAY", "ARRAY(varchar(42))");
+        assertCast("foo(42, 55) ARRAY", "ARRAY(foo(42,55))");
     }
 
     @Test

--- a/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisPlugin.java
+++ b/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisPlugin.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.Node;
 import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.TypeParameterSignature;
 import com.facebook.presto.spi.type.TypeSignature;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -68,6 +69,12 @@ public class TestRedisPlugin
     {
         @Override
         public Type getType(TypeSignature signature)
+        {
+            return null;
+        }
+
+        @Override
+        public Type getParameterizedType(String baseTypeName, List<TypeParameterSignature> typeParameters)
         {
             return null;
         }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeManager.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeManager.java
@@ -25,6 +25,12 @@ public interface TypeManager
     /**
      * Gets the type with the specified base type, and the given parameters, or null if not found.
      */
+    Type getParameterizedType(String baseTypeName, List<TypeParameterSignature> typeParameters);
+
+    /**
+     * Gets the type with the specified base type, and the given parameters, or null if not found.
+     */
+    @Deprecated
     Type getParameterizedType(String baseTypeName, List<TypeSignature> typeParameters, List<Object> literalParameters);
 
     /**

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeParameterSignature.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeParameterSignature.java
@@ -61,6 +61,11 @@ public class TypeParameterSignature
         return typeSignature;
     }
 
+    public Optional<Long> getLongLiteral()
+    {
+        return longLiteral;
+    }
+
     @Override
     public boolean equals(Object o)
     {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeParameterSignature.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeParameterSignature.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.spi.type;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -86,5 +87,15 @@ public class TypeParameterSignature
     public int hashCode()
     {
         return Objects.hash(typeSignature, longLiteral);
+    }
+
+    public TypeParameterSignature bindParameters(Map<String, Type> boundParameters)
+    {
+        if (typeSignature.isPresent()) {
+            return TypeParameterSignature.of(typeSignature.get().bindParameters(boundParameters));
+        }
+        else {
+            return this;
+        }
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeParameterSignature.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeParameterSignature.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.type;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.lang.String.format;
+
+public class TypeParameterSignature
+{
+    private final Optional<TypeSignature> typeSignature;
+    private final Optional<Long> longLiteral;
+
+    public static TypeParameterSignature of(TypeSignature typeSignature)
+    {
+        return new TypeParameterSignature(Optional.of(typeSignature), Optional.empty());
+    }
+
+    public static TypeParameterSignature of(long longLiteral)
+    {
+        return new TypeParameterSignature(Optional.empty(), Optional.of(longLiteral));
+    }
+
+    private TypeParameterSignature(Optional<TypeSignature> typeSignature, Optional<Long> longLiteral)
+    {
+        if (typeSignature.isPresent() && longLiteral.isPresent()) {
+            throw new IllegalStateException(
+                    format("typeSignature and longLiteral are mutual exclusive but [%s, %s] was found",
+                            typeSignature.get(),
+                            longLiteral.get()));
+        }
+        this.typeSignature = typeSignature;
+        this.longLiteral = longLiteral;
+    }
+
+    @Override
+    public String toString()
+    {
+        if (typeSignature.isPresent()) {
+            return typeSignature.get().toString();
+        }
+        else {
+            return longLiteral.get().toString();
+        }
+    }
+
+    public Optional<TypeSignature> getTypeSignature()
+    {
+        return typeSignature;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        TypeParameterSignature other = (TypeParameterSignature) o;
+
+        return Objects.equals(this.typeSignature, other.typeSignature) &&
+                Objects.equals(this.longLiteral, other.longLiteral);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(typeSignature, longLiteral);
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeSignature.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeSignature.java
@@ -66,15 +66,21 @@ public class TypeSignature
 
     public TypeSignature bindParameters(Map<String, Type> boundParameters)
     {
-        List<TypeSignature> parameters = getTypeSignaturesAndAssertNoLiterals().stream().map(signature -> signature.bindParameters(boundParameters)).collect(Collectors.toList());
-        String base = getBase();
         if (boundParameters.containsKey(base)) {
-            if (!getLiteralParameters().isEmpty() || !getTypeSignaturesAndAssertNoLiterals().isEmpty()) {
+            if (!getLiteralParameters().isEmpty() || !getTypeParameters().isEmpty()) {
                 throw new IllegalStateException("Type parameters cannot have parameters");
             }
             return boundParameters.get(base).getTypeSignature();
         }
-        return new TypeSignature(base, parameters, getLiteralParameters());
+
+        if (base.equals(StandardTypes.ROW)) {
+            List<TypeSignature> parameters = getTypeSignaturesAndAssertNoLiterals().stream().map(signature -> signature.bindParameters(boundParameters)).collect(Collectors.toList());
+            return new TypeSignature(base, parameters, getLiteralParameters());
+        }
+        else {
+            List<TypeParameterSignature> parameters = getTypeParameters().stream().map(signature -> signature.bindParameters(boundParameters)).collect(Collectors.toList());
+            return new TypeSignature(base, parameters);
+        }
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeSignature.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeSignature.java
@@ -86,48 +86,6 @@ public class TypeSignature
         }
     }
 
-    private String toString(String leftParamBracket, String rightParamBracket)
-    {
-        StringBuilder typeName = new StringBuilder(base);
-        if (!parameters.isEmpty()) {
-            typeName.append(leftParamBracket);
-            boolean first = true;
-            for (TypeParameterSignature parameter : parameters) {
-                if (!first) {
-                    typeName.append(",");
-                }
-                first = false;
-                typeName.append(parameter.toString());
-            }
-            typeName.append(rightParamBracket);
-        }
-        if (!literalParameters.isEmpty()) {
-            typeName.append("(");
-            boolean first = true;
-            for (Object parameter : literalParameters) {
-                if (!first) {
-                    typeName.append(",");
-                }
-                first = false;
-                if (parameter instanceof String) {
-                    typeName.append("'").append(parameter).append("'");
-                }
-                else {
-                    typeName.append(parameter.toString());
-                }
-            }
-            typeName.append(")");
-        }
-
-        return typeName.toString();
-    }
-
-    @Deprecated
-    private String rowToString()
-    {
-        return toString("<", ">");
-    }
-
     public String getBase()
     {
         return base;
@@ -138,7 +96,7 @@ public class TypeSignature
         return parameters;
     }
 
-    public List<TypeSignature> getParameters()
+    public List<TypeSignature> getTypeSignaturesAndAssertNoLiterals()
     {
         List<TypeSignature> result = new ArrayList<>();
         for (TypeParameterSignature parameter : parameters) {
@@ -307,6 +265,48 @@ public class TypeSignature
         else {
             return Long.parseLong(literal);
         }
+    }
+
+    @Deprecated
+    private String rowToString()
+    {
+        return toString("<", ">");
+    }
+
+    private String toString(String leftParamBracket, String rightParamBracket)
+    {
+        StringBuilder typeName = new StringBuilder(base);
+        if (!parameters.isEmpty()) {
+            typeName.append(leftParamBracket);
+            boolean first = true;
+            for (TypeParameterSignature parameter : parameters) {
+                if (!first) {
+                    typeName.append(",");
+                }
+                first = false;
+                typeName.append(parameter.toString());
+            }
+            typeName.append(rightParamBracket);
+        }
+        if (!literalParameters.isEmpty()) {
+            typeName.append("(");
+            boolean first = true;
+            for (Object parameter : literalParameters) {
+                if (!first) {
+                    typeName.append(",");
+                }
+                first = false;
+                if (parameter instanceof String) {
+                    typeName.append("'").append(parameter).append("'");
+                }
+                else {
+                    typeName.append(parameter.toString());
+                }
+            }
+            typeName.append(")");
+        }
+
+        return typeName.toString();
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeSignature.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeSignature.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static java.util.Collections.unmodifiableList;
@@ -27,21 +28,38 @@ import static java.util.Collections.unmodifiableList;
 public class TypeSignature
 {
     private final String base;
-    private final List<TypeSignature> parameters;
+    private final List<TypeParameterSignature> parameters;
     private final List<Object> literalParameters;
 
-    public TypeSignature(String base, List<TypeSignature> parameters, List<Object> literalParameters)
+    public TypeSignature(String base, List<TypeParameterSignature> parameters)
     {
         checkArgument(base != null, "base is null");
         this.base = base;
         checkArgument(!base.isEmpty(), "base is empty");
         checkArgument(validateName(base), "Bad characters in base type: %s", base);
         checkArgument(parameters != null, "parameters is null");
+        this.parameters = unmodifiableList(new ArrayList<>(parameters));
+        this.literalParameters = unmodifiableList(new ArrayList<>());
+    }
+
+    // TODO: merge literalParameters for Row with TypeParameterSignature
+    @Deprecated
+    public TypeSignature(String base, List<TypeSignature> typeSignatureParameters, List<Object> literalParameters)
+    {
+        checkArgument(base != null, "base is null");
+        this.base = base;
+        checkArgument(!base.isEmpty(), "base is empty");
+        checkArgument(validateName(base), "Bad characters in base type: %s", base);
+        checkArgument(typeSignatureParameters != null, "parameters is null");
         checkArgument(literalParameters != null, "literalParameters is null");
         for (Object literal : literalParameters) {
             checkArgument(literal instanceof String || literal instanceof Long, "Unsupported literal type: %s", literal.getClass());
         }
-        this.parameters = unmodifiableList(new ArrayList<>(parameters));
+
+        List<TypeParameterSignature> typeParameters =
+                typeSignatureParameters.stream().map(TypeParameterSignature::of).collect(Collectors.toList());
+
+        this.parameters = unmodifiableList(typeParameters);
         this.literalParameters = unmodifiableList(new ArrayList<>(literalParameters));
     }
 
@@ -60,18 +78,28 @@ public class TypeSignature
     @JsonValue
     public String toString()
     {
+        if (base.equals(StandardTypes.ROW)) {
+            return rowToString();
+        }
+        else {
+            return toString("(", ")");
+        }
+    }
+
+    private String toString(String leftParamBracket, String rightParamBracket)
+    {
         StringBuilder typeName = new StringBuilder(base);
         if (!parameters.isEmpty()) {
-            typeName.append("<");
+            typeName.append(leftParamBracket);
             boolean first = true;
-            for (TypeSignature parameter : parameters) {
+            for (TypeParameterSignature parameter : parameters) {
                 if (!first) {
                     typeName.append(",");
                 }
                 first = false;
                 typeName.append(parameter.toString());
             }
-            typeName.append(">");
+            typeName.append(rightParamBracket);
         }
         if (!literalParameters.isEmpty()) {
             typeName.append("(");
@@ -94,14 +122,33 @@ public class TypeSignature
         return typeName.toString();
     }
 
+    @Deprecated
+    private String rowToString()
+    {
+        return toString("<", ">");
+    }
+
     public String getBase()
     {
         return base;
     }
 
-    public List<TypeSignature> getParameters()
+    public List<TypeParameterSignature> getTypeParameters()
     {
         return parameters;
+    }
+
+    public List<TypeSignature> getParameters()
+    {
+        List<TypeSignature> result = new ArrayList<>();
+        for (TypeParameterSignature parameter : parameters) {
+            if (!parameter.getTypeSignature().isPresent()) {
+                throw new IllegalStateException(
+                        format("Expected all parameters to be TypeSignatures but [%s] was found", parameter.toString()));
+            }
+            result.add(parameter.getTypeSignature().get());
+        }
+        return result;
     }
 
     public List<Object> getLiteralParameters()
@@ -113,9 +160,58 @@ public class TypeSignature
     public static TypeSignature parseTypeSignature(String signature)
     {
         if (!signature.contains("<") && !signature.contains("(")) {
-            return new TypeSignature(signature, new ArrayList<TypeSignature>(), new ArrayList<>());
+            return new TypeSignature(signature, new ArrayList<>());
+        }
+        if (signature.startsWith(StandardTypes.ROW)) {
+            return parseRowTypeSignature(signature);
         }
 
+        String baseName = null;
+        List<TypeParameterSignature> parameters = new ArrayList<>();
+        int parameterStart = -1;
+        int bracketCount = 0;
+
+        for (int i = 0; i < signature.length(); i++) {
+            char c = signature.charAt(i);
+            // TODO: remove angel brackets support once ROW<TYPE>(name) will be dropped
+            // Angel brackets here are checked not for the support of ARRAY<> and MAP<>
+            // but to correctly parse ARRAY(row<BIGINT, BIGINT>('a','b'))
+            if (c == '(' || c == '<') {
+                if (bracketCount == 0) {
+                    verify(baseName == null, "Expected baseName to be null");
+                    verify(parameterStart == -1, "Expected parameter start to be -1");
+                    baseName = signature.substring(0, i);
+                    parameterStart = i + 1;
+                }
+                bracketCount++;
+            }
+            else if (c == ')' || c == '>') {
+                bracketCount--;
+                checkArgument(bracketCount >= 0, "Bad type signature: '%s'", signature);
+                if (bracketCount == 0) {
+                    checkArgument(parameterStart >= 0, "Bad type signature: '%s'", signature);
+                    parseSignatureOrLong(signature, parameterStart, i, parameters);
+                    parameterStart = i + 1;
+                    if (i == signature.length() - 1) {
+                        return new TypeSignature(baseName, parameters);
+                    }
+                }
+            }
+            else if (c == ',') {
+                if (bracketCount == 1) {
+                    checkArgument(parameterStart >= 0, "Bad type signature: '%s'", signature);
+                    parseSignatureOrLong(signature, parameterStart, i, parameters);
+                    parameterStart = i + 1;
+                }
+            }
+        }
+
+        throw new IllegalArgumentException(format("Bad type signature: '%s'", signature));
+    }
+
+    @Deprecated
+    private static TypeSignature parseRowTypeSignature(String signature)
+    {
         String baseName = null;
         List<TypeSignature> parameters = new ArrayList<>();
         List<Object> literalParameters = new ArrayList<>();
@@ -147,21 +243,22 @@ public class TypeSignature
                 }
             }
             else if (c == ',') {
-                if (bracketCount == 1 && !inLiteralParameters) {
-                    checkArgument(parameterStart >= 0, "Bad type signature: '%s'", signature);
-                    parameters.add(parseTypeSignature(signature.substring(parameterStart, i)));
-                    parameterStart = i + 1;
-                }
-                else if (bracketCount == 0 && inLiteralParameters) {
-                    checkArgument(parameterStart >= 0, "Bad type signature: '%s'", signature);
-                    literalParameters.add(parseLiteral(signature.substring(parameterStart, i)));
-                    parameterStart = i + 1;
+                if (bracketCount == 1) {
+                    if (!inLiteralParameters) {
+                        checkArgument(parameterStart >= 0, "Bad type signature: '%s'", signature);
+                        parameters.add(parseTypeSignature(signature.substring(parameterStart, i)));
+                        parameterStart = i + 1;
+                    }
+                    else {
+                        checkArgument(parameterStart >= 0, "Bad type signature: '%s'", signature);
+                        literalParameters.add(parseLiteral(signature.substring(parameterStart, i)));
+                        parameterStart = i + 1;
+                    }
                 }
             }
             else if (c == '(') {
-                checkArgument(!inLiteralParameters, "Bad type signature: '%s'", signature);
-                inLiteralParameters = true;
                 if (bracketCount == 0) {
+                    inLiteralParameters = true;
                     if (baseName == null) {
                         verify(parameters.isEmpty(), "Expected no parameters");
                         verify(parameterStart == -1, "Expected parameter start to be -1");
@@ -169,11 +266,13 @@ public class TypeSignature
                     }
                     parameterStart = i + 1;
                 }
+                bracketCount++;
             }
             else if (c == ')') {
-                checkArgument(inLiteralParameters, "Bad type signature: '%s'", signature);
-                inLiteralParameters = false;
+                bracketCount--;
                 if (bracketCount == 0) {
+                    checkArgument(inLiteralParameters, "Bad type signature: '%s'", signature);
+                    inLiteralParameters = false;
                     checkArgument(i == signature.length() - 1, "Bad type signature: '%s'", signature);
                     checkArgument(parameterStart >= 0, "Bad type signature: '%s'", signature);
                     literalParameters.add(parseLiteral(signature.substring(parameterStart, i)));
@@ -183,6 +282,20 @@ public class TypeSignature
         }
 
         throw new IllegalArgumentException(format("Bad type signature: '%s'", signature));
+    }
+
+    private static void parseSignatureOrLong(
+            String signature,
+            int begin,
+            int end,
+            List<TypeParameterSignature> parameters)
+    {
+        if (Character.isDigit(signature.charAt(begin))) {
+            parameters.add(TypeParameterSignature.of(Long.parseLong(signature.substring(begin, end))));
+        }
+        else {
+            parameters.add(TypeParameterSignature.of(parseTypeSignature(signature.substring(begin, end))));
+        }
     }
 
     private static Object parseLiteral(String literal)
@@ -219,7 +332,7 @@ public class TypeSignature
         return Objects.hash(base.toLowerCase(Locale.ENGLISH), parameters, literalParameters);
     }
 
-    private static void checkArgument(boolean argument, String format, Object...args)
+    private static void checkArgument(boolean argument, String format, Object... args)
     {
         if (!argument) {
             throw new IllegalArgumentException(format(format, args));

--- a/presto-spi/src/test/java/com/facebook/presto/spi/type/TestTypeSignature.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/type/TestTypeSignature.java
@@ -40,6 +40,7 @@ public class TestTypeSignature
         assertBindSignature("map(T1,T2)", boundParameters, "map(varchar,bigint)");
         assertBindSignature("map<T1,T2>", boundParameters, "map(varchar,bigint)");
         assertBindSignature("row<T1,T2>('a','b')", boundParameters, "row<varchar,bigint>('a','b')");
+        assertBindSignature("bla(T1,42,T2)", boundParameters, "bla(varchar,42,bigint)");
 
         assertBindSignatureFails("T1(bigint)", boundParameters, "Unbounded parameters can not have parameters");
     }

--- a/presto-spi/src/test/java/com/facebook/presto/spi/type/TestTypeSignature.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/type/TestTypeSignature.java
@@ -13,90 +13,126 @@
  */
 package com.facebook.presto.spi.type;
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
 import java.util.List;
 
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
-import static java.util.Locale.ENGLISH;
-import static java.util.stream.Collectors.toList;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
 public class TestTypeSignature
 {
     @Test
+    public void testRow()
+            throws Exception
+    {
+        assertRowSignature(
+                "row<bigint,varchar>('a','b')",
+                "row",
+                ImmutableList.of("bigint", "varchar"),
+                ImmutableList.of("a", "b"));
+        assertRowSignature(
+                "row<bigint,array(bigint),row<bigint>('a')>('a','b','c')",
+                "row",
+                ImmutableList.of("bigint", "array(bigint)", "row<bigint>('a')"),
+                ImmutableList.of("a", "b", "c"));
+        assertRowSignature(
+                "row<varchar(10),row<bigint>('a')>('a','b')",
+                "row",
+                ImmutableList.of("varchar(10)", "row<bigint>('a')"),
+                ImmutableList.of("a", "b"));
+        assertRowSignature(
+                "array(row<bigint,double>('col0','col1'))",
+                "array",
+                ImmutableList.of("row<bigint,double>('col0','col1')"),
+                ImmutableList.of());
+        assertRowSignature(
+                "row<array(row<bigint,double>('col0','col1'))>('col0')",
+                "row",
+                ImmutableList.of("array(row<bigint,double>('col0','col1'))"),
+                ImmutableList.of("col0"));
+    }
+
+    @Test
     public void test()
             throws Exception
     {
-        assertSignature("bigint", ImmutableList.<String>of());
-        assertSignature("boolean", ImmutableList.<String>of());
-        assertSignature("varchar", ImmutableList.<String>of());
-        assertSignature("array", ImmutableList.of("bigint"));
-        assertSignature("array", ImmutableList.of("array<bigint>"));
-        assertSignature("map", ImmutableList.of("bigint", "bigint"));
-        assertSignature("map", ImmutableList.of("bigint", "array<bigint>"));
-        assertSignature("map", ImmutableList.of("bigint", "map<bigint,map<varchar,bigint>>"));
-        assertSignature("array", ImmutableList.of("timestamp with time zone"));
-        assertSignature("row", ImmutableList.of("bigint", "varchar"), ImmutableList.<Object>of("a", "b"));
-        assertSignature("row", ImmutableList.of("bigint", "array<bigint>", "row<bigint>('a')"), ImmutableList.<Object>of("a", "b", "c"));
-        assertSignature("row", ImmutableList.of("varchar(10)", "row<bigint>('a')"), ImmutableList.<Object>of("a", "b"));
-        assertSignature("foo", ImmutableList.<String>of(), ImmutableList.<Object>of("a"));
-        assertSignature("varchar", ImmutableList.<String>of(), ImmutableList.<Object>of(10L));
+        assertSignature("bigint", "bigint", ImmutableList.<String>of());
+        assertSignature("boolean", "boolean", ImmutableList.<String>of());
+        assertSignature("varchar", "varchar", ImmutableList.<String>of());
+
+        assertSignature("array(bigint)", "array", ImmutableList.of("bigint"));
+        assertSignature("array(array(bigint))", "array", ImmutableList.of("array(bigint)"));
+        assertSignature(
+                "array(timestamp with time zone)",
+                "array",
+                ImmutableList.of("timestamp with time zone"));
+
+        assertSignature(
+                "map(bigint,bigint)",
+                "map",
+                ImmutableList.of("bigint", "bigint"));
+        assertSignature(
+                "map(bigint,array(bigint))",
+                "map", ImmutableList.of("bigint", "array(bigint)"));
+        assertSignature(
+                "map(bigint,map(bigint,map(varchar,bigint)))",
+                "map",
+                ImmutableList.of("bigint", "map(bigint,map(varchar,bigint))"));
+
+        assertSignatureFail("blah()");
+        assertSignatureFail("array()");
+        assertSignatureFail("map()");
+    }
+
+    @Test
+    public void testLiteralParameters()
+    {
+        assertSignature("foo(42)", "foo", ImmutableList.<String>of("42"));
+        assertSignature("varchar(10)", "varchar", ImmutableList.<String>of("10"));
+    }
+
+    private static void assertRowSignature(
+            String typeName,
+            String base,
+            List<String> parameters,
+            List<Object> literalParameters)
+    {
+        assertSignature(typeName, base, parameters, literalParameters, typeName);
+    }
+
+    private static void assertSignature(String typeName, String base, List<String> parameters)
+    {
+        assertSignature(typeName, base, parameters, ImmutableList.of(), typeName.replace("<", "(").replace(">", ")"));
+    }
+
+    private static void assertSignature(
+            String typeName,
+            String base,
+            List<String> parameters,
+            List<Object> literalParameters,
+            String expectedTypeName)
+    {
+        TypeSignature signature = parseTypeSignature(typeName);
+        assertEquals(signature.getBase(), base);
+        assertEquals(signature.getTypeParameters().size(), parameters.size());
+        for (int i = 0; i < signature.getTypeParameters().size(); i++) {
+            assertEquals(signature.getTypeParameters().get(i).toString(), parameters.get(i));
+        }
+        assertEquals(signature.getLiteralParameters(), literalParameters);
+        assertEquals(signature.toString(), expectedTypeName);
+    }
+
+    private void assertSignatureFail(String typeName)
+    {
         try {
-            parseTypeSignature("blah<>");
+            parseTypeSignature(typeName);
             fail("Type signatures with zero parameters should fail to parse");
         }
         catch (RuntimeException e) {
             // Expected
         }
-        try {
-            parseTypeSignature("blah()");
-            fail("Type signatures with zero literal parameters should fail to parse");
-        }
-        catch (RuntimeException e) {
-            // Expected
-        }
-    }
-
-    private static void assertSignature(String base, List<String> parameters)
-    {
-        assertSignature(base, parameters, ImmutableList.of());
-    }
-
-    private static void assertSignature(String base, List<String> parameters, List<Object> literalParameters)
-    {
-        List<String> lowerCaseTypeNames = parameters.stream()
-                .map(value -> value.toLowerCase(ENGLISH))
-                .collect(toList());
-
-        String typeName = base.toLowerCase(ENGLISH);
-        if (!parameters.isEmpty()) {
-            typeName += "<" + Joiner.on(",").join(lowerCaseTypeNames) + ">";
-        }
-        if (!literalParameters.isEmpty()) {
-            List<String> transform = literalParameters.stream()
-                    .map(TestTypeSignature::convertParameter)
-                    .collect(toList());
-            typeName += "(" + Joiner.on(",").join(transform) + ")";
-        }
-        TypeSignature signature = parseTypeSignature(typeName);
-        assertEquals(signature.getBase(), base);
-        assertEquals(signature.getParameters().size(), parameters.size());
-        for (int i = 0; i < signature.getParameters().size(); i++) {
-            assertEquals(signature.getParameters().get(i).toString(), parameters.get(i));
-        }
-        assertEquals(signature.getLiteralParameters(), literalParameters);
-        assertEquals(typeName, signature.toString());
-    }
-
-    private static String convertParameter(Object value)
-    {
-        if (value instanceof String) {
-            return "'" + value + "'";
-        }
-        return value.toString();
     }
 }

--- a/presto-spi/src/test/java/com/facebook/presto/spi/type/TestingTypeManager.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/type/TestingTypeManager.java
@@ -42,6 +42,12 @@ public class TestingTypeManager
     }
 
     @Override
+    public Type getParameterizedType(String baseTypeName, List<TypeParameterSignature> typeParameters)
+    {
+        return getType(new TypeSignature(baseTypeName, typeParameters));
+    }
+
+    @Override
     public Type getParameterizedType(String baseTypeName, List<TypeSignature> typeParameters, List<Object> literalParameters)
     {
         return getType(new TypeSignature(baseTypeName, typeParameters, literalParameters));

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -4814,7 +4814,7 @@ public abstract class AbstractTestQueries
         computeActual("SELECT 1 <> 'x'");
     }
 
-    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "\\Qline 1:8: Unknown type: ARRAY<FOO>\\E")
+    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "\\Qline 1:8: Unknown type: ARRAY(FOO)\\E")
     public void testInvalidType()
     {
         computeActual("SELECT CAST(null AS array<foo>)");


### PR DESCRIPTION
- generailized parametric types
- deprecated literalParameters
- added parser support for BIGINT typeParameter
- propagated TypeParameterSignature to most of previous TypeSignature uses

TODO/Questions:
- move parseSignature to presto-main and base it on antlr
- add similar class to TypeParameterSignature (vs TypeSignature) for Type (in other words: add TypeParameter class) and refactor Signature/TypeRegistry classes
