### PR TITLE
DateTime types implicit conversion from varchar.

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/type/TestDate.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestDate.java
@@ -58,6 +58,11 @@ public class TestDate
         functionAssertions.assertFunction(projection, expectedType, expected);
     }
 
+    private void assertEvaluates(String projection, Type expectedType)
+    {
+        functionAssertions.tryEvaluate(projection, expectedType);
+    }
+
     @Test
     public void testLiteral()
             throws Exception
@@ -192,5 +197,27 @@ public class TestDate
         int days = (int) TimeUnit.MILLISECONDS.toDays(new DateTime(2012, 5, 23, 0, 0, UTC).getMillis());
         assertFunction("least(DATE '2013-03-30', DATE '2012-05-23')", DATE, new SqlDate(days));
         assertFunction("least(DATE '2013-03-30', DATE '2012-05-23', DATE '2012-06-01')", DATE, new SqlDate(days));
+    }
+
+    @Test
+    public void dateCanBeImplicitlyCastedFromVarchar()
+            throws Exception
+    {
+        assertFunction("'1999-01-01' < DATE '2000-01-01'", BOOLEAN, true);
+        assertFunction("DATE '1999-01-01' < '2000-01-01'", BOOLEAN, true);
+
+        assertFunction("'2000-01-01' = DATE '2000-01-01'", BOOLEAN, true);
+        assertFunction("DATE '2000-01-01' = '2000-01-02'", BOOLEAN, false);
+    }
+
+    @Test
+    public void dateCoertForCompareOperators()
+    {
+        assertEvaluates("'2000-01-01' < DATE '2000-01-01'", BOOLEAN);
+        assertEvaluates("'2000-01-01' = DATE '2000-01-01'", BOOLEAN);
+        assertEvaluates("'2000-01-01' > DATE '2000-01-01'", BOOLEAN);
+        assertEvaluates("'2000-01-01' <> DATE '2000-01-01'", BOOLEAN);
+        assertEvaluates("'2000-01-01' <= DATE '2000-01-01'", BOOLEAN);
+        assertEvaluates("'2000-01-01' >= DATE '2000-01-01'", BOOLEAN);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTime.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTime.java
@@ -57,6 +57,11 @@ public class TestTime
         functionAssertions.assertFunction(projection, expectedType, expected);
     }
 
+    private void assertEvaluates(String projection, Type expectedType)
+    {
+        functionAssertions.tryEvaluate(projection, expectedType);
+    }
+
     @Test
     public void testLiteral()
             throws Exception
@@ -180,5 +185,24 @@ public class TestTime
         assertFunction("cast('03:04:05.321' as time) = TIME '03:04:05.321'", BOOLEAN, true);
         assertFunction("cast('03:04:05' as time) = TIME '03:04:05.000'", BOOLEAN, true);
         assertFunction("cast('03:04' as time) = TIME '03:04:00.000'", BOOLEAN, true);
+    }
+
+    @Test
+    public void timeCanBeImplicitlyCastedFromVarchar()
+            throws Exception
+    {
+        assertFunction("'05:30:00.0' < TIME '05:00:00.0'", BOOLEAN, false);
+        assertFunction("TIME '05:30:00.0' < '05:00:00.0'", BOOLEAN, false);
+    }
+
+    @Test
+    public void timeCoertForCompareOperators()
+    {
+        assertEvaluates("'05:30:00.0' < TIME '05:00:00.0'", BOOLEAN);
+        assertEvaluates("'05:30:00.0' = TIME '05:00:00.0'", BOOLEAN);
+        assertEvaluates("'05:30:00.0' > TIME '05:00:00.0'", BOOLEAN);
+        assertEvaluates("'05:30:00.0' <> TIME '05:00:00.0'", BOOLEAN);
+        assertEvaluates("'05:30:00.0' <= TIME '05:00:00.0'", BOOLEAN);
+        assertEvaluates("'05:30:00.0' >= TIME '05:00:00.0'", BOOLEAN);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTimestamp.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTimestamp.java
@@ -67,6 +67,11 @@ public class TestTimestamp
         functionAssertions.assertFunction(projection, expectedType, expected);
     }
 
+    private void assertEvaluates(String projection, Type expectedType)
+    {
+        functionAssertions.tryEvaluate(projection, expectedType);
+    }
+
     @Test
     public void testLiteral()
     {
@@ -282,5 +287,30 @@ public class TestTimestamp
         assertFunction("least(TIMESTAMP '2013-03-30 01:05', TIMESTAMP '2012-03-30 01:05', TIMESTAMP '2012-05-01 01:05')",
                 TIMESTAMP,
                 new SqlTimestamp(new DateTime(2012, 3, 30, 1, 5, 0, 0, DATE_TIME_ZONE).getMillis(), TIME_ZONE_KEY));
+    }
+
+    @Test
+    public void timestampCanBeImplicitlyCastedFromVarchar()
+            throws Exception
+    {
+        assertFunction("'2000-01-01 05:30:00.0' < TIMESTAMP '2000-01-01 05:00:00.0'", BOOLEAN, false);
+        assertFunction("TIMESTAMP '2000-01-01 05:30:00.0' < '2000-01-01 05:00:00.0'", BOOLEAN, false);
+
+        assertFunction("'1999-01-01 05:30:00.0' < TIMESTAMP '2000-01-01 05:00:00.0'", BOOLEAN, true);
+        assertFunction("TIMESTAMP '1999-01-01 05:30:00.0' < '2000-01-01 05:00:00.0'", BOOLEAN, true);
+
+        assertFunction("'2000-01-01 05:00' = TIMESTAMP '2000-01-01 05:00:00.0'", BOOLEAN, true);
+        assertFunction("TIMESTAMP '2000-01-01 05:30:00.0' = '2000-01-01 05:00'", BOOLEAN, false);
+    }
+
+    @Test
+    public void timestampCoertForCompareOperators()
+    {
+        assertEvaluates("'2000-01-01 05:30:00.0' < TIMESTAMP '2000-01-01 05:00:00.0'", BOOLEAN);
+        assertEvaluates("'2000-01-01 05:30:00.0' = TIMESTAMP '2000-01-01 05:00:00.0'", BOOLEAN);
+        assertEvaluates("'2000-01-01 05:30:00.0' > TIMESTAMP '2000-01-01 05:00:00.0'", BOOLEAN);
+        assertEvaluates("'2000-01-01 05:30:00.0' <> TIMESTAMP '2000-01-01 05:00:00.0'", BOOLEAN);
+        assertEvaluates("'2000-01-01 05:30:00.0' <= TIMESTAMP '2000-01-01 05:00:00.0'", BOOLEAN);
+        assertEvaluates("'2000-01-01 05:30:00.0' >= TIMESTAMP '2000-01-01 05:00:00.0'", BOOLEAN);
     }
 }


### PR DESCRIPTION
Additionaly TIME_WITH_TIME_ZONE from VARCHAR missing conversion operator was implemented.

Missing bits:
- Coersion when cast from VARCHAR is ambiguous.
- Coersion to match INSERT types.
