### PR TITLE
Fix order for prepared statements docs

### DIFF
--- a/presto-docs/src/main/sphinx/sql.rst
+++ b/presto-docs/src/main/sphinx/sql.rst
@@ -13,13 +13,18 @@ This chapter describes the SQL syntax used in Presto.
     sql/create-table
     sql/create-table-as
     sql/create-view
+    sql/deallocate-prepare
     sql/delete
     sql/describe
+    sql/describe-input
+    sql/describe-output
     sql/drop-table
     sql/drop-view
+    sql/execute
     sql/explain
     sql/explain-analyze
     sql/insert
+    sql/prepare
     sql/reset-session
     sql/rollback
     sql/select
@@ -34,8 +39,3 @@ This chapter describes the SQL syntax used in Presto.
     sql/start-transaction
     sql/use
     sql/values
-    sql/prepare
-    sql/execute
-    sql/deallocate-prepare
-    sql/describe-input
-    sql/describe-output


### PR DESCRIPTION
The sql docs are in alphabetical order.  Put prepared statements
commands in their appropriate locations

@petroav I'll squash this separately into the prepared-statements branch
