### PR TITLE
Fix bug with prepare name already exists

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -416,8 +416,11 @@ public class QueryStateMachine
         requireNonNull(key, "key is null");
         requireNonNull(value, "value is null");
 
+        if (session.getPreparedStatements().containsKey(key)) {
+            throw new PrestoException(ALREADY_EXISTS, "Prepared statement already exists: " + key);
+        }
         String previousValue = addedPreparedStatements.putIfAbsent(key, value);
-        if (previousValue != null || session.getPreparedStatements().containsKey(key)) {
+        if (previousValue != null) {
             throw new PrestoException(ALREADY_EXISTS, "Prepared statement already exists: " + key);
         }
     }


### PR DESCRIPTION
Fix a bug wherein preparing a query with a name that is already in use,
would throw an error that the name exists, but still update the prepared
statement to the new one.  Now it retains the old query for that name.

@petroav 
