### PR TITLE
Add decimal TRUNCATE(``x``, ``n``) function.

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -196,6 +196,7 @@ import static com.facebook.presto.operator.scalar.MathFunctions.DECIMAL_CEILING_
 import static com.facebook.presto.operator.scalar.MathFunctions.DECIMAL_FLOOR_FUNCTION;
 import static com.facebook.presto.operator.scalar.MathFunctions.DECIMAL_MOD_FUNCTION;
 import static com.facebook.presto.operator.scalar.MathFunctions.DECIMAL_ROUND_FUNCTIONS;
+import static com.facebook.presto.operator.scalar.MathFunctions.DECIMAL_TRUNCATE_FUNCTION;
 import static com.facebook.presto.operator.scalar.RowEqualOperator.ROW_EQUAL;
 import static com.facebook.presto.operator.scalar.RowHashCodeOperator.ROW_HASH_CODE;
 import static com.facebook.presto.operator.scalar.RowNotEqualOperator.ROW_NOT_EQUAL;
@@ -412,7 +413,8 @@ public class FunctionRegistry
                 .functions(DECIMAL_CEILING_FUNCTIONS)
                 .function(DECIMAL_FLOOR_FUNCTION)
                 .function(DECIMAL_MOD_FUNCTION)
-                .functions(DECIMAL_ROUND_FUNCTIONS);
+                .functions(DECIMAL_ROUND_FUNCTIONS)
+                .function(DECIMAL_TRUNCATE_FUNCTION);
 
         if (experimentalSyntaxEnabled) {
             builder.aggregate(ApproximateAverageAggregations.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
@@ -50,6 +50,7 @@ import static java.math.BigInteger.ZERO;
 
 public final class MathFunctions
 {
+    public static final SqlScalarFunction DECIMAL_TRUNCATE_FUNCTION = decimalTruncateNFunction();
     public static final SqlScalarFunction[] DECIMAL_CEILING_FUNCTIONS = {decimalCeilingFunction("ceiling"), decimalCeilingFunction("ceil")};
     public static final SqlScalarFunction DECIMAL_FLOOR_FUNCTION = decimalFloorFunction();
     public static final SqlScalarFunction DECIMAL_MOD_FUNCTION = decimalModFunction();
@@ -572,6 +573,67 @@ public final class MathFunctions
         BigInteger rounded = divideAndRemainder[0].add(roundUp).multiply(rescaleFactor);
         checkOverflow(rounded);
         return rounded;
+    }
+
+    private static SqlScalarFunction decimalTruncateNFunction()
+    {
+        Signature signature = Signature.builder()
+                .kind(SCALAR)
+                .name("truncate")
+                .literalParameters("num_precision", "num_scale")
+                .argumentTypes("decimal(num_precision, num_scale)", BIGINT)
+                .returnType("decimal(num_precision, num_scale)")
+                .build();
+        return SqlScalarFunction.builder(MathFunctions.class)
+                .signature(signature)
+                .description("truncate decimal to N places after decimal point")
+                .methods("truncateNShortDecimal", "truncateNLongDecimal")
+                .extraParameters(MathFunctions::decimalTruncateNExtraParameters)
+                .build();
+    }
+
+    private static List<Object> decimalTruncateNExtraParameters(SpecializeContext context)
+    {
+        return ImmutableList.of(context.getLiteral("num_precision"), context.getLiteral("num_scale"));
+    }
+
+    public static long truncateNShortDecimal(long num, long roundScale, long inputPrecision, long inputScale)
+    {
+        if (num == 0 || inputPrecision - inputScale + roundScale <= 0) {
+            return 0;
+        }
+        if (roundScale >= inputScale) {
+            return num;
+        }
+        if (num < 0) {
+            return -truncateNShortDecimal(-num, roundScale, inputPrecision, inputScale);
+        }
+
+        long rescaleFactor = tenToNth((int) (inputScale - roundScale)).longValueExact();
+        long remainder = num % rescaleFactor;
+        return num - remainder;
+    }
+
+    public static Slice truncateNLongDecimal(Slice num, long roundScale, long inputPrecision, long inputScale)
+    {
+        BigInteger unscaledVal = unscaledValueToBigInteger(num);
+        if (unscaledVal.signum() == 0 || inputPrecision - inputScale + roundScale <= 0) {
+            return unscaledValueToSlice(0);
+        }
+        if (roundScale >= inputScale) {
+            return num;
+        }
+        BigInteger rescaleFactor = tenToNth((int) (inputScale - roundScale));
+        if (unscaledVal.signum() < 0) {
+            return unscaledValueToSlice(truncateNLongDecimal(unscaledVal.negate(), rescaleFactor).negate());
+        }
+        return unscaledValueToSlice(truncateNLongDecimal(unscaledVal, rescaleFactor));
+    }
+
+    public static BigInteger truncateNLongDecimal(BigInteger num, BigInteger rescaleFactor)
+    {
+        BigInteger remainder = num.remainder(rescaleFactor);
+        return num.subtract(remainder);
     }
 
     @Description("sine")

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
@@ -545,6 +545,47 @@ public class TestMathFunctions
     }
 
     @Test
+    public void testTruncate()
+    {
+        // SHORT DECIMAL
+        assertFunction("truncate(DECIMAL '1234', 1)", createDecimalType(4, 0), SqlDecimal.of("1234"));
+        assertFunction("truncate(DECIMAL '1234', -1)", createDecimalType(4, 0), SqlDecimal.of("1230"));
+        assertFunction("truncate(DECIMAL '1234.56', 1)", createDecimalType(6, 2), SqlDecimal.of("1234.50"));
+        assertFunction("truncate(DECIMAL '1234.56', -1)", createDecimalType(6, 2), SqlDecimal.of("1230.00"));
+        assertFunction("truncate(DECIMAL '-1234.56', 1)", createDecimalType(6, 2), SqlDecimal.of("-1234.50"));
+        assertFunction("truncate(DECIMAL '1239.99', 1)", createDecimalType(6, 2), SqlDecimal.of("1239.90"));
+        assertFunction("truncate(DECIMAL '-1239.99', 1)", createDecimalType(6, 2), SqlDecimal.of("-1239.90"));
+
+        assertFunction("truncate(DECIMAL '1234', -4)", createDecimalType(4, 0), SqlDecimal.of("0000"));
+        assertFunction("truncate(DECIMAL '1234.56', -4)", createDecimalType(6, 2), SqlDecimal.of("0000.00"));
+        assertFunction("truncate(DECIMAL '-1234.56', -4)", createDecimalType(6, 2), SqlDecimal.of("0000.00"));
+
+        assertFunction("truncate(DECIMAL '1234.56', 3)", createDecimalType(6, 2), SqlDecimal.of("1234.56"));
+        assertFunction("truncate(DECIMAL '-1234.56', 3)", createDecimalType(6, 2), SqlDecimal.of("-1234.56"));
+
+        // LONG DECIMAL
+        assertFunction("truncate(DECIMAL '123456789012345678901', 1)", createDecimalType(21, 0), SqlDecimal.of("123456789012345678901"));
+        assertFunction("truncate(DECIMAL '123456789012345678901', -1)", createDecimalType(21, 0), SqlDecimal.of("123456789012345678900"));
+        assertFunction("truncate(DECIMAL '123456789012345678901.23', 1)", createDecimalType(23, 2), SqlDecimal.of("123456789012345678901.20"));
+        assertFunction("truncate(DECIMAL '123456789012345678901.23', -1)", createDecimalType(23, 2), SqlDecimal.of("123456789012345678900.00"));
+        assertFunction("truncate(DECIMAL '123456789012345678999.99', -1)", createDecimalType(23, 2), SqlDecimal.of("123456789012345678990.00"));
+        assertFunction("truncate(DECIMAL '-123456789012345678999.99', -1)", createDecimalType(23, 2), SqlDecimal.of("-123456789012345678990.00"));
+
+        assertFunction("truncate(DECIMAL '123456789012345678901', -21)", createDecimalType(21, 0), SqlDecimal.of("000000000000000000000"));
+        assertFunction("truncate(DECIMAL '123456789012345678901.23', -21)", createDecimalType(23, 2), SqlDecimal.of("000000000000000000000.00"));
+
+        assertFunction("truncate(DECIMAL '123456789012345678901.23', 3)", createDecimalType(23, 2), SqlDecimal.of("123456789012345678901.23"));
+        assertFunction("truncate(DECIMAL '-123456789012345678901.23', 3)", createDecimalType(23, 2), SqlDecimal.of("-123456789012345678901.23"));
+
+        // NULL DECIMAL
+        assertFunction("truncate(CAST(NULL AS DECIMAL(1,0)), -1)", createDecimalType(1, 0), null);
+        assertFunction("truncate(NULL, NULL)", createDecimalType(1, 0), null);
+
+        // OUT OF RANGE DECIMAL
+        assertInvalidFunction("truncate(DECIMAL '123456789012345678901234567890123456789', 0)", INVALID_FUNCTION_ARGUMENT);
+    }
+
+    @Test
     public void testSin()
     {
         for (double doubleValue : DOUBLE_VALUES) {


### PR DESCRIPTION
This function takes `x` value DECIMAL(p, s) and
return the value of same type truncated to `n` places
after decimal point. All decimal places starting at `n`
after decimal point are zeroed.

In case of negative `n` all decimal places after decimal
point as well as abs(`n`) decimal places before decimal
point are truncated.
