### PR TITLE
Support INSERT for Decimal in Hive connector

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.BigintType;
 import com.facebook.presto.spi.type.BooleanType;
 import com.facebook.presto.spi.type.DateType;
+import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.DoubleType;
 import com.facebook.presto.spi.type.TimestampType;
 import com.facebook.presto.spi.type.Type;
@@ -32,6 +33,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Ints;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.ProtectMode;
 import org.apache.hadoop.hive.metastore.api.Database;
@@ -44,12 +46,14 @@ import org.apache.hadoop.hive.ql.exec.FileSinkOperator.RecordWriter;
 import org.apache.hadoop.hive.ql.io.HiveOutputFormat;
 import org.apache.hadoop.hive.serde2.io.DateWritable;
 import org.apache.hadoop.hive.serde2.io.DoubleWritable;
+import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
 import org.apache.hadoop.hive.serde2.io.TimestampWritable;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector.PrimitiveCategory;
 import org.apache.hadoop.hive.serde2.objectinspector.SettableStructObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.StructField;
+import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.ListTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.MapTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
@@ -64,6 +68,7 @@ import org.apache.hadoop.mapred.Reporter;
 import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.sql.Date;
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -87,6 +92,7 @@ import static com.facebook.presto.hive.HiveUtil.isMapType;
 import static com.facebook.presto.hive.HiveUtil.isRowType;
 import static com.facebook.presto.hive.util.Types.checkType;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static com.facebook.presto.spi.type.LongDecimalType.unscaledValueToBigInteger;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -94,6 +100,8 @@ import static java.util.UUID.randomUUID;
 import static java.util.stream.Collectors.toList;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.COMPRESSRESULT;
 import static org.apache.hadoop.hive.metastore.MetaStoreUtils.getProtectMode;
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.getPrimitiveJavaObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.getPrimitiveWritableObjectInspector;
 import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaBooleanObjectInspector;
 import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaByteArrayObjectInspector;
 import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaDateObjectInspector;
@@ -153,6 +161,10 @@ public final class HiveWriteUtils
         else if (type.equals(TimestampType.TIMESTAMP)) {
             return javaTimestampObjectInspector;
         }
+        else if (type instanceof DecimalType) {
+            DecimalType decimalType = (DecimalType) type;
+            return getPrimitiveJavaObjectInspector(new DecimalTypeInfo(decimalType.getPrecision(), decimalType.getScale()));
+        }
         else if (isArrayType(type)) {
             return ObjectInspectorFactory.getStandardListObjectInspector(getJavaObjectInspector(type.getTypeParameters().get(0)));
         }
@@ -200,6 +212,10 @@ public final class HiveWriteUtils
         if (TimestampType.TIMESTAMP.equals(type)) {
             long millisUtc = type.getLong(block, position);
             return new Timestamp(millisUtc);
+        }
+        if (type instanceof DecimalType) {
+            DecimalType decimalType = (DecimalType) type;
+            return getHiveDecimal(decimalType, block, position);
         }
         if (isArrayType(type)) {
             Type elementType = type.getTypeParameters().get(0);
@@ -449,6 +465,7 @@ public final class HiveWriteUtils
             case DATE:
             case TIMESTAMP:
             case BINARY:
+            case DECIMAL:
                 return true;
         }
         return false;
@@ -491,6 +508,11 @@ public final class HiveWriteUtils
             return writableTimestampObjectInspector;
         }
 
+        if (type instanceof DecimalType) {
+            DecimalType decimalType = (DecimalType) type;
+            return getPrimitiveWritableObjectInspector(new DecimalTypeInfo(decimalType.getPrecision(), decimalType.getScale()));
+        }
+
         if (isArrayType(type) || isMapType(type) || isRowType(type)) {
             return getJavaObjectInspector(type);
         }
@@ -526,6 +548,11 @@ public final class HiveWriteUtils
 
         if (type.equals(TimestampType.TIMESTAMP)) {
             return new TimestampFieldSetter(rowInspector, row, field);
+        }
+
+        if (type instanceof DecimalType) {
+            DecimalType decimalType = (DecimalType) type;
+            return new DecimalFieldSetter(rowInspector, row, field, decimalType);
         }
 
         if (isArrayType(type)) {
@@ -685,6 +712,38 @@ public final class HiveWriteUtils
             value.setTime(millisUtc);
             rowInspector.setStructFieldData(row, field, value);
         }
+    }
+
+    private static class DecimalFieldSetter
+            extends FieldSetter
+    {
+        private final HiveDecimalWritable value = new HiveDecimalWritable();
+        private final DecimalType decimalType;
+
+        public DecimalFieldSetter(SettableStructObjectInspector rowInspector, Object row, StructField field, DecimalType decimalType)
+        {
+            super(rowInspector, row, field);
+            this.decimalType = decimalType;
+        }
+
+        @Override
+        public void setField(Block block, int position)
+        {
+            value.set(getHiveDecimal(decimalType, block, position));
+            rowInspector.setStructFieldData(row, field, value);
+        }
+    }
+
+    private static HiveDecimal getHiveDecimal(DecimalType decimalType, Block block, int position)
+    {
+        BigInteger unscaledValue;
+        if (decimalType.isShort()) {
+            unscaledValue = BigInteger.valueOf(decimalType.getLong(block, position));
+        }
+        else {
+            unscaledValue = unscaledValueToBigInteger(decimalType.getSlice(block, position));
+        }
+        return HiveDecimal.create(unscaledValue, decimalType.getScale());
     }
 
     private static class ArrayFieldSetter

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -32,6 +32,7 @@ import org.intellij.lang.annotations.Language;
 import org.joda.time.DateTime;
 import org.testng.annotations.Test;
 
+import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.Timestamp;
 import java.util.List;
@@ -111,7 +112,9 @@ public class TestHiveIntegrationSmokeTest
                 ", DOUBLE '3.14' _double" +
                 ", true _boolean" +
                 ", DATE '1980-05-07' _date" +
-                ", TIMESTAMP '1980-05-07 11:22:33.456' _timestamp";
+                ", TIMESTAMP '1980-05-07 11:22:33.456' _timestamp" +
+                ", DECIMAL '3.14' _decimal_short" +
+                ", DECIMAL '12345678901234567890.0123456789' _decimal_long";
 
         assertUpdate(query, 1);
 
@@ -125,6 +128,8 @@ public class TestHiveIntegrationSmokeTest
         assertEquals(row.getField(4), true);
         assertEquals(row.getField(5), new Date(new DateTime(1980, 5, 7, 0, 0, 0, UTC).getMillis()));
         assertEquals(row.getField(6), new Timestamp(new DateTime(1980, 5, 7, 11, 22, 33, 456, UTC).getMillis()));
+        assertEquals(row.getField(7), new BigDecimal("3.14"));
+        assertEquals(row.getField(8), new BigDecimal("12345678901234567890.0123456789"));
         assertUpdate("DROP TABLE test_types_table");
 
         assertFalse(queryRunner.tableExists(getSession(), "test_types_table"));
@@ -135,7 +140,9 @@ public class TestHiveIntegrationSmokeTest
             throws Exception
     {
         for (HiveStorageFormat storageFormat : HiveStorageFormat.values()) {
-            createPartitionedTable(storageFormat);
+            if (insertOperationsSupported(storageFormat)) {
+                createPartitionedTable(storageFormat);
+            }
         }
     }
 
@@ -145,16 +152,19 @@ public class TestHiveIntegrationSmokeTest
         @Language("SQL") String createTable = "" +
                 "CREATE TABLE test_partitioned_table (" +
                 "  _varchar VARCHAR" +
-                ", _varbinary VARBINARY" +
                 ", _bigint BIGINT" +
                 ", _double DOUBLE" +
                 ", _boolean BOOLEAN" +
+                ", _decimal_short DECIMAL(3,2)" +
+                ", _decimal_long DECIMAL(30,10)" +
                 ", _partition_varchar VARCHAR" +
                 ", _partition_bigint BIGINT" +
+                ", _partition_decimal_short DECIMAL(3,2)" +
+                ", _partition_decimal_long DECIMAL(30,10)" +
                 ") " +
                 "WITH (" +
                 "format = '" + storageFormat + "', " +
-                "partitioned_by = ARRAY[ '_partition_varchar', '_partition_bigint' ]" +
+                "partitioned_by = ARRAY[ '_partition_varchar', '_partition_bigint', '_partition_decimal_short', '_partition_decimal_long' ]" +
                 ") ";
 
         assertUpdate(createTable);
@@ -162,7 +172,7 @@ public class TestHiveIntegrationSmokeTest
         TableMetadata tableMetadata = getTableMetadata("test_partitioned_table");
         assertEquals(tableMetadata.getMetadata().getProperties().get(STORAGE_FORMAT_PROPERTY), storageFormat);
 
-        List<String> partitionedBy = ImmutableList.of("_partition_varchar", "_partition_bigint");
+        List<String> partitionedBy = ImmutableList.of("_partition_varchar", "_partition_bigint", "_partition_decimal_short", "_partition_decimal_long");
         assertEquals(tableMetadata.getMetadata().getProperties().get(PARTITIONED_BY_PROPERTY), partitionedBy);
         for (ColumnMetadata columnMetadata : tableMetadata.getColumns()) {
             assertEquals(columnMetadata.isPartitionKey(), partitionedBy.contains(columnMetadata.getName()));
@@ -170,6 +180,22 @@ public class TestHiveIntegrationSmokeTest
 
         MaterializedResult result = computeActual("SELECT * from test_partitioned_table");
         assertEquals(result.getRowCount(), 0);
+
+        @Language("SQL") String select = "" +
+                "SELECT" +
+                " 'foo' _varchar" +
+                ", 1 _bigint" +
+                ", cast('3.14' AS DOUBLE) _double" +
+                ", true _boolean" +
+                ", 3.14 _decimal_short" +
+                ", 12345678901234567890.0123456789 _decimal_long" +
+                ", 'foo' _varchar" +
+                ", 1 _bigint" +
+                ", 3.14 _partition_decimal_short" +
+                ", 12345678901234567890.0123456789 _partition_decimal_long";
+
+        assertUpdate("INSERT INTO test_partitioned_table " + select, 1);
+        assertQuery("SELECT * from test_partitioned_table", select);
 
         assertUpdate("DROP TABLE test_partitioned_table");
 
@@ -181,7 +207,9 @@ public class TestHiveIntegrationSmokeTest
             throws Exception
     {
         for (HiveStorageFormat storageFormat : HiveStorageFormat.values()) {
-            createTableAs(storageFormat);
+            if (insertOperationsSupported(storageFormat)) {
+                createTableAs(storageFormat);
+            }
         }
     }
 
@@ -192,7 +220,9 @@ public class TestHiveIntegrationSmokeTest
                 " 'foo' _varchar" +
                 ", 1 _bigint" +
                 ", CAST(3.14 AS DOUBLE) _double" +
-                ", true _boolean";
+                ", true _boolean" +
+                ", 3.14 _decimal_short" +
+                ", 12345678901234567890.0123456789 _decimal_long";
 
         String createTableAs = String.format("CREATE TABLE test_format_table WITH (format = '%s') AS %s", storageFormat, select);
 
@@ -295,7 +325,9 @@ public class TestHiveIntegrationSmokeTest
             throws Exception
     {
         for (HiveStorageFormat storageFormat : HiveStorageFormat.values()) {
-            insertTable(storageFormat);
+            if (insertOperationsSupported(storageFormat)) {
+                insertTable(storageFormat);
+            }
         }
     }
 
@@ -308,7 +340,9 @@ public class TestHiveIntegrationSmokeTest
                 "  _varchar VARCHAR," +
                 "  _bigint BIGINT," +
                 "  _double DOUBLE," +
-                "  _boolean BOOLEAN" +
+                "  _boolean BOOLEAN," +
+                "  _decimal_short DECIMAL(3,2)," +
+                "  _decimal_long DECIMAL(30,10)" +
                 ") " +
                 "WITH (format = '" + storageFormat + "') ";
 
@@ -321,7 +355,9 @@ public class TestHiveIntegrationSmokeTest
                 " 'foo' _varchar" +
                 ", 1 _bigint" +
                 ", CAST(3.14 as DOUBLE) _double" +
-                ", true _boolean";
+                ", true _boolean" +
+                ", 3.14 _decimal_short" +
+                ", 12345678901234567890.0123456789 _decimal_long";
 
         assertUpdate("INSERT INTO test_insert_format_table " + select, 1);
 
@@ -329,11 +365,15 @@ public class TestHiveIntegrationSmokeTest
 
         assertUpdate("INSERT INTO test_insert_format_table (_bigint, _double) SELECT 2, DOUBLE '14.3'", 1);
 
-        assertQuery("SELECT * from test_insert_format_table where _bigint = 2", "SELECT null, 2, 14.3, null");
+        assertQuery("SELECT * from test_insert_format_table where _bigint = 2", "SELECT null, 2, 14.3, null, null, null");
 
         assertUpdate("INSERT INTO test_insert_format_table (_double, _bigint) SELECT DOUBLE '2.72', 3", 1);
 
-        assertQuery("SELECT * from test_insert_format_table where _bigint = 3", "SELECT null, 3, 2.72, null");
+        assertQuery("SELECT * from test_insert_format_table where _bigint = 3", "SELECT null, 3, 2.72, null, null, null");
+
+        assertUpdate("INSERT INTO test_insert_format_table (_decimal_short, _decimal_long) SELECT DECIMAL '2.72', DECIMAL '98765432101234567890.0123456789'", 1);
+
+        assertQuery("SELECT * from test_insert_format_table where _decimal_long = 98765432101234567890.0123456789", "SELECT null, null, null, null, 2.72, 98765432101234567890.0123456789");
 
         assertUpdate("DROP TABLE test_insert_format_table");
 
@@ -535,6 +575,10 @@ public class TestHiveIntegrationSmokeTest
         assertUpdate("CREATE TABLE tmp_array6 AS SELECT ARRAY[ARRAY['\"hi\"'], NULL, ARRAY['puppies']] AS col", 1);
         assertQuery("SELECT col[1][1] FROM tmp_array6", "SELECT '\"hi\"'");
         assertQuery("SELECT col[3][1] FROM tmp_array6", "SELECT 'puppies'");
+
+        assertUpdate("CREATE TABLE tmp_array9 AS SELECT ARRAY[ARRAY[DECIMAL '3.14']] AS col1, ARRAY[ARRAY[DECIMAL '12345678901234567890.0123456789']] AS col2", 1);
+        assertQuery("SELECT col1[1][1] FROM tmp_array9", "SELECT 3.14");
+        assertQuery("SELECT col2[1][1] FROM tmp_array9", "SELECT 12345678901234567890.0123456789");
     }
 
     @Test
@@ -571,6 +615,10 @@ public class TestHiveIntegrationSmokeTest
         assertOneNotNullResult("SELECT col[DATE '2014-09-30'] FROM tmp_map6");
         assertUpdate("CREATE TABLE tmp_map7 AS SELECT MAP(ARRAY[TIMESTAMP '2001-08-22 03:04:05.321'], ARRAY[TIMESTAMP '2001-08-22 03:04:05.321']) AS col", 1);
         assertOneNotNullResult("SELECT col[TIMESTAMP '2001-08-22 03:04:05.321'] FROM tmp_map7");
+
+        assertUpdate("CREATE TABLE tmp_map8 AS SELECT MAP(ARRAY[DECIMAL '3.14', DECIMAL '12345678901234567890.0123456789'], " +
+                "ARRAY[DECIMAL '12345678901234567890.0123456789', DECIMAL '3.14']) AS col", 1);
+        assertQuery("SELECT col[3.14], col[12345678901234567890.0123456789] FROM tmp_map8", "SELECT 12345678901234567890.0123456789, 3.14");
     }
 
     @Test
@@ -603,5 +651,10 @@ public class TestHiveIntegrationSmokeTest
         assertEquals(results.getRowCount(), 1);
         assertEquals(results.getMaterializedRows().get(0).getFieldCount(), 1);
         assertNotNull(results.getMaterializedRows().get(0).getField(0));
+    }
+
+    private boolean insertOperationsSupported(HiveStorageFormat storageFormat)
+    {
+        return storageFormat != HiveStorageFormat.DWRF;
     }
 }


### PR DESCRIPTION
Insert operations (CREATE TABLE AS, INSERT INTO) is now supported for all the
supported formats except DWRF.
Hive-DWRF library is not longer maintained, and it doesn't have serializers for DECIMAL type.
