### PR TITLE
Set rowcount to false for show and explain queries

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -67,6 +67,7 @@ import com.facebook.presto.sql.tree.CreateView;
 import com.facebook.presto.sql.tree.Deallocate;
 import com.facebook.presto.sql.tree.Delete;
 import com.facebook.presto.sql.tree.DescribeInput;
+import com.facebook.presto.sql.tree.DescribeOutput;
 import com.facebook.presto.sql.tree.DropTable;
 import com.facebook.presto.sql.tree.DropView;
 import com.facebook.presto.sql.tree.Explain;
@@ -197,6 +198,7 @@ public class CoordinatorModule
         executionBinder.addBinding(Insert.class).to(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);
         executionBinder.addBinding(Delete.class).to(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);
         executionBinder.addBinding(DescribeInput.class).to(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);
+        executionBinder.addBinding(DescribeOutput.class).to(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);
 
         binder.bind(DataDefinitionExecutionFactory.class).in(Scopes.SINGLETON);
         bindDataDefinitionTask(binder, executionBinder, AddColumn.class, AddColumnTask.class);

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
@@ -96,6 +96,10 @@ public class Analysis
     // for describe input and describe output
     private boolean isDescribe = false;
 
+    // A row count query (as opposed to a result set query) is one that doesn't return
+    // any data, e.g. DDL (CREATE, ALTER, DROP, ...) and some DML (INSERT, UPDATE, DELETE, ...)
+    private boolean rowCountQuery;
+
     public Query getQuery()
     {
         return query;
@@ -421,6 +425,16 @@ public class Analysis
     public void setIsDescribe(boolean isDescribe)
     {
         this.isDescribe = isDescribe;
+    }
+
+    public boolean isRowCountQuery()
+    {
+        return rowCountQuery;
+    }
+
+    public void setRowCountQuery(boolean rowCountQuery)
+    {
+        this.rowCountQuery = rowCountQuery;
     }
 
     public static class JoinInPredicates

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
@@ -98,7 +98,7 @@ public class Analysis
 
     // A row count query (as opposed to a result set query) is one that doesn't return
     // any data, e.g. DDL (CREATE, ALTER, DROP, ...) and some DML (INSERT, UPDATE, DELETE, ...)
-    private boolean rowCountQuery;
+    private boolean rowCountQuery = false;
 
     public Query getQuery()
     {

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -286,7 +286,6 @@ class StatementAnalyzer
                 predicate,
                 ordering(ascending("table_name")));
 
-        analysis.setRowCountQuery(true);
         return process(query, context);
     }
 
@@ -302,7 +301,6 @@ class StatementAnalyzer
                 from(node.getCatalog().orElseGet(() -> session.getCatalog().get()), TABLE_SCHEMATA),
                 ordering(ascending("schema_name")));
 
-        analysis.setRowCountQuery(true);
         return process(query, context);
     }
 
@@ -317,7 +315,6 @@ class StatementAnalyzer
                 selectList(new AllColumns()),
                 aliased(new Values(rows), "catalogs", ImmutableList.of("Catalog")));
 
-        analysis.setRowCountQuery(true);
         return process(query, context);
     }
 
@@ -342,7 +339,6 @@ class StatementAnalyzer
                         equal(nameReference("table_name"), new StringLiteral(tableName.getObjectName()))),
                 ordering(ascending("ordinal_position")));
 
-        analysis.setRowCountQuery(true);
         return process(query, context);
     }
 
@@ -522,7 +518,6 @@ class StatementAnalyzer
                         .build(),
                 showPartitions.getLimit());
 
-        analysis.setRowCountQuery(true);
         return process(query, context);
     }
 
@@ -563,7 +558,6 @@ class StatementAnalyzer
                         ascending("argument_types"),
                         ascending("function_type")));
 
-        analysis.setRowCountQuery(true);
         return process(query, context);
     }
 
@@ -620,7 +614,6 @@ class StatementAnalyzer
                         ImmutableList.of("name", "value", "default", "type", "description", "include")),
                 nameReference("include"));
 
-        analysis.setRowCountQuery(true);
         return process(query, context);
     }
 
@@ -865,7 +858,6 @@ class StatementAnalyzer
                         "plan",
                         ImmutableList.of("Query Plan")));
 
-        analysis.setRowCountQuery(true);
         return process(query, context);
     }
 

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -69,6 +69,7 @@ statement
     | DEALLOCATE PREPARE identifier                                    #deallocate
     | EXECUTE identifier (USING literal (',' literal)*)?               #execute
     | DESCRIBE INPUT identifier                                        #describeInput
+    | DESCRIBE OUTPUT identifier                                       #describeOutput
     ;
 
 query
@@ -568,6 +569,7 @@ PREPARE: 'PREPARE';
 DEALLOCATE: 'DEALLOCATE';
 EXECUTE: 'EXECUTE';
 INPUT: 'INPUT';
+OUTPUT: 'OUTPUT';
 
 NORMALIZE: 'NORMALIZE';
 NFD : 'NFD';

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -26,6 +26,7 @@ import com.facebook.presto.sql.tree.CreateView;
 import com.facebook.presto.sql.tree.Deallocate;
 import com.facebook.presto.sql.tree.Delete;
 import com.facebook.presto.sql.tree.DescribeInput;
+import com.facebook.presto.sql.tree.DescribeOutput;
 import com.facebook.presto.sql.tree.DropTable;
 import com.facebook.presto.sql.tree.DropView;
 import com.facebook.presto.sql.tree.Except;
@@ -173,6 +174,14 @@ public final class SqlFormatter
                 String parameterString = Joiner.on(", ").join(parameters);
                 builder.append(parameterString);
             }
+            return null;
+        }
+
+        @Override
+        protected Void visitDescribeOutput(DescribeOutput node, Integer indent)
+        {
+            append(indent, "DESCRIBE OUTPUT ");
+            builder.append(node.getName());
             return null;
         }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -40,6 +40,7 @@ import com.facebook.presto.sql.tree.Deallocate;
 import com.facebook.presto.sql.tree.Delete;
 import com.facebook.presto.sql.tree.DereferenceExpression;
 import com.facebook.presto.sql.tree.DescribeInput;
+import com.facebook.presto.sql.tree.DescribeOutput;
 import com.facebook.presto.sql.tree.DoubleLiteral;
 import com.facebook.presto.sql.tree.DropTable;
 import com.facebook.presto.sql.tree.DropView;
@@ -342,6 +343,13 @@ class AstBuilder
             parameterValues.add((Literal) visit(literalContext));
         }
         return new Execute(getLocation(context), name, parameterValues);
+    }
+
+    @Override
+    public Node visitDescribeOutput(SqlBaseParser.DescribeOutputContext context)
+    {
+        String name = context.identifier().getText();
+        return new DescribeOutput(getLocation(context), name);
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
@@ -92,6 +92,11 @@ public abstract class AstVisitor<R, C>
         return visitStatement(node, context);
     }
 
+    protected R visitDescribeOutput(DescribeOutput node, C context)
+    {
+        return visitStatement(node, context);
+    }
+
     protected R visitDescribeInput(DescribeInput node, C context)
     {
         return visitStatement(node, context);

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DescribeOutput.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DescribeOutput.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.sql.tree;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+public class DescribeOutput
+        extends Statement
+{
+    private final String name;
+
+    public DescribeOutput(NodeLocation location, String name)
+    {
+        this(Optional.of(location), name);
+    }
+
+    public DescribeOutput(String name)
+    {
+        this(Optional.empty(), name);
+    }
+
+    private DescribeOutput(Optional<NodeLocation> location, String name)
+    {
+        super(location);
+        this.name = name;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitDescribeOutput(this, context);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(name);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        DescribeOutput o = (DescribeOutput) obj;
+        return Objects.equals(name, o.name);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("name", name)
+                .toString();
+    }
+}

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -35,6 +35,7 @@ import com.facebook.presto.sql.tree.Deallocate;
 import com.facebook.presto.sql.tree.Delete;
 import com.facebook.presto.sql.tree.DereferenceExpression;
 import com.facebook.presto.sql.tree.DescribeInput;
+import com.facebook.presto.sql.tree.DescribeOutput;
 import com.facebook.presto.sql.tree.DoubleLiteral;
 import com.facebook.presto.sql.tree.DropTable;
 import com.facebook.presto.sql.tree.DropView;
@@ -1302,6 +1303,12 @@ public class TestSqlParser
     public void testExecuteWithUsing()
     {
         assertStatement("EXECUTE myquery USING 1, 'abc'", new Execute("myquery", ImmutableList.of(new LongLiteral("1"), new StringLiteral("abc"))));
+    }
+
+    @Test
+    public void testDescribeOutput()
+    {
+        assertStatement("DESCRIBE OUTPUT myquery", new DescribeOutput("myquery"));
     }
 
     @Test

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -5587,10 +5587,21 @@ public abstract class AbstractTestQueries
     @Test
     public void testDescribeOutputRowCountQuery()
     {
-        Session session = getSession().withPreparedStatement("my_query", "show tables");
+        Session session = getSession().withPreparedStatement("my_query", "CREATE TABLE foo AS SELECT * FROM nation");
         MaterializedResult actual = computeActual(session, "DESCRIBE OUTPUT my_query");
         MaterializedResult expected = resultBuilder(session, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, BIGINT, BOOLEAN, BOOLEAN)
                 .row(null, null, null, null, null, null, null, true)
+                .build();
+        assertEqualsIgnoreOrder(actual, expected);
+    }
+
+    @Test
+    public void testDescribeOutputShowTables()
+    {
+        Session session = getSession().withPreparedStatement("my_query", "SHOW TABLES");
+        MaterializedResult actual = computeActual(session, "DESCRIBE OUTPUT my_query");
+        MaterializedResult expected = resultBuilder(session, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, BIGINT, BOOLEAN, BOOLEAN)
+                .row("Table", "tables", "information_schema", session.getCatalog().get(), "varchar", 0, true, false)
                 .build();
         assertEqualsIgnoreOrder(actual, expected);
     }


### PR DESCRIPTION
Queries such as show tables and explain return actual rows, so row count
is false for describe output

Testing: updated row count query test, added test for show tables

@petroav 
