### PR TITLE
Add standard TRUNCATE(x, n) function for double.

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
@@ -107,6 +107,15 @@ public final class MathFunctions
         return Math.ceil(num);
     }
 
+    @Description("truncate decimal places")
+    @ScalarFunction
+    @SqlType(StandardTypes.DOUBLE)
+    public static double truncate(@SqlType(StandardTypes.DOUBLE) double num, @SqlType(StandardTypes.BIGINT) long truncate_to)
+    {
+        double multiplier = Math.pow(10.0, truncate_to);
+        return Math.signum(num) * Math.floor(Math.abs(num) * multiplier) / multiplier;
+    }
+
     @Description("cosine")
     @ScalarFunction
     @SqlType(StandardTypes.DOUBLE)


### PR DESCRIPTION
For `x` being DOUBLE and `n` being BIGINT the function will
truncate to only leave `n` digits after decimal point.
If `n` is negative the output will truncate all decimal points
after decimal point and also will zero `abs(n)` less significant
digits before decimal point.

This is standard SQL function from SQL:2008 standard.
