### PR TITLE
Don't remove directories for rpm on upgrade

### DIFF
--- a/presto-server-rpm/src/main/rpm/postremove
+++ b/presto-server-rpm/src/main/rpm/postremove
@@ -1,9 +1,13 @@
 # Post erase script
 
-# Delete the conf directory manually during uninstall.
-# rpm -e wont remove it, because this directory was manually updated in postinstall
-rm -rf /etc/presto
-# Delete the data directory manually during uninstall.
-# rpm -e wont remove it, because this directory may later contain files not
-# deployed by the rpm
-rm -rf /var/lib/presto
+# if this is the last version of presto-server-rpm being removed (i.e. not on upgrade)
+if [ "$1" -eq 0 ]
+then
+    # Delete the conf directory manually during uninstall.
+    # rpm -e wont remove it, because this directory was manually updated in postinstall
+    rm -rf /etc/presto
+    # Delete the data directory manually during uninstall.
+    # rpm -e wont remove it, because this directory may later contain files not
+    # deployed by the rpm
+    rm -rf /var/lib/presto
+fi


### PR DESCRIPTION
The postunistall script for the rpm removes the configuration
directories, since rpm would not do that itself.  Only remove those
directories if this is the last version of the rpm on the machine.  On
upgrade, those directories should not be removed.

Testing: manually verified
