### PR TITLE
Add configuration for postgresql security system

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/ConditionalModule.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/ConditionalModule.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.jdbc;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.airlift.configuration.ConfigurationAwareModule;
+
+import java.util.function.Predicate;
+
+public class ConditionalModule<T>
+        extends AbstractConfigurationAwareModule
+{
+    public static <T> Module installModuleIf(Class<T> config, Predicate<T> predicate, Module module)
+    {
+        return new ConditionalModule<>(config, predicate, module);
+    }
+
+    private final Class<T> config;
+    private final Predicate<T> predicate;
+    private final Module module;
+
+    private ConditionalModule(Class<T> config, Predicate<T> predicate, Module module)
+    {
+        this.config = config;
+        this.predicate = predicate;
+        this.module = module;
+    }
+
+    @Override
+    protected void setup(Binder binder)
+    {
+        T configuration = buildConfigObject(config);
+        if (predicate.test(configuration)) {
+            if (module instanceof ConfigurationAwareModule) {
+                install((ConfigurationAwareModule) module);
+            }
+            else {
+                binder.install(module);
+            }
+        }
+    }
+}

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcConnector.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcConnector.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.ConnectorMetadata;
 import com.facebook.presto.spi.ConnectorRecordSetProvider;
 import com.facebook.presto.spi.ConnectorRecordSinkProvider;
 import com.facebook.presto.spi.ConnectorSplitManager;
+import com.facebook.presto.spi.security.ConnectorAccessControl;
 import io.airlift.bootstrap.LifeCycleManager;
 import io.airlift.log.Logger;
 
@@ -37,6 +38,7 @@ public class JdbcConnector
     private final JdbcRecordSetProvider jdbcRecordSetProvider;
     private final JdbcHandleResolver jdbcHandleResolver;
     private final JdbcRecordSinkProvider jdbcRecordSinkProvider;
+    private final ConnectorAccessControl accessControl;
 
     @Inject
     public JdbcConnector(
@@ -45,7 +47,8 @@ public class JdbcConnector
             JdbcSplitManager jdbcSplitManager,
             JdbcRecordSetProvider jdbcRecordSetProvider,
             JdbcHandleResolver jdbcHandleResolver,
-            JdbcRecordSinkProvider jdbcRecordSinkProvider)
+            JdbcRecordSinkProvider jdbcRecordSinkProvider,
+            ConnectorAccessControl accessControl)
     {
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
         this.jdbcMetadata = requireNonNull(jdbcMetadata, "jdbcMetadata is null");
@@ -53,6 +56,7 @@ public class JdbcConnector
         this.jdbcRecordSetProvider = requireNonNull(jdbcRecordSetProvider, "jdbcRecordSetProvider is null");
         this.jdbcHandleResolver = requireNonNull(jdbcHandleResolver, "jdbcHandleResolver is null");
         this.jdbcRecordSinkProvider = requireNonNull(jdbcRecordSinkProvider, "jdbcRecordSinkProvider is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
     }
 
     @Override
@@ -83,6 +87,12 @@ public class JdbcConnector
     public ConnectorRecordSinkProvider getRecordSinkProvider()
     {
         return jdbcRecordSinkProvider;
+    }
+
+    @Override
+    public ConnectorAccessControl getAccessControl()
+    {
+        return accessControl;
     }
 
     @Override

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcSecurityConfig.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcSecurityConfig.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.jdbc;
+
+import io.airlift.configuration.Config;
+
+public class JdbcSecurityConfig
+{
+    public static final String ALLOW_ALL_ACCESS_CONTROL = "allow-all";
+
+    private String postgreSqlSecuritySystem = ALLOW_ALL_ACCESS_CONTROL;
+
+    public String getPostgreSqlSecuritySystem()
+    {
+        return postgreSqlSecuritySystem;
+    }
+
+    @Config("postgresql.security")
+    public JdbcSecurityConfig setPostgreSqlSecuritySystem(String postgreSqlSecuritySystem)
+    {
+        this.postgreSqlSecuritySystem = postgreSqlSecuritySystem;
+        return this;
+    }
+}

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/NoAccessControl.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/NoAccessControl.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.jdbc;
+
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.security.ConnectorAccessControl;
+import com.facebook.presto.spi.security.Identity;
+
+import javax.inject.Inject;
+
+import static com.facebook.presto.spi.security.AccessDeniedException.denyDropTable;
+import static java.util.Objects.requireNonNull;
+
+public class NoAccessControl
+        implements ConnectorAccessControl
+{
+    private final boolean allowDropTable;
+
+    @Inject
+    public NoAccessControl(JdbcMetadataConfig jdbcMetadataConfig)
+    {
+        requireNonNull(jdbcMetadataConfig, "jdbcMetadataConfig is null");
+        allowDropTable = jdbcMetadataConfig.isAllowDropTable();
+    }
+
+    @Override
+    public void checkCanCreateTable(Identity identity, SchemaTableName tableName)
+    {
+    }
+
+    @Override
+    public void checkCanDropTable(Identity identity, SchemaTableName tableName)
+    {
+        if (!allowDropTable) {
+            denyDropTable(tableName.toString());
+        }
+    }
+
+    @Override
+    public void checkCanRenameTable(Identity identity, SchemaTableName tableName, SchemaTableName newTableName)
+    {
+    }
+
+    @Override
+    public void checkCanAddColumn(Identity identity, SchemaTableName tableName)
+    {
+    }
+
+    @Override
+    public void checkCanRenameColumn(Identity identity, SchemaTableName tableName)
+    {
+    }
+
+    @Override
+    public void checkCanSelectFromTable(Identity identity, SchemaTableName tableName)
+    {
+    }
+
+    @Override
+    public void checkCanInsertIntoTable(Identity identity, SchemaTableName tableName)
+    {
+    }
+
+    @Override
+    public void checkCanDeleteFromTable(Identity identity, SchemaTableName tableName)
+    {
+    }
+
+    @Override
+    public void checkCanCreateView(Identity identity, SchemaTableName viewName)
+    {
+    }
+
+    @Override
+    public void checkCanDropView(Identity identity, SchemaTableName viewName)
+    {
+    }
+
+    @Override
+    public void checkCanSelectFromView(Identity identity, SchemaTableName viewName)
+    {
+    }
+
+    @Override
+    public void checkCanCreateViewWithSelectFromTable(Identity identity, SchemaTableName tableName)
+    {
+    }
+
+    @Override
+    public void checkCanCreateViewWithSelectFromView(Identity identity, SchemaTableName viewName)
+    {
+    }
+
+    @Override
+    public void checkCanSetCatalogSessionProperty(Identity identity, String propertyName)
+    {
+    }
+}

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/NoSecurityModule.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/NoSecurityModule.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.jdbc;
+
+import com.facebook.presto.spi.security.ConnectorAccessControl;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+
+public class NoSecurityModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        binder.bind(ConnectorAccessControl.class).to(NoAccessControl.class).in(Scopes.SINGLETON);
+    }
+}


### PR DESCRIPTION
The goal is to add a security configuration property for postgresql connector that will honor the existing permissions in postgresql. The configuration property will have three values: none, read-only and sql-standard. This PR adds code for the configuration property and handles the case when the value is 'none' (with 'none' value, there are no access control checks). Changes are similar to what Dain added in here:
https://github.com/dain/presto/commit/b5754c41509dc02abaf20961448df313fc518405

I will create subsequent PRs or add more commits to handle other two values -- 'read-only' and 'sql-standard'.
