### PR TITLE
Adding _default to uniquely identify the network

### DIFF
--- a/presto-product-tests/bin/run_on_docker.sh
+++ b/presto-product-tests/bin/run_on_docker.sh
@@ -41,7 +41,7 @@ function stop_unnecessary_hadoop_services() {
 }
 
 function docker_compose_network() {
-  docker network ls | grep ${ENVIRONMENT} | cut  -f 1 -d ' '
+  docker network ls | grep ${ENVIRONMENT}"_default" | cut  -f 1 -d ' '
 }
 
 function check_presto() {


### PR DESCRIPTION
In case we have more than one configuration with the same name docker_compose_network gives multiple output. In my case, I was having the 2 configuration as singlenode and singlenode-kerberos. It's more appropriate to add "_default" to find the network.
