### PR TITLE
Add standard TRUNCATE(x) function for DOUBLE ``x``

### DIFF
--- a/presto-docs/src/main/sphinx/functions/math.rst
+++ b/presto-docs/src/main/sphinx/functions/math.rst
@@ -118,6 +118,10 @@ Mathematical Functions
 
     Returns the base-``radix`` representation of ``x``.
 
+.. function:: truncate(x) -> double
+
+    Returns ``x`` rounded to integer by dropping digits after decimal point.
+
 Trigonometric Functions
 -----------------------
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
@@ -107,6 +107,14 @@ public final class MathFunctions
         return Math.ceil(num);
     }
 
+    @Description("round to integer by dropping digits after decimal point")
+    @ScalarFunction
+    @SqlType(StandardTypes.DOUBLE)
+    public static double truncate(@SqlType(StandardTypes.DOUBLE) double num)
+    {
+        return Math.signum(num) * Math.floor(Math.abs(num));
+    }
+
     @Description("cosine")
     @ScalarFunction
     @SqlType(StandardTypes.DOUBLE)

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
@@ -115,6 +115,21 @@ public class TestMathFunctions
     }
 
     @Test
+    public void testTruncate()
+    {
+        final String maxDouble = Double.toString(Double.MAX_VALUE);
+        final String minDouble = Double.toString(-Double.MAX_VALUE);
+        assertFunction("truncate(17.18)", DOUBLE, 17.0);
+        assertFunction("truncate(-17.18)", DOUBLE, -17.0);
+        assertFunction("truncate(17.88)", DOUBLE, 17.0);
+        assertFunction("truncate(-17.88)", DOUBLE, -17.0);
+        assertFunction("truncate(NULL)", DOUBLE, null);
+        assertFunction("truncate(CAST(NULL AS DOUBLE))", DOUBLE, null);
+        assertFunction("truncate(" + maxDouble + ")", DOUBLE, Double.MAX_VALUE);
+        assertFunction("truncate(" + minDouble + ")", DOUBLE, -Double.MAX_VALUE);
+    }
+
+    @Test
     public void testCos()
     {
         for (double doubleValue : DOUBLE_VALUES) {


### PR DESCRIPTION
For `x` being DOUBLE the function will drop all digits after
decimal point returning new value as DOUBLE.
