### PR TITLE
Add Insert and GroupingElement to TraversalVisitor

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -1852,7 +1852,8 @@ class StatementAnalyzer
                 .collect(toImmutableList());
 
         // is this an aggregation query?
-        if (!groupingSets.isEmpty()) {
+        // skip describe queries because if there are parameters involved we can't verify equality
+        if (!groupingSets.isEmpty() && !analysis.isDescribe()) {
             // ensure SELECT, ORDER BY and HAVING are constant with respect to group
             // e.g, these are all valid expressions:
             //     SELECT f(a) GROUP BY a

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
@@ -571,4 +571,29 @@ public abstract class AstVisitor<R, C>
     {
         return visitStatement(node, context);
     }
+
+    protected R visitGroupingElement(GroupingElement node, C context)
+    {
+        return visitNode(node, context);
+    }
+
+    protected R visitSimpleGroupBy(SimpleGroupBy node, C context)
+    {
+        return visitGroupingElement(node, context);
+    }
+
+    protected R visitCube(Cube node, C context)
+    {
+        return visitGroupingElement(node, context);
+    }
+
+    protected R visitRollup(Rollup node, C context)
+    {
+        return visitGroupingElement(node, context);
+    }
+
+    protected R visitGroupingSets(GroupingSets node, C context)
+    {
+        return visitGroupingElement(node, context);
+    }
 }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Cube.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Cube.java
@@ -52,6 +52,12 @@ public class Cube
     }
 
     @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitCube(this, context);
+    }
+
+    @Override
     public Set<Set<Expression>> enumerateGroupingSets()
     {
         return Sets.powerSet(columns.stream()

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
@@ -445,4 +445,20 @@ public abstract class DefaultTraversalVisitor<R, C>
 
         return null;
     }
+
+    @Override
+    protected R visitInsert(Insert node, C context)
+    {
+        process(node.getQuery(), context);
+        return null;
+    }
+
+    @Override
+    protected R visitSimpleGroupBy(SimpleGroupBy node, C context)
+    {
+        for (Expression expression : node.getColumnExpressions()) {
+            process(expression, context);
+        }
+        return null;
+    }
 }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/GroupingSets.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/GroupingSets.java
@@ -55,6 +55,12 @@ public class GroupingSets
     }
 
     @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitGroupingSets(this, context);
+    }
+
+    @Override
     public boolean equals(Object o)
     {
         if (this == o) {

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Insert.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Insert.java
@@ -32,7 +32,7 @@ public final class Insert
         this(Optional.empty(), columns, target, query);
     }
 
-    private Insert(Optional<NodeLocation> location, Optional<List<String>> columns, QualifiedName target, Query query)
+    protected Insert(Optional<NodeLocation> location, Optional<List<String>> columns, QualifiedName target, Query query)
     {
         super(location);
         this.target = requireNonNull(target, "target is null");

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/RewritingTraversalVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/RewritingTraversalVisitor.java
@@ -458,4 +458,18 @@ public abstract class RewritingTraversalVisitor<C>
     {
         return visitNode(node, context);
     }
+
+    @Override
+    protected Node visitInsert(Insert node, C context)
+    {
+        Query query = (Query) process(node.getQuery(), context);
+        return new Insert(node.getLocation(), node.getColumns(), node.getTarget(), query);
+    }
+
+    @Override
+    protected Node visitSimpleGroupBy(SimpleGroupBy node, C context)
+    {
+        List<Expression> groupByExpressions = ImmutableList.copyOf(Lists.transform(node.getColumnExpressions(), (value -> (Expression) process(value, context))));
+        return new SimpleGroupBy(node.getLocation(), groupByExpressions);
+    }
 }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Rollup.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Rollup.java
@@ -68,6 +68,12 @@ public class Rollup
     }
 
     @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitRollup(this, context);
+    }
+
+    @Override
     public boolean equals(Object o)
     {
         if (this == o) {

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/SimpleGroupBy.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/SimpleGroupBy.java
@@ -37,7 +37,7 @@ public class SimpleGroupBy
         this(Optional.of(location), simpleGroupByExpressions);
     }
 
-    private SimpleGroupBy(Optional<NodeLocation> location, List<Expression> simpleGroupByExpressions)
+    protected SimpleGroupBy(Optional<NodeLocation> location, List<Expression> simpleGroupByExpressions)
     {
         super(location);
         this.columns = simpleGroupByExpressions;
@@ -52,6 +52,12 @@ public class SimpleGroupBy
     public Set<Set<Expression>> enumerateGroupingSets()
     {
         return ImmutableSet.of(ImmutableSet.copyOf(columns));
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitSimpleGroupBy(this, context);
     }
 
     @Override

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -5810,6 +5810,19 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testDescribeInputParametersInGrouping()
+    {
+        Session session = getSession().withPreparedStatement("my_query", "select count(nationkey), regionkey + ? from nation group by regionkey + ? order by regionkey + ?");
+        MaterializedResult actual = computeActual(session, "DESCRIBE INPUT my_query");
+        MaterializedResult expected = resultBuilder(session, BIGINT, VARCHAR)
+                .row(0, "bigint")
+                .row(1, "bigint")
+                .row(2, "bigint")
+                .build();
+        assertEqualsIgnoreOrder(actual, expected);
+    }
+
+    @Test
     public void testDescribeInputNoParameters()
     {
         Session session = getSession().withPreparedStatement("my_query", "select * from nation");

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -5778,6 +5778,20 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testExecuteWithGrouping()
+    {
+        String query = "SELECT a + ?, count(1) FROM (VALUES 1, 2, 3, 2) t(a) GROUP BY a + ? HAVING count(1) > ?";
+        Session session = getSession().withPreparedStatement("my_query", query);
+        MaterializedResult actual = computeActual(session, "EXECUTE my_query USING 1, 1, 0");
+        MaterializedResult expected = resultBuilder(session, BIGINT, VARCHAR)
+                .row(2, 1)
+                .row(3, 2)
+                .row(4, 1)
+                .build();
+        assertEqualsIgnoreOrder(actual, expected);
+    }
+
+    @Test
     public void testExecuteNoSuchQuery()
     {
         assertQueryFails("EXECUTE my_query", "Prepared statement not found: my_query");


### PR DESCRIPTION
Inserts and GroupBys need to be traversed to be able to replace any
parameter expressions.  Add them to DefaultTraversalVisitor and
RewritingTraversalVisitor.  And add all GroupingElements to the
AstVisitor where absent.
