### PR TITLE
Configurable temporary files location for hive connector

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -125,6 +125,7 @@ public class HiveClientConfig
     private String hdfsPrestoPrincipal;
     private String hdfsPrestoKeytab;
     private AuthenticationType hdfsAuthenticationType = SIMPLE;
+    private String temporaryDirectory = "/tmp";
 
     public int getMaxInitialSplits()
     {
@@ -962,6 +963,18 @@ public class HiveClientConfig
     public HiveClientConfig setHdfsPrestoKeytab(String hdfsPrestoKeytab)
     {
         this.hdfsPrestoKeytab = hdfsPrestoKeytab;
+        return this;
+    }
+
+    public String getTemporaryDirectory()
+    {
+        return temporaryDirectory;
+    }
+
+    @Config("hive.hdfs.temporary.directory")
+    public HiveClientConfig setTemporaryDirectory(String temporaryDirectory)
+    {
+        this.temporaryDirectory = temporaryDirectory;
         return this;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -966,9 +966,9 @@ public class HiveClientConfig
         return this;
     }
 
-    public String getTemporaryDirectory()
+    public String getTemporaryDirectory(String userName)
     {
-        return temporaryDirectory;
+        return temporaryDirectory.replace("%NAME%", userName);
     }
 
     @Config("hive.hdfs.temporary.directory")

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveLocationService.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveLocationService.java
@@ -105,7 +105,7 @@ public class HiveLocationService
         String temporaryPrefix;
         try {
             String currentUser = UserGroupInformation.getCurrentUser().getUserName();
-            temporaryPrefix = hiveClientConfig.getTemporaryDirectory().replace("%USER%", currentUser);
+            temporaryPrefix = hiveClientConfig.getTemporaryDirectory(currentUser);
             temporaryPrefix = temporaryPrefix + "/prestotmp-" + currentUser;
         }
         catch (IOException e) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveLocationService.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveLocationService.java
@@ -15,9 +15,11 @@ package com.facebook.presto.hive;
 
 import com.facebook.presto.hive.metastore.HiveMetastore;
 import com.facebook.presto.spi.PrestoException;
+import com.google.common.base.Throwables;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.security.UserGroupInformation;
 
 import javax.inject.Inject;
 
@@ -26,21 +28,24 @@ import java.util.Optional;
 
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_FILESYSTEM_ERROR;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_PATH_ALREADY_EXISTS;
-import static com.facebook.presto.hive.HiveWriteUtils.createTemporaryPath;
+import static com.facebook.presto.hive.HiveWriteUtils.createDirectory;
 import static com.facebook.presto.hive.HiveWriteUtils.getTableDefaultLocation;
 import static com.facebook.presto.hive.HiveWriteUtils.pathExists;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static java.util.UUID.randomUUID;
 
 public class HiveLocationService
         implements LocationService
 {
     private final HiveMetastore metastore;
     private final HdfsEnvironment hdfsEnvironment;
+    private final HiveClientConfig hiveClientConfig;
 
     @Inject
-    public HiveLocationService(HiveMetastore metastore, HdfsEnvironment hdfsEnvironment)
+    public HiveLocationService(HiveMetastore metastore, HdfsEnvironment hdfsEnvironment, HiveClientConfig hiveClientConfig)
     {
+        this.hiveClientConfig = hiveClientConfig;
         this.metastore = requireNonNull(metastore);
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment);
     }
@@ -91,6 +96,29 @@ public class HiveLocationService
         catch (IOException e) {
             throw new PrestoException(HIVE_FILESYSTEM_ERROR, "Failed checking path: " + path, e);
         }
+    }
+
+    private Path createTemporaryPath(HdfsEnvironment hdfsEnvironment, Path targetPath)
+    {
+        // use a per-user temporary directory to avoid permission problems
+
+        String temporaryPrefix;
+        try {
+            String currentUser = UserGroupInformation.getCurrentUser().getUserName();
+            temporaryPrefix = hiveClientConfig.getTemporaryDirectory().replace("%USER%", currentUser);
+            temporaryPrefix = temporaryPrefix + "/prestotmp-" + currentUser;
+        }
+        catch (IOException e) {
+            throw Throwables.propagate(e);
+        }
+
+        // create a temporary directory on the same filesystem
+        Path temporaryRoot = new Path(targetPath, temporaryPrefix);
+        Path temporaryPath = new Path(temporaryRoot, randomUUID().toString());
+
+        createDirectory(hdfsEnvironment, temporaryPath);
+
+        return temporaryPath;
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
@@ -27,7 +27,6 @@ import com.facebook.presto.spi.type.TimestampType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.VarbinaryType;
 import com.facebook.presto.spi.type.VarcharType;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Ints;
 import org.apache.hadoop.fs.Path;
@@ -55,7 +54,6 @@ import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.Reporter;
-import org.apache.hadoop.security.UserGroupInformation;
 import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
@@ -84,7 +82,6 @@ import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
-import static java.util.UUID.randomUUID;
 import static java.util.stream.Collectors.toList;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.COMPRESSRESULT;
 import static org.apache.hadoop.hive.metastore.MetaStoreUtils.getProtectMode;
@@ -372,26 +369,6 @@ public final class HiveWriteUtils
         catch (IOException e) {
             throw new PrestoException(HIVE_FILESYSTEM_ERROR, format("Failed to rename %s to %s", source, target), e);
         }
-    }
-
-    public static Path createTemporaryPath(HdfsEnvironment hdfsEnvironment, Path targetPath)
-    {
-        // use a per-user temporary directory to avoid permission problems
-        String temporaryPrefix;
-        try {
-            temporaryPrefix = "/tmp/presto-" + UserGroupInformation.getCurrentUser().getUserName();
-        }
-        catch (IOException e) {
-            throw Throwables.propagate(e);
-        }
-
-        // create a temporary directory on the same filesystem
-        Path temporaryRoot = new Path(targetPath, temporaryPrefix);
-        Path temporaryPath = new Path(temporaryRoot, randomUUID().toString());
-
-        createDirectory(hdfsEnvironment, temporaryPath);
-
-        return temporaryPath;
     }
 
     public static void createDirectory(HdfsEnvironment hdfsEnvironment, Path path)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -437,7 +437,7 @@ public abstract class AbstractTestHiveClient
         HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationUpdater(hiveClientConfig));
 
         hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hiveClientConfig);
-        locationService = new HiveLocationService(metastoreClient, hdfsEnvironment);
+        locationService = new HiveLocationService(metastoreClient, hdfsEnvironment, hiveClientConfig);
         TypeManager typeManager = new TypeRegistry();
         JsonCodec<PartitionUpdate> partitionUpdateCodec = JsonCodec.jsonCodec(PartitionUpdate.class);
         metadata = new HiveMetadata(

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientS3.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientS3.java
@@ -150,7 +150,7 @@ public abstract class AbstractTestHiveClientS3
 
         hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hiveClientConfig);
         metastoreClient = new TestingHiveMetastore(hiveCluster, executor, hiveClientConfig, writableBucket, hdfsEnvironment);
-        locationService = new HiveLocationService(metastoreClient, hdfsEnvironment);
+        locationService = new HiveLocationService(metastoreClient, hdfsEnvironment, hiveClientConfig);
         TypeRegistry typeManager = new TypeRegistry();
         JsonCodec<PartitionUpdate> partitionUpdateCodec = JsonCodec.jsonCodec(PartitionUpdate.class);
         metadata = new HiveMetadata(

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -100,7 +100,8 @@ public class TestHiveClientConfig
                 .setHiveMetastorePrestoKeytab(null)
                 .setHdfsAuthenticationType(SIMPLE)
                 .setHdfsPrestoPrincipal(null)
-                .setHdfsPrestoKeytab(null));
+                .setHdfsPrestoKeytab(null)
+                .setTemporaryDirectory("/tmp"));
     }
 
     @Test
@@ -170,6 +171,7 @@ public class TestHiveClientConfig
                 .put("hive.hdfs.authentication.type", "KERBEROS")
                 .put("hive.hdfs.presto.principal", "hdfs@EXAMPLE.COM")
                 .put("hive.hdfs.presto.keytab", "/tmp/hdfs.keytab")
+                .put("hive.hdfs.temporary.directory", "/example/temporary/dir")
                 .build();
 
         HiveClientConfig expected = new HiveClientConfig()
@@ -235,7 +237,8 @@ public class TestHiveClientConfig
                 .setHiveMetastorePrestoKeytab("/tmp/metastore.keytab")
                 .setHdfsAuthenticationType(KERBEROS)
                 .setHdfsPrestoPrincipal("hdfs@EXAMPLE.COM")
-                .setHdfsPrestoKeytab("/tmp/hdfs.keytab");
+                .setHdfsPrestoKeytab("/tmp/hdfs.keytab")
+                .setTemporaryDirectory("/example/temporary/dir");
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
This patch allows configuring where temporary files are created in hdfs during
INSERT/CREATE TABLE AS SELECT flow via hive connector.
New configuration property 'hive.hdfs.temporary.directory' was added. If
%USER% appears in value of property it is replaced with id of user
currently executing query.
