### PR TITLE
Release notes

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -6,3 +6,30 @@ Release Notes
     :maxdepth: 1
 
     release/unsupported
+    release/teradata-additions
+    release/release-0.127
+    release/release-0.126
+    release/release-0.125
+    release/release-0.124
+    release/release-0.123
+    release/release-0.122
+    release/release-0.121
+    release/release-0.120
+    release/release-0.119
+    release/release-0.118
+    release/release-0.117
+    release/release-0.116
+    release/release-0.115
+    release/release-0.114
+    release/release-0.113
+    release/release-0.112
+    release/release-0.111
+    release/release-0.110
+    release/release-0.109
+    release/release-0.108
+    release/release-0.107
+    release/release-0.106
+    release/release-0.105
+    release/release-0.104
+    release/release-0.103
+    release/release-0.102

--- a/presto-docs/src/main/sphinx/release/release-0.102.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.102.rst
@@ -1,0 +1,53 @@
+=============
+Release 0.102
+=============
+
+Unicode Support
+---------------
+
+All string functions have been updated to support Unicode. The functions assume
+that the string contains valid UTF-8 encoded code points. There are no explicit
+checks for valid UTF-8, and the functions may return incorrect results on
+invalid UTF-8.  Invalid UTF-8 data can be corrected with :func:`from_utf8`.
+
+Additionally, the functions operate on Unicode code points and not user visible
+*characters* (or *grapheme clusters*).  Some languages combine multiple code points
+into a single user-perceived *character*, the basic unit of a writing system for a
+language, but the functions will treat each code point as a separate unit.
+
+Regular Expression Functions
+----------------------------
+
+All :doc:`/functions/regexp` have been rewritten to improve performance.
+The new versions are often twice as fast and in some cases can be many
+orders of magnitude faster (due to removal of quadratic behavior).
+This change introduced some minor incompatibilities that are explained
+in the documentation for the functions.
+
+General Changes
+---------------
+
+* Add support for partitioned right outer joins, which allows for larger tables to
+  be joined on the inner side.
+* Add support for full outer joins.
+* Support returning booleans as numbers in JDBC driver
+* Fix :func:`contains` to return ``NULL`` if the value was not found, but a ``NULL`` was.
+* Fix nested :ref:`row_type` rendering in ``DESCRIBE``.
+* Add :func:`array_join`.
+* Optimize map subscript operator.
+* Add :func:`from_utf8` and :func:`to_utf8` functions.
+* Add ``task_writer_count`` session property to set ``task.writer-count``.
+* Add cast from ``ARRAY<F>`` to ``ARRAY<T>``.
+* Extend implicit coercions to ``ARRAY`` element types.
+* Implement implicit coercions in ``VALUES`` expressions.
+* Fix potential deadlock in scheduler.
+
+Hive Changes
+------------
+
+* Collect more metrics from ``PrestoS3FileSystem``.
+* Retry when seeking in ``PrestoS3FileSystem``.
+* Ignore ``InvalidRange`` error in ``PrestoS3FileSystem``.
+* Implement rename and delete in ``PrestoS3FileSystem``.
+* Fix assertion failure when running ``SHOW TABLES FROM schema``.
+* Fix S3 socket leak when reading ORC files.

--- a/presto-docs/src/main/sphinx/release/release-0.102.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.102.rst
@@ -32,7 +32,7 @@ General Changes
 * Add support for full outer joins.
 * Support returning booleans as numbers in JDBC driver
 * Fix :func:`contains` to return ``NULL`` if the value was not found, but a ``NULL`` was.
-* Fix nested :ref:`row_type` rendering in ``DESCRIBE``.
+* Fix nested row_type rendering in ``DESCRIBE``.
 * Add :func:`array_join`.
 * Optimize map subscript operator.
 * Add :func:`from_utf8` and :func:`to_utf8` functions.

--- a/presto-docs/src/main/sphinx/release/release-0.103.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.103.rst
@@ -1,0 +1,55 @@
+=============
+Release 0.103
+=============
+
+Cluster Resource Management
+---------------------------
+
+There is a new cluster resource manager, which can be enabled via the
+``experimental.cluster-memory-manager-enabled`` flag. Currently, the only
+resource that's tracked is memory, and the cluster resource manager guarantees
+that the cluster will not deadlock waiting for memory. However, in a low memory
+situation it is possible that only one query will make progress. Memory limits can
+now be configured via ``query.max-memory`` which controls the total distributed
+memory a query may use and ``query.max-memory-per-node`` which limits the amount
+of memory a query may use on any one node. On each worker, the
+``resources.reserved-system-memory`` flags controls how much memory is reserved
+for internal Presto data structures and temporary allocations.
+
+Task Parallelism
+----------------
+Queries involving a large number of aggregations or a large hash table for a
+join can be slow due to single threaded execution in the intermediate stages.
+This release adds experimental configuration and session properties to execute
+this single threaded work in parallel.  Depending on the exact query this may
+reduce wall time, but will likely increase CPU usage.
+
+Use the configuration parameter ``task.default-concurrency`` or the session
+property ``task_default_concurrency`` to set the default number of parallel
+workers to use for join probes, hash builds and final aggregations.
+Additionally, the session properties ``task_join_concurrency``,
+``task_hash_build_concurrency`` and ``task_aggregation_concurrency`` can be
+used to control the parallelism for each type of work.
+
+This is an experimental feature and will likely change in a future release.  It
+is also expected that this will eventually be handled automatically by the
+query planner and these options will be removed entirely.
+
+Hive Changes
+------------
+
+* Removed the ``hive.max-split-iterator-threads`` parameter and renamed
+  ``hive.max-global-split-iterator-threads`` to ``hive.max-split-iterator-threads``.
+* Fix excessive object creation when querying tables with a large number of partitions.
+* Do not retry requests when an S3 path is not found.
+
+General Changes
+---------------
+
+* Add :func:`array_remove`.
+* Fix NPE in :func:`max_by` and :func:`min_by` caused when few rows were present in the aggregation.
+* Reduce memory usage of :func:`map_agg`.
+* Change HTTP client defaults: 2 second idle timeout, 10 second request
+  timeout and 250 connections per host.
+* Add SQL command autocompletion to CLI.
+* Increase CLI history file size.

--- a/presto-docs/src/main/sphinx/release/release-0.104.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.104.rst
@@ -1,0 +1,30 @@
+=============
+Release 0.104
+=============
+
+General Changes
+---------------
+
+* Handle thread interruption in StatementClient.
+* Fix CLI hang when server becomes unreachable during a query.
+* Add :func:`covar_pop`, :func:`covar_samp`, :func:`corr`, :func:`regr_slope`,
+  and :func:`regr_intercept` functions.
+* Fix potential deadlock in cluster memory manager.
+* Add a visualization of query execution timeline.
+* Allow mixed case in input to :func:`from_hex`.
+* Display "BLOCKED" state in web UI.
+* Reduce CPU usage in coordinator.
+* Fix excess object retention in workers due to long running queries.
+* Reduce memory usage of :func:`array_distinct`.
+* Add optimizer for projection push down which can
+  improve the performance of certain query shapes.
+* Improve query performance by storing pre-partitioned pages.
+* Support ``TIMESTAMP`` for :func:`first_value`, :func:`last_value`,
+  :func:`nth_value`, :func:`lead` and :func:`lag`.
+
+Hive Changes
+------------
+
+* Upgrade to Parquet 1.6.0.
+* Collect request time and retry statistics in ``PrestoS3FileSystem``.
+* Fix retry attempt counting for S3.

--- a/presto-docs/src/main/sphinx/release/release-0.105.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.105.rst
@@ -1,0 +1,21 @@
+=============
+Release 0.105
+=============
+
+General Changes
+---------------
+
+* Fix issue which can cause queries to be blocked permanently.
+* Close connections correctly in JDBC connectors.
+* Add implicit coercions for values of equi-join criteria.
+* Fix detection of window function calls without an ``OVER`` clause.
+
+SPI Changes
+-----------
+
+* Remove ``ordinalPosition`` from ``ColumnMetadata``.
+
+.. note::
+    This is a backwards incompatible change with the previous connector SPI.
+    If you have written a connector, you will need to update your code
+    before deploying this release.

--- a/presto-docs/src/main/sphinx/release/release-0.106.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.106.rst
@@ -1,0 +1,15 @@
+=============
+Release 0.106
+=============
+
+General Changes
+---------------
+
+* Parallelize startup of table scan task splits.
+* Fixed index join driver resource leak.
+* Improve memory accounting for JOINs and GROUP BYs.
+* Improve CPU efficiency of coordinator.
+* Added ``Asia/Chita``, ``Asia/Srednekolymsk``, and ``Pacific/Bougainville`` time zones.
+* Fix task leak caused by race condition in stage state machine.
+* Fix blocking in Hive split source.
+* Free resources sooner for queries that finish prematurely.

--- a/presto-docs/src/main/sphinx/release/release-0.107.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.107.rst
@@ -1,0 +1,16 @@
+=============
+Release 0.107
+=============
+
+General Changes
+---------------
+
+* Added ``query_max_memory`` session property. Note: this session property cannot
+  increase the limit above the limit set by the ``query.max-memory`` configuration option.
+* Fixed task leak caused by queries that finish early, such as a ``LIMIT`` query
+  or cancelled query, when the cluster is under high load.
+* Added ``task.info-refresh-max-wait`` to configure task info freshness.
+* Add support for ``DELETE`` to language and connector SPI.
+* Reenable error classification code for syntax errors.
+* Fix out of bounds exception in :func:`lower` and :func:`upper`
+  when the string contains the code point ``U+10FFFF``.

--- a/presto-docs/src/main/sphinx/release/release-0.108.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.108.rst
@@ -1,0 +1,38 @@
+=============
+Release 0.108
+=============
+
+General Changes
+---------------
+
+* Fix incorrect query results when a window function follows a :func:`row_number`
+  function and both are partitioned on the same column(s).
+* Fix planning issue where queries that apply a ``false`` predicate
+  to the result of a non-grouped aggregation produce incorrect results.
+* Fix exception when ``ORDER BY`` clause contains duplicate columns.
+* Fix issue where a query (read or write) that should fail can instead
+  complete successfully with zero rows.
+* Add :func:`normalize`, :func:`from_iso8601_timestamp`, :func:`from_iso8601_date`
+  and :func:`to_iso8601` functions.
+* Add support for :func:`position` syntax.
+* Add Teradata compatibility functions: :func:`index`, :func:`char2hexint`,
+  :func:`to_char`, :func:`to_date` and :func:`to_timestamp`.
+* Make ``ctrl-C`` in CLI cancel the query (rather than a partial cancel).
+* Allow calling ``Connection.setReadOnly(false)`` in the JDBC driver.
+  The read-only status for the connection is currently ignored.
+* Add missing ``CAST`` from ``VARCHAR`` to ``TIMESTAMP WITH TIME ZONE``.
+* Allow optional time zone in ``CAST`` from ``VARCHAR`` to ``TIMESTAMP`` and
+  ``TIMESTAMP WITH TIME ZONE``.
+* Trim values when converting from ``VARCHAR`` to date/time types.
+* Add support for fixed time zones ``+00:00`` and ``-00:00``.
+* Properly account for query memory when using the :func:`row_number` function.
+* Skip execution of inner join when the join target is empty.
+* Improve query detail UI page.
+* Fix printing of table layouts in :doc:`/sql/explain`.
+* Add :doc:`/connector/blackhole`.
+
+Cassandra Changes
+-----------------
+
+* Randomly select Cassandra node for split generation.
+* Fix handling of ``UUID`` partition keys.

--- a/presto-docs/src/main/sphinx/release/release-0.109.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.109.rst
@@ -1,0 +1,26 @@
+=============
+Release 0.109
+=============
+
+General Changes
+---------------
+
+* Add :func:`slice`, :func:`md5`, :func:`array_min` and :func:`array_max` functions.
+* Fix bug that could cause queries submitted soon after startup to hang forever.
+* Fix bug that could cause ``JOIN`` queries to hang forever, if the right side of
+  the ``JOIN`` had too little data or skewed data.
+* Improve index join planning heuristics to favor streaming execution.
+* Improve validation of date/time literals.
+* Produce RPM package for Presto server.
+* Always redistribute data when writing tables to avoid skew. This can
+  be disabled by setting the session property ``redistribute_writes``
+  or the config property ``redistribute-writes`` to false.
+
+Remove "Big Query" Support
+--------------------------
+The experimental support for big queries has been removed in favor of
+the new resource manager which can be enabled via the
+``experimental.cluster-memory-manager-enabled`` config option.
+The ``experimental_big_query`` session property and the following config
+options are no longer supported: ``experimental.big-query-initial-hash-partitions``,
+``experimental.max-concurrent-big-queries`` and ``experimental.max-queued-big-queries``.

--- a/presto-docs/src/main/sphinx/release/release-0.110.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.110.rst
@@ -1,0 +1,16 @@
+=============
+Release 0.110
+=============
+
+General Changes
+---------------
+
+* Fix result truncation bug in window function :func:`row_number` when performing a
+  partitioned top-N that chooses the maximum or minimum ``N`` rows. For example::
+
+    SELECT * FROM (
+        SELECT row_number() OVER (PARTITION BY orderstatus ORDER BY orderdate) AS rn,
+            custkey, orderdate, orderstatus
+        FROM orders
+    ) WHERE rn <= 5;
+

--- a/presto-docs/src/main/sphinx/release/release-0.111.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.111.rst
@@ -1,0 +1,14 @@
+=============
+Release 0.111
+=============
+
+General Changes
+---------------
+
+* Add :func:`histogram` function.
+* Optimize ``CASE`` expressions on a constant.
+* Add basic support for ``IF NOT EXISTS`` for ``CREATE TABLE``.
+* Semi-joins are hash-partitioned if ``distributed_join`` is turned on.
+* Add support for partial cast from JSON. For example, ``json`` can be cast to ``array<json>``, ``map<varchar, json>``, etc.
+* Add implicit coercions for ``UNION``.
+* Expose query stats in the JDBC driver ``ResultSet``.

--- a/presto-docs/src/main/sphinx/release/release-0.112.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.112.rst
@@ -1,0 +1,21 @@
+=============
+Release 0.112
+=============
+
+General Changes
+---------------
+
+* Fix incorrect handling of filters and limits in :func:`row_number` optimizer.
+  This caused certain query shapes to produce incorrect results.
+* Fix non-string object arrays in JMX connector.
+
+Hive Changes
+------------
+
+* Tables created using :doc:`/sql/create-table` (not :doc:`/sql/create-table-as`)
+  had invalid metadata and were not readable.
+* Improve performance of ``IN`` and ``OR`` clauses when reading ``ORC`` data.
+  Previously, the ranges for a column were always compacted into a single range
+  before being passed to the reader, preventing the reader from taking full
+  advantage of row skipping. The compaction only happens now if the number of
+  ranges exceeds the ``hive.domain-compaction-threshold`` config property.

--- a/presto-docs/src/main/sphinx/release/release-0.113.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.113.rst
@@ -1,0 +1,69 @@
+=============
+Release 0.113
+=============
+
+.. warning::
+
+    The ORC reader in the Hive connector is broken in this release.
+
+Cluster Resource Management
+---------------------------
+
+The cluster resource manager announced in :doc:`/release/release-0.103` is now enabled by default.
+You can disable it with the ``experimental.cluster-memory-manager-enabled`` flag.
+Memory limits can now be configured via ``query.max-memory`` which controls the total distributed
+memory a query may use and ``query.max-memory-per-node`` which limits the amount
+of memory a query may use on any one node. On each worker, the
+``resources.reserved-system-memory`` config property controls how much memory is reserved
+for internal Presto data structures and temporary allocations.
+
+Session Properties
+------------------
+
+All session properties now have a SQL type, default value and description.  The
+value for :doc:`/sql/set-session` can now be any constant expression, and the
+:doc:`/sql/show-session` command prints the current effective value and default
+value for all session properties.
+
+This type safety extends to the :doc:`SPI </develop/spi-overview>` where properties
+can be validated and converted to any Java type using
+``SessionPropertyMetadata``. For an example, see ``HiveSessionProperties``.
+
+.. note::
+    This is a backwards incompatible change with the previous connector SPI.
+    If you have written a connector that uses session properties, you will need
+    to update your code to declare the properties in the ``Connector``
+    implementation and callers of ``ConnectorSession.getProperty()`` will now
+    need the expected Java type of the property.
+
+General Changes
+---------------
+
+* Allow using any type with value window functions :func:`first_value`,
+  :func:`last_value`, :func:`nth_value`, :func:`lead` and :func:`lag`.
+* Add :func:`element_at` function.
+* Add :func:`url_encode` and :func:`url_decode` functions.
+* :func:`concat` now allows arbitrary number of arguments.
+* Fix JMX connector. In the previous release it always returned zero rows.
+* Fix handling of literal ``NULL`` in ``IS DISTINCT FROM``.
+* Fix an issue that caused some specific queries to fail in planning.
+
+Hive Changes
+------------
+
+* Fix the Hive metadata cache to properly handle negative responses.
+  This makes the background refresh work properly by clearing the cached
+  metadata entries when an object is dropped outside of Presto.
+  In particular, this fixes the common case where a table is dropped using
+  Hive but Presto thinks it still exists.
+* Fix metastore socket leak when SOCKS connect fails.
+
+SPI Changes
+-----------
+
+* Changed the internal representation of structural types.
+
+.. note::
+    This is a backwards incompatible change with the previous connector SPI.
+    If you have written a connector that uses structural types, you will need
+    to update your code to the new APIs.

--- a/presto-docs/src/main/sphinx/release/release-0.113.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.113.rst
@@ -25,10 +25,6 @@ value for :doc:`/sql/set-session` can now be any constant expression, and the
 :doc:`/sql/show-session` command prints the current effective value and default
 value for all session properties.
 
-This type safety extends to the :doc:`SPI </develop/spi-overview>` where properties
-can be validated and converted to any Java type using
-``SessionPropertyMetadata``. For an example, see ``HiveSessionProperties``.
-
 .. note::
     This is a backwards incompatible change with the previous connector SPI.
     If you have written a connector that uses session properties, you will need

--- a/presto-docs/src/main/sphinx/release/release-0.114.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.114.rst
@@ -1,0 +1,14 @@
+=============
+Release 0.114
+=============
+
+General Changes
+---------------
+
+* Fix ``%k`` specifier for :func:`date_format` and :func:`date_parse`.
+  It previously used ``24`` rather than ``0`` for the midnight hour.
+
+Hive Changes
+------------
+
+* Fix ORC reader for Hive connector.

--- a/presto-docs/src/main/sphinx/release/release-0.115.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.115.rst
@@ -1,0 +1,18 @@
+=============
+Release 0.115
+=============
+
+General Changes
+---------------
+
+* Fix an issue with hierarchical queue rules where queries could be rejected after being accepted.
+* Add :func:`sha1`, :func:`sha256` and :func:`sha512` functions.
+* Add :func:`power` as an alias for :func:`pow`.
+* Add support for ``LIMIT ALL`` syntax.
+
+Hive Changes
+------------
+
+* Fix a race condition which could cause queries to finish without reading all the data.
+* Fix a bug in Parquet reader that causes failures while reading lists that has an element
+  schema name other than ``array_element`` in its Parquet-level schema.

--- a/presto-docs/src/main/sphinx/release/release-0.116.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.116.rst
@@ -1,0 +1,45 @@
+=============
+Release 0.116
+=============
+
+Cast between JSON and VARCHAR
+-----------------------------
+
+Casts of both directions between JSON and VARCHAR have been removed. If you
+have such casts in your scripts or views, they will fail with a message when
+you move to release 0.116. To get the semantics of the current casts, use:
+
+* `JSON_PARSE(x)` instead of `CAST(x as JSON)`
+* `JSON_FORMAT(x)` instead of `CAST(x as VARCHAR)`
+
+In a future release, we intend to reintroduce casts between JSON and VARCHAR
+along with other casts involving JSON. The semantics of the new JSON and
+VARCHAR cast will be consistent with the other casts being introduced. But it
+will be different from the semantics in 0.115 and before. When that comes,
+cast between JSON and VARCHAR in old scripts and views will produce unexpected
+result.
+
+Cluster Memory Manager Improvements
+-----------------------------------
+
+The cluster memory manager now has a low memory killer. If the cluster runs low
+on memory, the killer will kill queries to improve throughput. It can be enabled
+with the ``query.low-memory-killer.enabled`` config flag, and the delay between
+when the cluster runs low on memory and when the killer will be invoked can be
+configured with the ``query.low-memory-killer.delay`` option.
+
+General Changes
+---------------
+
+* Add :func:`multimap_agg` function.
+* Add :func:`checksum` function.
+* Add :func:`max` and :func:`min` that takes a second argument and produces
+  ``n`` largest or ``n`` smallest values.
+* Add ``query_max_run_time`` session property and ``query.max-run-time``
+  config. Queries are failed after the specified duration.
+* Removed ``experimental.cluster-memory-manager-enabled`` config. The cluster
+  memory manager is now always enabled.
+* Removed ``task.max-memory`` config.
+* ``optimizer.optimize-hash-generation`` and ``distributed-joins-enabled`` are
+  both enabled by default now.
+* Add optimization for ``IF`` on a constant condition.

--- a/presto-docs/src/main/sphinx/release/release-0.117.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.117.rst
@@ -1,0 +1,12 @@
+=============
+Release 0.117
+=============
+
+General Changes
+---------------
+
+* Add back casts between JSON and VARCHAR to provide an easier migration path
+  to :func:`json_parse` and :func:`json_format`. These will be removed in a
+  future release.
+* Fix bug in semi joins and group bys on a single ``BIGINT`` column where
+  0 could match ``NULL``.

--- a/presto-docs/src/main/sphinx/release/release-0.118.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.118.rst
@@ -1,0 +1,25 @@
+=============
+Release 0.118
+=============
+
+General Changes
+---------------
+
+* Fix planning error for ``UNION`` queries that require implicit coercions.
+* Fix null pointer exception when using :func:`checksum`.
+* Fix completion condition for ``SqlTask`` that can cause queries to be blocked.
+
+Authorization
+-------------
+
+We've added experimental support for authorization of SQL queries in Presto.
+This is currently only supported by the Hive connector. You can enable Hive
+checks by setting the ``hive.security`` property to ``none``, ``read-only``,
+or ``sql-standard``.
+
+.. note::
+
+    The authentication support is experimental and only lightly tested. We are
+    actively working on this feature, so expect backwards incompatible changes.
+    See the ``ConnectorAccessControl`` interface the SPI for details.
+

--- a/presto-docs/src/main/sphinx/release/release-0.119.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.119.rst
@@ -1,0 +1,74 @@
+=============
+Release 0.119
+=============
+
+General Changes
+---------------
+
+* Add :doc:`/connector/redis`.
+* Add :func:`geometric_mean` function.
+* Fix restoring interrupt status in ``StatementClient``.
+* Support getting server version in JDBC driver.
+* Improve correctness and compliance of JDBC ``DatabaseMetaData``.
+* Catalog and schema are now optional on the server. This allows connecting
+  and executing metadata commands or queries that use fully qualified names.
+  Previously, the CLI and JDBC driver would use a catalog and schema named
+  ``default`` if they were not specified.
+* Fix scheduler handling of partially canceled queries.
+* Execute views with the permissions of the view owner.
+* Replaced the ``task.http-notification-threads`` config option with two
+  independent options: ``task.http-response-threads`` and ``task.http-timeout-threads``.
+* Improve handling of negated expressions in join criteria.
+* Fix :func:`arbitrary`, :func:`max_by` and :func:`min_by` functions when used
+  with an array, map or row type.
+* Fix union coercion when the same constant or column appears more than once on
+  the same side.
+* Support ``RENAME COLUMN`` in :doc:`/sql/alter-table`.
+
+SPI Changes
+-----------
+
+* Add more system table distribution modes.
+* Add owner to view metadata.
+
+.. note::
+    These are backwards incompatible changes with the previous connector SPI.
+    If you have written a connector, you may need to update your code to the
+    new APIs.
+
+
+CLI Changes
+-----------
+
+* Fix handling of full width characters.
+* Skip printing query URL if terminal is too narrow.
+* Allow performing a partial query cancel using ``ctrl-P``.
+* Allow toggling debug mode during query by pressing ``D``.
+* Fix handling of query abortion after result has been partially received.
+* Fix handling of ``ctrl-C`` when displaying results without a pager.
+
+Verifier Changes
+----------------
+
+* Add ``expected-double-precision`` config to specify the expected level of
+  precision when comparing double values.
+* Return non-zero exit code when there are failures.
+
+Cassandra Changes
+-----------------
+
+* Add support for Cassandra blob types.
+
+Hive Changes
+------------
+
+* Support adding and renaming columns using :doc:`/sql/alter-table`.
+* Automatically configure the S3 region when running in EC2.
+* Allow configuring multiple Hive metastores for high availability.
+* Add support for ``TIMESTAMP`` and ``VARBINARY`` in Parquet.
+
+MySQL and PostgreSQL Changes
+----------------------------
+
+* Enable streaming results instead of buffering everything in memory.
+* Fix handling of pattern characters when matching table or column names.

--- a/presto-docs/src/main/sphinx/release/release-0.119.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.119.rst
@@ -5,7 +5,6 @@ Release 0.119
 General Changes
 ---------------
 
-* Add :doc:`/connector/redis`.
 * Add :func:`geometric_mean` function.
 * Fix restoring interrupt status in ``StatementClient``.
 * Support getting server version in JDBC driver.

--- a/presto-docs/src/main/sphinx/release/release-0.120.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.120.rst
@@ -1,0 +1,6 @@
+=============
+Release 0.120
+=============
+.. warning::
+
+   This release is broken and should not be used.

--- a/presto-docs/src/main/sphinx/release/release-0.121.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.121.rst
@@ -1,0 +1,11 @@
+=============
+Release 0.121
+=============
+
+General Changes
+---------------
+
+* Fix regression that causes task scheduler to not retry requests in some cases.
+* Throttle task info refresher on errors.
+* Fix planning failure that prevented the use of large ``IN`` lists.
+* Fix comparision of ``array<x>`` where ``x`` is a comparable, non-orderable type.

--- a/presto-docs/src/main/sphinx/release/release-0.122.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.122.rst
@@ -1,0 +1,22 @@
+=============
+Release 0.122
+=============
+
+.. warning::
+
+   There is a bug in this release that will cause queries to fail when the
+   ``optimizer.optimize-hash-generation`` config is disabled.
+
+General Changes
+---------------
+
+* The deprecated casts between JSON and VARCHAR will now fail and provide the
+  user with instructions to migrate their query. For more details, see
+  :doc:`/release/release-0.116`.
+* Fix ``NoSuchElementException`` when cross join is used inside ``IN`` query.
+* Fix ``GROUP BY`` to support maps of structural types.
+* The web interface now displays a lock icon next to authenticated users.
+* The :func:`min_by` and :func:`max_by` aggregations now have an additional form
+  that return multiple values.
+* Fix incorrect results when using ``IN`` lists of more than 1000 elements of
+  ``timestamp with time zone``, ``time with time zone`` or structural types.

--- a/presto-docs/src/main/sphinx/release/release-0.123.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.123.rst
@@ -1,0 +1,54 @@
+=============
+Release 0.123
+=============
+
+General Changes
+---------------
+
+* Remove ``node-scheduler.location-aware-scheduling-enabled`` config.
+* Fixed query failures that occur when the ``optimizer.optimize-hash-generation``
+  config is disabled.
+* Fix exception when using the ``ResultSet`` returned from the
+  ``DatabaseMetaData.getColumns`` method in the JDBC driver.
+* Increase default value of ``failure-detector.threshold`` config.
+* Fix race in queueing system which could cause queries to fail with
+  "Entering secondary queue failed".
+* Fix issue with :func:`histogram` that can cause failures or incorrect results
+  when there are more than ten buckets.
+* Optimize execution of cross join.
+* Run Presto server as ``presto`` user in RPM init scripts.
+
+Table Properties
+----------------
+
+When creating tables with :doc:`/sql/create-table` or :doc:`/sql/create-table-as`,
+you can now add connector specific properties to the new table.  For example, when
+creating a Hive table you can specify the file format.  To list all available table,
+properties, run the following query::
+
+    SELECT * FROM system.metadata.table_properties
+
+Hive Changes
+------------
+
+We have implemented ``INSERT`` and ``DELETE`` for Hive.  Both ``INSERT`` and ``CREATE``
+statements support partitioned tables.  For example, to create a partitioned table
+execute the following::
+
+    CREATE TABLE orders (
+       order_date VARCHAR,
+       order_region VARCHAR,
+       order_id BIGINT,
+       order_info VARCHAR
+    ) WITH (partitioned_by = ARRAY['order_date', 'order_region'])
+
+To ``DELETE`` from a Hive table, you must specify a ``WHERE`` clause that matches
+entire partitions.  For example, to delete from the above table, execute the following::
+
+    DELETE FROM orders
+    WHERE order_date = '2015-10-15' AND order_region = 'APAC'
+
+.. note::
+
+    Currently, Hive deletion is only supported for partitioned tables.
+    Additionally, partition keys must be of type VARCHAR.

--- a/presto-docs/src/main/sphinx/release/release-0.124.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.124.rst
@@ -1,0 +1,48 @@
+=============
+Release 0.124
+=============
+
+General Changes
+---------------
+
+* Fix race in memory tracking of ``JOIN`` which could cause the cluster to become over
+  committed and possibly crash.
+* The :func:`approx_percentile` aggregation now also accepts an array of percentages.
+* Allow nested row type references.
+* Fix correctness for some queries with ``IN`` lists. When all constants in the
+  list are in the range of 32-bit signed integers but the test value can be
+  outside of the range, ``true`` may be produced when the correct result should
+  be ``false``.
+* Fail queries submitted while coordinator is starting.
+* Add JMX stats to track authentication and authorization successes and failures.
+* Add configuration support for the system access control plugin. The system access
+  controller can be selected and configured using ``etc/access-control.properties``.
+  Note that Presto currently does not ship with any system access controller
+  implementations.
+* Add support for ``WITH NO DATA`` syntax in ``CREATE TABLE ... AS SELECT``.
+* Fix issue where invalid plans are generated for queries with multiple aggregations 
+  that require input values to be cast in different ways.
+* Fix performance issue due to redundant processing in queries involving ``DISTINCT`` 
+  and ``LIMIT``.
+* Add optimization that can reduce the amount of data sent over the network
+  for grouped aggregation queries. This feature can be enabled by
+  ``optimizer.use-intermediate-aggregations`` config property or
+  ``task_intermediate_aggregation`` session property.
+
+Hive Changes
+------------
+
+* Do not count expected exceptions as errors in the Hive metastore client stats.
+* Improve performance when reading ORC files with many tiny stripes.
+
+Verifier
+--------
+
+* Add support for pre and post control and test queries.
+
+If you are upgrading, you need to alter your ``verifier_queries`` table::
+
+    ALTER TABLE verifier_queries ADD COLUMN test_postqueries text;
+    ALTER TABLE verifier_queries ADD COLUMN test_prequeries text;
+    ALTER TABLE verifier_queries ADD COLUMN control_postqueries text;
+    ALTER TABLE verifier_queries ADD COLUMN control_prequeries text;

--- a/presto-docs/src/main/sphinx/release/release-0.125.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.125.rst
@@ -1,0 +1,11 @@
+=============
+Release 0.125
+=============
+
+General Changes
+---------------
+
+* Fix an issue where certain operations such as ``GROUP BY``, ``DISTINCT``, etc. on the
+  output of a ``RIGHT`` or ``FULL OUTER JOIN`` can return incorrect results if they reference columns
+  from the left relation that are also used in the join clause, and not every row from the right relation
+  has a match.

--- a/presto-docs/src/main/sphinx/release/release-0.126.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.126.rst
@@ -1,0 +1,51 @@
+=============
+Release 0.126
+=============
+
+General Changes
+---------------
+
+* Add error location information (line and column number) for semantic errors.
+* Fix a CLI crash during tab-completion when no schema is currently selected.
+* Fix reset of session properties in CLI when running :doc:`/sql/use`.
+* Fix occasional query planning failure due to a bug in the projection
+  push down optimizer.
+* Fix a parsing issue when expressions contain the form ``POSITION(x in (y))``.
+* Add a new version of :func:`approx_percentile` that takes an ``accuracy``
+  parameter.
+* Allow specifying columns names in :doc:`/sql/insert` queries.
+* Add ``field_length`` table property to blackhole connector to control the
+  size of generated ``VARCHAR`` and ``VARBINARY`` fields.
+* Bundle Teradata functions plugin in server package.
+* Improve handling of physical properties which can increase performance for
+  queries involving window functions.
+* Add ability to control whether index join lookups and caching are shared
+  within a task. This allows us to optimize for index cache hits or for more
+  CPU parallelism. This option is toggled by the ``task.share-index-loading``
+  config property or the ``task_share_index_loading`` session property.
+* Add :doc:`Tableau web connector </installation/tableau>`.
+* Improve performance of queries that use an ``IN`` expression with a large
+  list of constant values.
+* Enable connector predicate push down for all comparable and equatable types.
+* Fix query planning failure when using certain operations such as ``GROUP BY``,
+  ``DISTINCT``, etc. on the output columns of ``UNNEST``.
+* In ``ExchangeClient`` set ``maxResponseSize`` to be slightly smaller than
+  the configured value. This reduces the possibility of encountering
+  ``PageTooLargeException``.
+* Fix memory leak in coordinator.
+* Add validation for names of table properties.
+
+Hive Changes
+------------
+
+* Fix reading structural types containing nulls in Parquet.
+* Fix writing DATE type when timezone offset is negative. Previous versions
+  would write the wrong date (off by one day).
+* Fix an issue where ``VARCHAR`` columns added to an existing table could not be
+  queried.
+* Fix over-creation of initial splits.
+* Fix ``hive.immutable-partitions`` config property to also apply to
+  unpartitioned tables.
+* Allow non-``VARCHAR`` columns in ``DELETE`` query.
+* Support ``DATE`` columns as partition columns in parquet tables.
+* Improve error message for cases where partition columns are also table columns.

--- a/presto-docs/src/main/sphinx/release/release-0.126.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.126.rst
@@ -23,7 +23,6 @@ General Changes
   within a task. This allows us to optimize for index cache hits or for more
   CPU parallelism. This option is toggled by the ``task.share-index-loading``
   config property or the ``task_share_index_loading`` session property.
-* Add :doc:`Tableau web connector </installation/tableau>`.
 * Improve performance of queries that use an ``IN`` expression with a large
   list of constant values.
 * Enable connector predicate push down for all comparable and equatable types.

--- a/presto-docs/src/main/sphinx/release/release-0.127.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.127.rst
@@ -1,0 +1,9 @@
+=============
+Release 0.127
+=============
+
+General Changes
+---------------
+
+* Disable index join repartitioning when it disrupts streaming execution.
+* Fix memory accounting leak in some ``JOIN`` queries.

--- a/presto-docs/src/main/sphinx/release/teradata-additions.rst
+++ b/presto-docs/src/main/sphinx/release/teradata-additions.rst
@@ -1,0 +1,21 @@
+==================
+Teradata Additions
+==================
+
+The following are additions that Teradata has added to Facebook's 0.127 release of presto
+
+General Fixes
+-------------
+
+* Remove buggy optimization to prune redundant projections because it produced wrong results.
+
+Datatypes
+---------
+
+* Experimental support for the decimal datatype
+
+RPM Fixes
+---------
+* The presto rpm now works with all versions of rpm after and including 4.6.  And has a separate rpm
+  for rpm versions before 4.6
+* Fix rpm upgrade

--- a/presto-docs/src/main/sphinx/release/unsupported.rst
+++ b/presto-docs/src/main/sphinx/release/unsupported.rst
@@ -1,14 +1,14 @@
-=============
-Release Notes
-=============
+==========================================
+Unsupported Features and Known Limitations
+==========================================
 
-Presto 115t is equivalent to Presto release 0.115, with some additional features. Below
+Presto 127t is equivalent to Presto release 0.127, with some additional features. Below
 are documented unsupported features and known limitations.
 
 Unsupported Features
 --------------------
 
-The following features from Presto 0.115 may work but are not officially supported:
+The following features from Presto 0.127 may work but are not officially supported:
 
  * Installing presto via the tar ball
  * Running presto via the launcher script


### PR DESCRIPTION
I have added release notes for 0.102-0.127 from facebook/presto with some changes.  The initialcommit that adds the release notes does not build without the commit that follows it.  I put them as separate commits so that you would be able to see what changes were needed.  I did not read through the release notes to check for supported vs. unsupported features.  Anything that's unsupported should be appropriately documented in the unsupported page.

@KBP-TDC @mattsfuller 
