### PR TITLE
Make resolveFunction need fewer unknown functions

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -119,7 +119,7 @@ import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Iterator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -236,6 +236,7 @@ import static com.facebook.presto.type.DecimalOperators.DECIMAL_SUBSTRACT_OPERAT
 import static com.facebook.presto.type.DecimalToDecimalCasts.DECIMAL_TO_DECIMAL_CAST;
 import static com.facebook.presto.type.TypeUtils.resolveTypes;
 import static com.facebook.presto.type.UnknownOperators.UNKNOWN_OPERATORS;
+import static com.facebook.presto.type.UnknownType.UNKNOWN;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableSet;
 import static com.facebook.presto.util.Types.checkType;
@@ -553,6 +554,22 @@ public class FunctionRegistry
             return Optional.of(mostSpecificFunction.getBoundSignature());
         }
 
+        // if there is more than one function, look for functions that only cast the unknown arguments
+        List<ApplicableFunction> unknownCastFunctions = mostSpecificFunctions.stream().filter(f -> onlyCastsUnknown(f, actualParameters)).collect(Collectors.toList());
+        if (!unknownCastFunctions.isEmpty()) {
+            if (unknownCastFunctions.size() == 1) {
+                return Optional.of(getOnlyElement(unknownCastFunctions).getBoundSignature());
+            }
+
+            // When casting unknown arguments, prefer functions whose arguments are all of the same type.
+            List<ApplicableFunction> sameArgumentFunctions = unknownCastFunctions.stream()
+                    .filter(function -> new HashSet<>(function.getBoundSignature().getArgumentTypes()).size() == 1)
+                    .collect(Collectors.toList());
+            if (sameArgumentFunctions.size() == 1) {
+                return Optional.of(getOnlyElement(sameArgumentFunctions).getBoundSignature());
+            }
+        }
+
         List<Signature> mostSpecificFunctionDefinitions = mostSpecificFunctions.stream()
                 .map(ApplicableFunction::getDeclaredSignature)
                 .collect(Collectors.toList());
@@ -561,6 +578,18 @@ public class FunctionRegistry
         mostSpecificFunctionDefinitions.sort((o1, o2) -> o1.toString().compareTo(o2.toString()));
 
         throw new PrestoException(AMBIGUOUS_FUNCTION_CALL, format("Ambiguous call to %s with parameters %s", mostSpecificFunctionDefinitions.toString(), actualParameters.toString()));
+    }
+
+    private boolean onlyCastsUnknown(ApplicableFunction applicableFunction, List<Type> actualParameters)
+    {
+        List<Type> boundTypes = resolveTypes(applicableFunction.getBoundSignature().getArgumentTypes(), typeManager);
+        checkState(actualParameters.size() == boundTypes.size(), "type lists are of different lengths");
+        for (int i = 0; i < actualParameters.size(); i++) {
+            if (!boundTypes.get(i).equals(actualParameters.get(i)) && actualParameters.get(i) != UNKNOWN) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private List<ApplicableFunction> identifyPotentiallyApplicableFunctions(List<SqlFunction> candidates, List<Type> actualParameters)
@@ -580,11 +609,8 @@ public class FunctionRegistry
     private List<ApplicableFunction> filterOutLessSpecificFunctions(List<ApplicableFunction> applicableFunctions)
     {
         final List<ApplicableFunction> mostSpecificFunctions = new ArrayList<>();
-        final Iterator<ApplicableFunction> applicableFunctionIterator = applicableFunctions.iterator();
 
-        while (applicableFunctionIterator.hasNext()) {
-            final ApplicableFunction function = applicableFunctionIterator.next();
-
+        for (ApplicableFunction function : applicableFunctions) {
             Optional<Integer> mostSpecificId = function.getIdOfFunctionFamily(mostSpecificFunctions);
             if (mostSpecificId.isPresent() && function.isMoreSpecificThan(mostSpecificFunctions.get(mostSpecificId.get()))) {
                 mostSpecificFunctions.set(mostSpecificId.get(), function);

--- a/presto-main/src/test/java/com/facebook/presto/type/TestDecimalOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestDecimalOperators.java
@@ -72,7 +72,7 @@ public class TestDecimalOperators
         assertInvalidFunction("DECIMAL '-99999999999999999999999999999999999999' + DECIMAL '-99999999999999999999999999999999999999'", "DECIMAL result exceeds 38 digits: -199999999999999999999999999999999999998");
 
         // test null
-        assertFunction("NULL + DECIMAL '-2'", createDecimalType(1, 0), null);
+        assertFunction("NULL + DECIMAL '-2'", createDecimalType(2, 0), null);
         assertFunction("DECIMAL '12345678901234567.890123456789012345678' + NULL", createDecimalType(38, 21), null);
     }
 
@@ -130,7 +130,7 @@ public class TestDecimalOperators
         assertInvalidFunction("DECIMAL '-99999999999999999999999999999999999999' - DECIMAL '99999999999999999999999999999999999999'", "DECIMAL result exceeds 38 digits: -199999999999999999999999999999999999998");
 
         // test null
-        assertFunction("NULL - DECIMAL '-2'", createDecimalType(1, 0), null);
+        assertFunction("NULL - DECIMAL '-2'", createDecimalType(2, 0), null);
         assertFunction("DECIMAL '12345678901234567.890123456789012345678' - NULL", createDecimalType(38, 21), null);
     }
 
@@ -193,7 +193,7 @@ public class TestDecimalOperators
         assertInvalidFunction("DECIMAL '.12345678901234567890123456789012345678' * DECIMAL '-9'", "DECIMAL result exceeds 38 digits: -111111110111111111011111111101111111102");
 
         // test null
-        assertFunction("NULL * DECIMAL '-2'", createDecimalType(1, 0), null);
+        assertFunction("NULL * DECIMAL '-2'", createDecimalType(2, 0), null);
         assertFunction("DECIMAL '12345678901234567.890123456789012345678' * NULL", createDecimalType(38, 21), null);
     }
 
@@ -354,7 +354,7 @@ public class TestDecimalOperators
 
         // test null
         assertFunction("NULL % DECIMAL '-2'", createDecimalType(1, 0), null);
-        assertFunction("DECIMAL '12345678901234567.890123456789012345678' % NULL", createDecimalType(38, 21), null);
+        assertFunction("DECIMAL '12345678901234567.890123456789012345678' % NULL", createDecimalType(22, 21), null);
     }
 
     @Test

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -5665,7 +5665,7 @@ public abstract class AbstractTestQueries
         MaterializedResult actual = computeActual(session, "DESCRIBE INPUT my_query");
         MaterializedResult expected = resultBuilder(session, BIGINT, VARCHAR)
                 .row(0, "unknown")
-                .row(1, "unknown")
+                .row(1, "bigint")
                 .build();
         assertEqualsIgnoreOrder(actual, expected);
     }


### PR DESCRIPTION
Changes the algorithm to resolve functions as follows:
1. look for an exact match
2. find the most specific function after coercing null valued arguments
3. find the most specific function allowing coercion of any of the
arguments.

Also, only create UnknownOperators for argument types that would result
in ambiguous functions.
