### PR TITLE
Change download link text to www.teradata.com/presto

### DIFF
--- a/presto-docs/src/main/sphinx/ext/download.py
+++ b/presto-docs/src/main/sphinx/ext/download.py
@@ -23,17 +23,7 @@ TD_LINK_PRESTO = 'http://www.teradata.com/presto'
 
 GROUP_ID = 'com.facebook.presto'
 ARTIFACTS = {
-    'demo-cdh': ('presto-0.141t-demo-cdh', 'ova', TD_LINK_PRESTO),
-    'demo-hdp': ('presto-0.141t-demo-cdh', 'ova', TD_LINK_PRESTO),
-
-    'presto-server-pkg': ('presto_server_pkg.141t', 'tar.gz', TD_LINK_PRESTO),
-    'presto-ambari-pkg': ('presto_ambari_pkg.141t', 'tar.gz', TD_LINK_PRESTO),
-    'presto-client-pkg': ('presto_client_pkg.141t', 'tar.gz', TD_LINK_PRESTO),
-    'jdbc': ('presto_client_pkg.141', 'tar.gz', TD_LINK_PRESTO),
-
-    'odbc-documentation': ('Teradata ODBC Driver for Presto Install Guide', 'pdf', TD_LINK_PRESTO),
-    'presto-docs': ('presto-docs-0.141t-download', 'zip', TD_LINK_PRESTO),
-
+    'teradata-presto': ('www.teradata.com/presto', '', TD_LINK_PRESTO),
     'apache-slider': ('slider-assembly-0.80.0-incubating-all', 'tar.gz', TD_LINK_PRESTO)
 }
 

--- a/presto-docs/src/main/sphinx/getting-started.rst
+++ b/presto-docs/src/main/sphinx/getting-started.rst
@@ -17,7 +17,7 @@ Try out Presto preinstalled with Cloudera on a Virtual Machine.
 * VirtualBox 5.0
 
 | :doc:`Documentation <sandboxes/presto-sandbox-cdh>`
-| Download :download:`demo-cdh`
+| Download **presto-0.141t-demo-cdh.ova** from :download:`teradata-presto`
 
 ----
 
@@ -30,7 +30,7 @@ Try out Presto preinstalled with Hortonworks on a Virtual Machine.
 * VirtualBox 5.0
 
 | :doc:`Documentation <sandboxes/presto-sandbox-hdp>`
-| Download :download:`demo-hdp`
+| Download **presto-0.141t-demo-hdp.ova** from :download:`teradata-presto`
 
 Presto Server Installation
 ==========================
@@ -51,6 +51,6 @@ Presto Documentation
 ====================
 This documentation is available for download as HTML.
 
-Download :download:`presto-docs`
+Download Presto Documentation from :download:`teradata-presto`
 
 

--- a/presto-docs/src/main/sphinx/installation/cli.rst
+++ b/presto-docs/src/main/sphinx/installation/cli.rst
@@ -7,7 +7,7 @@ queries. The CLI is a
 `self-executing <http://skife.org/java/unix/2011/06/20/really_executable_jars.html>`_
 JAR file, which means it acts like a normal UNIX executable.
 
-Download the :download:`presto-server-pkg` which contains the CLI. Rename the CLI to ``presto``,
+Download the CLI included in **presto_client_pkg.141t.tar.gz** from :download:`teradata-presto`. Rename the CLI to ``presto``,
 make it executable with ``chmod +x``, then run it:
 
 .. code-block:: none

--- a/presto-docs/src/main/sphinx/installation/jdbc.rst
+++ b/presto-docs/src/main/sphinx/installation/jdbc.rst
@@ -4,7 +4,7 @@ JDBC Driver
 
 Presto can be accessed from Java using the JDBC driver.  The JDBC driver
 requires Java 1.8.
-Download :download:`jdbc` which contains the JDBC jar. Add the jar to the class path of your Java application.
+Download the JDBC driver included in **presto_client_pkg.141t.tar.gz** from :download:`teradata-presto`. Add the JDBC jar to the class path of your Java application.
 The following JDBC URL formats are supported:
 
 .. code-block:: none

--- a/presto-docs/src/main/sphinx/installation/odbc.rst
+++ b/presto-docs/src/main/sphinx/installation/odbc.rst
@@ -6,8 +6,7 @@ Presto can be accessed from using one of the Teradata ODBC drivers. The ODBC
 driver is available for Windows, Mac, and Linux. The drivers are available for
 free download from Teradata in the Presto Client Package.
 
-| Download :download:`odbc-documentation`
-| Download :download:`presto-client-pkg`
+Download **presto_client_pkg.141t.tar.gz** and documentation from :download:`teradata-presto`
 
 
 ODBC for Mac

--- a/presto-docs/src/main/sphinx/server-installation.rst
+++ b/presto-docs/src/main/sphinx/server-installation.rst
@@ -10,7 +10,7 @@ Automated Installation with Ambari 2.1
 Install and manage Presto using `Apache Ambari`_.
 
 | :doc:`Installation Instructions <installation/installation-ambari>`
-| Download :download:`presto-ambari-pkg`
+| Download **presto_ambari_pkg.141t.tar.gz** from :download:`teradata-presto`
 
 *Requires*:
 
@@ -31,7 +31,7 @@ Automated Installation with Ambari 2.1 with YARN integration
 Install and manage Presto integrated with YARN using the `Apache Slider`_ view for `Apache Ambari`_.
 
 | :doc:`Installation Instructions <installation/installation-yarn>`
-| The YARN package is included as part of the download :download:`presto-server-pkg`
+| Download the YARN Presto package included in **presto_server_pkg.141t.tar.gz** from :download:`teradata-presto`
 
 *Requires*:
 
@@ -53,7 +53,7 @@ Manual Installation via Presto-Admin
 Install and manage Presto manually using Presto-Admin.
 
 | :doc:`Installation Instructions <installation/installation-presto-admin>`
-| Download :download:`presto-server-pkg`
+| Download **presto_server_pkg.141t.tar.gz** from :download:`teradata-presto`
 
 *Requires*:
 
@@ -71,7 +71,7 @@ Manual Installation with YARN integration
 Install and manage Presto integrated with YARN manually using `Apache Slider`_.
 
 | :doc:`Installation Instructions <installation/installation-yarn>`
-| The YARN package is included as part of the download :download:`presto-server-pkg`
+| Download the YARN Presto package included in **presto_server_pkg.141t.tar.gz** from :download:`teradata-presto`
 | Download :download:`apache-slider`
 
 *Requires*:


### PR DESCRIPTION
The download links had the text of the software implying that it was a direct download link. However, it directed one to www.teradata.com/presto making it seem like the link was broken. The text has been changed to indicate that the software package can be downloaded by going to teradata.com/presto.
