### PR TITLE
Cache UserGroupInformation for proxy users

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/auth/HadoopAuthentication.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/auth/HadoopAuthentication.java
@@ -24,6 +24,8 @@ public interface HadoopAuthentication
 
     UserGroupInformation getUserGroupInformation();
 
+    UserGroupInformation getUserGroupInformation(String user);
+
     default <T> T doAs(PrivilegedAction<T> action)
     {
         return getUserGroupInformation()
@@ -41,15 +43,13 @@ public interface HadoopAuthentication
 
     default <T> T doAs(String user, PrivilegedAction<T> action)
     {
-        return UserGroupInformation
-                .createProxyUser(user, getUserGroupInformation())
+        return getUserGroupInformation(user)
                 .doAs(action);
     }
 
     default void doAs(String user, Runnable action)
     {
-        UserGroupInformation
-                .createProxyUser(user, getUserGroupInformation())
+        getUserGroupInformation(user)
                 .doAs((PrivilegedAction<Object>) () -> {
                     action.run();
                     return null;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/auth/HadoopKerberosAuthentication.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/auth/HadoopKerberosAuthentication.java
@@ -18,8 +18,7 @@
 package com.facebook.presto.hive.auth;
 
 import org.apache.hadoop.conf.Configuration;
-
-import java.security.PrivilegedAction;
+import org.apache.hadoop.security.UserGroupInformation;
 
 public class HadoopKerberosAuthentication
         extends HadoopKerberosBaseAuthentication
@@ -30,13 +29,9 @@ public class HadoopKerberosAuthentication
         super(principal, keytab, configuration);
     }
 
-    public <T> T doAs(String user, PrivilegedAction<T> action)
+    @Override
+    public UserGroupInformation getUserGroupInformation(String user)
     {
-        return doAs(action);
-    }
-
-    public void doAs(String user, Runnable action)
-    {
-        doAs(action);
+        return getUserGroupInformation();
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/auth/HadoopKerberosImpersonatingAuthentication.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/auth/HadoopKerberosImpersonatingAuthentication.java
@@ -18,6 +18,7 @@
 package com.facebook.presto.hive.auth;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.UserGroupInformation;
 
 public class HadoopKerberosImpersonatingAuthentication
         extends HadoopKerberosBaseAuthentication
@@ -25,5 +26,11 @@ public class HadoopKerberosImpersonatingAuthentication
     public HadoopKerberosImpersonatingAuthentication(String principal, String keytab, Configuration configuration)
     {
         super(principal, keytab, configuration);
+    }
+
+    @Override
+    public UserGroupInformation getUserGroupInformation(String user)
+    {
+        return UserGroupInformation.createProxyUser(user, getUserGroupInformation());
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/auth/HadoopSimpleAuthentication.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/auth/HadoopSimpleAuthentication.java
@@ -38,4 +38,10 @@ public class HadoopSimpleAuthentication
             throw Throwables.propagate(e);
         }
     }
+
+    @Override
+    public UserGroupInformation getUserGroupInformation(String user)
+    {
+        return UserGroupInformation.createProxyUser(user, getUserGroupInformation());
+    }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/auth/HadoopSimpleImpersonatingAuthentication.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/auth/HadoopSimpleImpersonatingAuthentication.java
@@ -19,7 +19,7 @@ import org.apache.hadoop.security.UserGroupInformation;
 
 import java.io.IOException;
 
-public class HadoopSimpleAuthentication
+public class HadoopSimpleImpersonatingAuthentication
         implements HadoopAuthentication
 {
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/auth/HdfsAuthenticatingConnectorModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/auth/HdfsAuthenticatingConnectorModule.java
@@ -86,7 +86,7 @@ public class HdfsAuthenticatingConnectorModule
             case KERBEROS_IMPERSONIFICATION:
                 return new HadoopKerberosImpersonatingAuthentication(principal, keytab, configuration);
             case SIMPLE_IMPERSONIFICATION:
-                return new HadoopSimpleAuthentication();
+                return new HadoopSimpleImpersonatingAuthentication();
             default:
                 throw new IllegalArgumentException("Authentication type is not supported: " + authenticationType);
         }


### PR DESCRIPTION
Cache UserGroupInformation for proxy users

Add proxy UserGroupInformation cache to impersonating implementations of
HadoopAuthentication. If no caching was used and new proxy UGI was
created on each call to getUserGroupInformation(String) HDFS Filesystem
mechanism did not work. Different proxy UGI are not equal in terms of
equals() method even if they represent same user. For this reason
new entry was created in HDFS Filesystem cache for each new proxy user.
