### PR TITLE
Ignore excess rows

### DIFF
--- a/presto-product-tests/src/main/resources/sql-tests/testcases/connectors/mysql/show_schemas.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/connectors/mysql/show_schemas.sql
@@ -2,6 +2,6 @@
 --!
 show schemas from mysql
 --!
--- delimiter: |; trimValues: true; ignoreOrder: true;
+-- delimiter: |; trimValues: true; ignoreOrder: true; ignoreExcessRows: true;
 test|
 information_schema|

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/connectors/mysql/show_tables.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/connectors/mysql/show_tables.sql
@@ -3,6 +3,6 @@
 --!
 show tables from mysql.test
 --!
--- delimiter: |; trimValues: true; ignoreOrder: true;
+-- delimiter: |; trimValues: true; ignoreOrder: true; ignoreExcessRows: true;
 datatype_jdbc|
 workers_jdbc|

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/connectors/postgresql/show_schemas.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/connectors/postgresql/show_schemas.sql
@@ -2,7 +2,7 @@
 --!
 show schemas from postgresql
 --!
--- delimeter: |; trimValues: true; ignoreOrder: true;
+-- delimeter: |; trimValues: true; ignoreOrder: true; ignoreExcessRows: true;
 information_schema|
 pg_catalog|
 public|

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/connectors/postgresql/show_tables.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/connectors/postgresql/show_tables.sql
@@ -3,6 +3,6 @@
 --!
 show tables from postgresql.public
 --!
--- delimiter: |; trimValues: true; ignoreOrder: true;
+-- delimiter: |; trimValues: true; ignoreOrder: true; ignoreExcessRows: true;
 datatype_psql|
 workers_jdbc|


### PR DESCRIPTION
For 'show schemas' and 'show tables', ignore unexpected rows as these do not represent bugs.
