### PR TITLE
Support uncorrelated subqueries in having clause

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/AggregationAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/AggregationAnalyzer.java
@@ -62,7 +62,6 @@ import java.util.Set;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MUST_BE_AGGREGATE_OR_GROUP_BY;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NESTED_AGGREGATION;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NESTED_WINDOW;
-import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.facebook.presto.util.Types.checkType;
 import static com.google.common.base.Preconditions.checkState;
@@ -153,8 +152,8 @@ class AggregationAnalyzer
         @Override
         protected Boolean visitSubqueryExpression(SubqueryExpression node, Void context)
         {
-            throw new SemanticException(NOT_SUPPORTED, node, "Scalar subqueries not yet supported");
-        }
+            return true;
+       }
 
         @Override
         protected Boolean visitSubscriptExpression(SubscriptExpression node, Void context)

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -1312,7 +1312,7 @@ class StatementAnalyzer
             Expression predicate = node.getHaving().get();
 
             ExpressionAnalysis expressionAnalysis = analyzeExpression(predicate, tupleDescriptor, context);
-            analysis.recordSubqueries(node, expressionAnalysis);
+            analysis.recordSubqueries(predicate, expressionAnalysis);
 
             Type predicateType = expressionAnalysis.getType(predicate);
             if (!predicateType.equals(BOOLEAN) && !predicateType.equals(UNKNOWN)) {

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q11.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q11.sql
@@ -1,4 +1,4 @@
--- database: presto; groups: tpch,quarantine; tables: partsupp,supplier,nation
+-- database: presto; groups: tpch; tables: partsupp,supplier,nation
 SELECT
   ps_partkey,
   sum(ps_supplycost * ps_availqty) AS value

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -4401,6 +4401,11 @@ public abstract class AbstractTestQueries
     public void testSemiJoin()
             throws Exception
     {
+        assertQuery("SELECT linenumber, min(orderkey) " +
+                "FROM lineitem " +
+                "GROUP BY linenumber " +
+                "HAVING min(orderkey) IN (SELECT orderkey FROM orders WHERE orderkey > 1)");
+
         // Throw in a bunch of IN subquery predicates
         assertQuery("" +
                 "SELECT *, o2.custkey\n" +
@@ -4584,6 +4589,12 @@ public abstract class AbstractTestQueries
                 multipleRowsErrorMsg);
         assertQueryFails("SELECT (VALUES (1), (2)) IN (1,2)",
                 multipleRowsErrorMsg);
+
+        // subquery in having
+        assertQuery("SELECT linenumber, min(orderkey) " +
+                "FROM lineitem " +
+                "GROUP BY linenumber " +
+                "HAVING min(orderkey) < (SELECT avg(orderkey) FROM orders WHERE orderkey < 7)");
     }
 
     @Test


### PR DESCRIPTION
Support uncorrelated subqueries in having clause
- Enable subqueries in HAVING clause.
- Semi join or full join created from subquery expression in having clause
  have to be added after aggregation, not before as it is right now.
  That is the semantic of HAVING clause.
