### PR TITLE
DateTime from varchar coercion.

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/type/DateOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/DateOperators.java
@@ -33,8 +33,9 @@ import static com.facebook.presto.metadata.OperatorType.LESS_THAN_OR_EQUAL;
 import static com.facebook.presto.metadata.OperatorType.NOT_EQUAL;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static com.facebook.presto.spi.type.DateTimeEncoding.packDateTimeWithZone;
-import static com.facebook.presto.util.DateTimeUtils.parseDate;
+import static com.facebook.presto.util.DateTimeUtils.parseTimestampWithTimeZone;
 import static com.facebook.presto.util.DateTimeUtils.printDate;
+import static com.facebook.presto.util.DateTimeUtils.timestampWithTimeZoneToDate;
 import static com.facebook.presto.util.DateTimeZoneIndex.getChronology;
 import static io.airlift.slice.SliceUtf8.trim;
 import static io.airlift.slice.Slices.utf8Slice;
@@ -128,10 +129,11 @@ public final class DateOperators
 
     @ScalarOperator(CAST)
     @SqlType(StandardTypes.DATE)
-    public static long castFromSlice(@SqlType(StandardTypes.VARCHAR) Slice value)
+    public static long castFromSlice(ConnectorSession session, @SqlType(StandardTypes.VARCHAR) Slice value)
     {
         try {
-            return parseDate(trim(value).toStringUtf8());
+            final long timestampValue = parseTimestampWithTimeZone(session.getTimeZoneKey(), trim(value).toStringUtf8());
+            return timestampWithTimeZoneToDate(timestampValue);
         }
         catch (IllegalArgumentException e) {
             throw new PrestoException(INVALID_CAST_ARGUMENT, e);

--- a/presto-main/src/main/java/com/facebook/presto/type/TimeOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TimeOperators.java
@@ -30,7 +30,7 @@ import static com.facebook.presto.metadata.OperatorType.LESS_THAN_OR_EQUAL;
 import static com.facebook.presto.metadata.OperatorType.NOT_EQUAL;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static com.facebook.presto.spi.type.DateTimeEncoding.packDateTimeWithZone;
-import static com.facebook.presto.util.DateTimeUtils.parseTimeWithoutTimeZone;
+import static com.facebook.presto.util.DateTimeUtils.parseTime;
 import static com.facebook.presto.util.DateTimeUtils.printTimeWithoutTimeZone;
 import static io.airlift.slice.Slices.utf8Slice;
 
@@ -122,7 +122,7 @@ public final class TimeOperators
     public static long castFromSlice(ConnectorSession session, @SqlType(StandardTypes.VARCHAR) Slice value)
     {
         try {
-            return parseTimeWithoutTimeZone(session.getTimeZoneKey(), value.toStringUtf8());
+            return parseTime(session.getTimeZoneKey(), value.toStringUtf8());
         }
         catch (IllegalArgumentException e) {
             throw new PrestoException(INVALID_CAST_ARGUMENT, e);

--- a/presto-main/src/main/java/com/facebook/presto/type/TimestampOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TimestampOperators.java
@@ -34,8 +34,9 @@ import static com.facebook.presto.metadata.OperatorType.NOT_EQUAL;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static com.facebook.presto.spi.type.DateTimeEncoding.packDateTimeWithZone;
 import static com.facebook.presto.type.DateTimeOperators.modulo24Hour;
-import static com.facebook.presto.util.DateTimeUtils.parseTimestampWithoutTimeZone;
+import static com.facebook.presto.util.DateTimeUtils.parseTimestampWithTimeZone;
 import static com.facebook.presto.util.DateTimeUtils.printTimestampWithoutTimeZone;
+import static com.facebook.presto.util.DateTimeUtils.timestampWithTimeZoneToTimestampWithoutTimeZone;
 import static com.facebook.presto.util.DateTimeZoneIndex.getChronology;
 import static io.airlift.slice.SliceUtf8.trim;
 import static io.airlift.slice.Slices.utf8Slice;
@@ -142,7 +143,8 @@ public final class TimestampOperators
     public static long castFromSlice(ConnectorSession session, @SqlType(StandardTypes.VARCHAR) Slice value)
     {
         try {
-            return parseTimestampWithoutTimeZone(session.getTimeZoneKey(), trim(value).toStringUtf8());
+            final long tsValue = parseTimestampWithTimeZone(session.getTimeZoneKey(), trim(value).toStringUtf8());
+            return timestampWithTimeZoneToTimestampWithoutTimeZone(tsValue);
         }
         catch (IllegalArgumentException e) {
             throw new PrestoException(INVALID_CAST_ARGUMENT, e);

--- a/presto-main/src/main/java/com/facebook/presto/type/TimestampWithTimeZoneOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TimestampWithTimeZoneOperators.java
@@ -18,9 +18,6 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.type.StandardTypes;
 import io.airlift.slice.Slice;
-import org.joda.time.chrono.ISOChronology;
-
-import java.util.concurrent.TimeUnit;
 
 import static com.facebook.presto.metadata.OperatorType.BETWEEN;
 import static com.facebook.presto.metadata.OperatorType.CAST;
@@ -32,13 +29,13 @@ import static com.facebook.presto.metadata.OperatorType.LESS_THAN;
 import static com.facebook.presto.metadata.OperatorType.LESS_THAN_OR_EQUAL;
 import static com.facebook.presto.metadata.OperatorType.NOT_EQUAL;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
-import static com.facebook.presto.spi.type.DateTimeEncoding.packDateTimeWithZone;
 import static com.facebook.presto.spi.type.DateTimeEncoding.unpackMillisUtc;
-import static com.facebook.presto.spi.type.DateTimeEncoding.unpackZoneKey;
-import static com.facebook.presto.type.DateTimeOperators.modulo24Hour;
 import static com.facebook.presto.util.DateTimeUtils.parseTimestampWithTimeZone;
 import static com.facebook.presto.util.DateTimeUtils.printTimestampWithTimeZone;
-import static com.facebook.presto.util.DateTimeZoneIndex.unpackChronology;
+import static com.facebook.presto.util.DateTimeUtils.timestampWithTimeZoneToDate;
+import static com.facebook.presto.util.DateTimeUtils.timestampWithTimeZoneToTime;
+import static com.facebook.presto.util.DateTimeUtils.timestampWithTimeZoneToTimeWithTimeZone;
+import static com.facebook.presto.util.DateTimeUtils.timestampWithTimeZoneToTimestampWithoutTimeZone;
 import static io.airlift.slice.SliceUtf8.trim;
 import static io.airlift.slice.Slices.utf8Slice;
 
@@ -104,35 +101,28 @@ public final class TimestampWithTimeZoneOperators
     @SqlType(StandardTypes.DATE)
     public static long castToDate(@SqlType(StandardTypes.TIMESTAMP_WITH_TIME_ZONE) long value)
     {
-        // round down the current timestamp to days
-        ISOChronology chronology = unpackChronology(value);
-        long date = chronology.dayOfYear().roundFloor(unpackMillisUtc(value));
-        // date is currently midnight in timezone of the original value
-        // convert to UTC
-        long millis = date + chronology.getZone().getOffset(date);
-        return TimeUnit.MILLISECONDS.toDays(millis);
+        return timestampWithTimeZoneToDate(value);
     }
 
     @ScalarOperator(CAST)
     @SqlType(StandardTypes.TIME)
     public static long castToTime(@SqlType(StandardTypes.TIMESTAMP_WITH_TIME_ZONE) long value)
     {
-        return modulo24Hour(unpackChronology(value), unpackMillisUtc(value));
+        return timestampWithTimeZoneToTime(value);
     }
 
     @ScalarOperator(CAST)
     @SqlType(StandardTypes.TIME_WITH_TIME_ZONE)
     public static long castToTimeWithTimeZone(@SqlType(StandardTypes.TIMESTAMP_WITH_TIME_ZONE) long value)
     {
-        int millis = modulo24Hour(unpackChronology(value), unpackMillisUtc(value));
-        return packDateTimeWithZone(millis, unpackZoneKey(value));
+        return timestampWithTimeZoneToTimeWithTimeZone(value);
     }
 
     @ScalarOperator(CAST)
     @SqlType(StandardTypes.TIMESTAMP)
     public static long castToTimestamp(@SqlType(StandardTypes.TIMESTAMP_WITH_TIME_ZONE) long value)
     {
-        return unpackMillisUtc(value);
+        return timestampWithTimeZoneToTimestampWithoutTimeZone(value);
     }
 
     @ScalarOperator(CAST)

--- a/presto-main/src/main/java/com/facebook/presto/type/TypeRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TypeRegistry.java
@@ -74,6 +74,9 @@ import static java.util.stream.Collectors.toList;
 public final class TypeRegistry
         implements TypeManager
 {
+    private static final List<String> VARCHAR_SUBTYPES = ImmutableList.of(StandardTypes.DATE, StandardTypes.TIME, StandardTypes.TIME_WITH_TIME_ZONE,
+            StandardTypes.TIMESTAMP, StandardTypes.TIMESTAMP_WITH_TIME_ZONE, RegexpType.NAME, LikePatternType.NAME, JsonPathType.NAME);
+
     private final ConcurrentMap<TypeSignature, Type> types = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, ParametricType> parametricTypes = new ConcurrentHashMap<>();
 
@@ -233,7 +236,7 @@ public final class TypeRegistry
             case StandardTypes.TIMESTAMP:
                 return StandardTypes.TIMESTAMP_WITH_TIME_ZONE.equals(toTypeBase);
             case StandardTypes.VARCHAR:
-                return RegexpType.NAME.equals(toTypeBase) || LikePatternType.NAME.equals(toTypeBase) || JsonPathType.NAME.equals(toTypeBase);
+                return VARCHAR_SUBTYPES.contains(toTypeBase);
             case StandardTypes.P4_HYPER_LOG_LOG:
                 return StandardTypes.HYPER_LOG_LOG.equals(toTypeBase);
             case StandardTypes.DECIMAL:
@@ -374,7 +377,7 @@ public final class TypeRegistry
     public static Optional<TypeSignature> getCommonSuperTypeSignature(TypeSignature firstType, TypeSignature secondType)
     {
         TypeSignaturePair typeSignaturePair = new TypeSignaturePair(firstType, secondType);
-        if (typeSignaturePair.containsAnyOf(StandardTypes.VARCHAR, StandardTypes.DECIMAL)) {
+        if (typeSignaturePair.containsAnyOf(StandardTypes.DECIMAL, StandardTypes.VARCHAR)) {
             return getCommonSuperTypeForTypesWithLongParameters(typeSignaturePair);
         }
 
@@ -394,6 +397,7 @@ public final class TypeRegistry
 
         List<TypeSignatureParameter> firstTypeTypeParameters = firstType.getParameters();
         List<TypeSignatureParameter> secondTypeTypeParameters = secondType.getParameters();
+
         if (firstTypeTypeParameters.size() != secondTypeTypeParameters.size()) {
             return Optional.empty();
         }
@@ -442,7 +446,7 @@ public final class TypeRegistry
     {
         checkState(typeSignaturePair.containsAnyOf(StandardTypes.VARCHAR, StandardTypes.DECIMAL));
 
-        for (String varcharSubType : new String[] {RegexpType.NAME, LikePatternType.NAME, JsonPathType.NAME}) {
+        for (String varcharSubType : VARCHAR_SUBTYPES) {
             if (typeSignaturePair.is(StandardTypes.VARCHAR, varcharSubType)) {
                 return Optional.of(typeSignaturePair.get(varcharSubType));
             }


### PR DESCRIPTION
THIS IS CONTINUATION OF #128 

State of DateTime\* and `VARCHAR` implicit cast after this task should be:
- `VARCHAR` -> DateTime implicit cast works when there is no ambiguity.
- `VARCHAR` -> DateTime casts will work with each type of DateTime format regardless of target type.
- When there is ambiguity the @arhimondr algorithm for most specific function will be used.
- The implicit cast from `VARCHAR` are allowed for the following target types: `TIMESTAMP`, `TIMESTAMP WITH TIME ZONE`, `TIME`, `TIME WITH TIME ZONE`, `DATE`

In examples:
- `SELECT '2016-02-19' < DATE '2016-02-20';` will return `true`
- `SELECT '2016-02-19 18:32 +01:00' < DATE '2016-02-20';`will return `true`
- `SELECT DAY('2016-02-19'); will return 19, but SELECT HOUR('2016-02-19 18:32');` will throw ambiguity due to the fact that the `VARCHAR` may be converted to `TIME` or `TIMESTAMP` and those types are not coertable.
- `SELECT TIME '12:12' < TIMESTAMP '2016-02-19 18:32'` will not be executed due to lacking operator.

Those assumptions are covered in tests.

\* - by DateTime i mean all types of DATE, TIME, TIME WITH TIME ZONE, TIMESTAMP and TIMESTAMP WITH TIME ZONE.
