### PR TITLE
Add profile(kerberos) specific tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
     - TEST_MODULES=presto-tests
     - TEST_MODULES=presto-raptor,presto-redis,presto-cassandra,presto-kafka,presto-postgresql,presto-mysql
     - RUN_PRODUCT_TESTS="singlenode -x quarantine,big_query,storage_formats,mysql_connector,postgresql_connector,profilespecifictests"
-    - RUN_PRODUCT_TESTS="singlenode-kerberos-hdfs-impersonation -g storage_formats,cli"
+    - RUN_PRODUCT_TESTS="singlenode-kerberos-hdfs-impersonation -g storage_formats,cli,singlenode_kerberos_hdfs_impersonation"
 
 sudo: required
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
     - TEST_MODULES=!presto-tests,!presto-kafka,!presto-redis,!presto-cassandra,!presto-raptor,!presto-postgresql,!presto-mysql
     - TEST_MODULES=presto-tests
     - TEST_MODULES=presto-raptor,presto-redis,presto-cassandra,presto-kafka,presto-postgresql,presto-mysql
-    - RUN_PRODUCT_TESTS="singlenode -x quarantine,big_query,storage_formats,mysql_connector,postgresql_connector"
+    - RUN_PRODUCT_TESTS="singlenode -x quarantine,big_query,storage_formats,mysql_connector,postgresql_connector,profilespecifictests"
     - RUN_PRODUCT_TESTS="singlenode-kerberos-hdfs-impersonation -g storage_formats,cli"
 
 sudo: required

--- a/presto-product-tests/README.md
+++ b/presto-product-tests/README.md
@@ -102,7 +102,7 @@ The Presto product tests must be run explicitly because they do not run
 as part of the Maven build like the unit tests do. Note that the product
 tests cannot be run in parallel. This means that only one instance of a
 test can be run at once in a given environment. To run all product
-tests and exclude the `quarantine`, `big_query` and `profile` groups run the
+tests and exclude the `quarantine`, `big_query` and `profile_specific_tests` groups run the
 following command:
 
 ```
@@ -113,23 +113,27 @@ presto-product-tests/bin/run_on_docker.sh <profile> -x quarantine,big_query,mysq
 where [profile](#profile) is one of either:
 - **multinode** - pseudo-distributed Hadoop installation running on a
  single Docker container and a distributed Presto installation running on
- multiple Docker containers. For multinode the default configuration is 1 coordinator and 1 worker.
+ multiple Docker containers. For multinode the default configuration is
+ 1 coordinator and 1 worker.
 - **singlenode** - pseudo-distributed Hadoop installation running on a
  single Docker container and a single node installation of Presto also running
  on a single Docker container.
-- **singlenode-hdfs-impersonation** - pseudo-distributed Hadoop installation running on a
- single Docker container and a single node installation of Presto also running
- on a single Docker container. Presto impersonates the user who is running the query when accessing HDFS.
-- **singlenode-kerberos-hdfs-impersonation** - pseudo-distributed kerberized Hadoop installation running on a
- single Docker container and a single node installation of kerberized Presto also running
- on a single Docker container. This profile has kerberos impersonation. Presto impersonates the user who
+- **singlenode-hdfs-impersonation** - pseudo-distributed Hadoop installation
+ running on a single Docker container and a single node installation of Presto
+ also running on a single Docker container. Presto impersonates the user who
  is running the query when accessing HDFS.
-- **singlenode-kerberos-hdfs-no-impersonation** - pseudo-distributed Hadoop installation running on a
- single Docker container and a single node installation of kerberized Presto also running
- on a single Docker container. This profile runs kerberos without impersonation.
+- **singlenode-kerberos-hdfs-impersonation** - pseudo-distributed kerberized
+ Hadoop installation running on a single Docker container and a single node
+ installation of kerberized Presto also running on a single Docker container.
+ This profile has Kerberos impersonation. Presto impersonates the user who
+ is running the query when accessing HDFS.
+- **singlenode-kerberos-hdfs-no-impersonation** - pseudo-distributed Hadoop
+ installation running on a single Docker container and a single node
+ installation of kerberized Presto also running on a single Docker container.
+ This profile runs Kerberos without impersonation.
 
-Complete documentation for presto can be found at [Presto](https://prestodb.io/docs/current/index.html).
-The hive connector documentation can be found at [hive-connector](https://prestodb.io/docs/current/connector/hive.html)
+For more information on the various ways in which Presto can be configured to
+interact with Kerberized Hive and Hadoop, please refer to the [Hive connector documentation](https://prestodb.io/docs/current/connector/hive.html).
 
 The `run_on_docker.sh` script can also run individual product tests. Presto
 product tests are either [Java based](https://github.com/prestodb/tempto#java-based-tests)
@@ -143,11 +147,41 @@ presto-product-tests/bin/run_on_docker.sh <profile> -t com.facebook.presto.tests
 presto-product-tests/bin/run_on_docker.sh <profile> -t sql_tests.testcases.system.selectInformationSchemaTables
 ```
 
-Profile specific tests are tests which runs only for that particular profile. It confirms if the profile is same as what is claims.
-For e.g. singlenode-kerberos-hdfs-impersonation - Test to check if kerberos is working with impersonation
-To run the kerberos/impersonation specific test cases
-presto-product-tests/bin/run_on_docker.sh <profile> -g <profile>
-E.g - presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-impersonation -g singlenode-kerberos-hdfs-impersonation
+Tests belong to a single or possibly multiple groups. Java based tests are
+tagged with groups in the @Test annotation and convention based tests have
+group information in the first line of the test file. Instead of running
+single tests, or all tests, users can also run one or more test groups.
+This enables users to test features in a cross functional way. To run a
+particular group, use the -g argument as shown:
+
+```
+# Run all tests in the string_functions and create_table groups
+presto-product-tests/bin/run_on_docker.sh <profile> -g string_functions,create_tables
+```
+
+Some groups of tests can only be run on specific profiles. For example, all
+tests that test Kerberos with HDFS impersonation can only be run on the
+singlenode-kerberos-hdfs-impersonation profile. The group of tests
+that must be run on the singlenode-kerberos-hdfs-impersonation profile
+is called singlenode_kerberos_hdfs_impersonation. The group is
+similar to profile name(hyphen replaced with underscore). This is true for
+the following profiles : singlenode-hdfs-impersonation,
+singlenode-kerberos-hdfs-impersonation and
+singlenode-kerberos-hdfs-no-impersonation. Tests that require
+a specific profile to run are called profile specific tests. In addition
+to their respective group, all such tests also belong to a parent group
+called profile_specific_tests. Thus, when running tests on the singlenode
+profile make sure to exclude all profile specific test by adding the
+profile_specific_tests to the list of excluded groups. The examples
+below illustrate the above concepts:
+
+```
+# Run the tests for Kerberos with HDFS impersonation
+presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-impersonation -g singlenode_kerberos_hdfs_impersonation
+# Run all tests but, among other groups, exclude all profile specific
+# tests because the singlenode profile is used
+presto-product-tests/bin/run_on_docker.sh singlenode -x quarantine,big_query,mysql_connector,postgresql_connector,profile_specific_tests
+```
 
 For running Java based tests from IntelliJ see the section on
 [Debugging Java based tests](#debugging-java-based-tests).

--- a/presto-product-tests/README.md
+++ b/presto-product-tests/README.md
@@ -102,12 +102,12 @@ The Presto product tests must be run explicitly because they do not run
 as part of the Maven build like the unit tests do. Note that the product
 tests cannot be run in parallel. This means that only one instance of a
 test can be run at once in a given environment. To run all product
-tests and exclude the `quarantine` and `big_query` groups run the
+tests and exclude the `quarantine`, `big_query` and `profile` groups run the
 following command:
 
 ```
 ./mvnw install -DskipTests
-presto-product-tests/bin/run_on_docker.sh <profile> -x quarantine,big_query,mysql_connector,postgresql_connector
+presto-product-tests/bin/run_on_docker.sh <profile> -x quarantine,big_query,mysql_connector,postgresql_connector,profilespecifictests
 ```
 
 where [profile](#profile) is one of either:
@@ -142,6 +142,12 @@ presto-product-tests/bin/run_on_docker.sh <profile> -t com.facebook.presto.tests
 # Run single convention based test
 presto-product-tests/bin/run_on_docker.sh <profile> -t sql_tests.testcases.system.selectInformationSchemaTables
 ```
+
+Profile specific tests are tests which runs only for that particular profile. It confirms if the profile is same as what is claims.
+For e.g. singlenode-kerberos-hdfs-impersonation - Test to check if kerberos is working with impersonation
+To run the kerberos/impersonation specific test cases
+presto-product-tests/bin/run_on_docker.sh <profile> -g <profile>
+E.g - presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-impersonation -g singlenode-kerberos-hdfs-impersonation
 
 For running Java based tests from IntelliJ see the section on
 [Debugging Java based tests](#debugging-java-based-tests).

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/ImpersonationTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/ImpersonationTests.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.tests.ImmutableTpchTablesRequirements.ImmutableNationTable;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import com.teradata.tempto.ProductTest;
+import com.teradata.tempto.Requires;
+import com.teradata.tempto.hadoop.hdfs.HdfsClient;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.tests.TestGroups.PROFILE_SPECIFIC_TESTS;
+import static com.facebook.presto.tests.TestGroups.SINGLENODE;
+import static com.facebook.presto.tests.TestGroups.SINGLENODE_HDFS_IMPERSONATION;
+import static com.facebook.presto.tests.TestGroups.SINGLENODE_KERBEROS_HDFS_IMPERSONATION;
+import static com.facebook.presto.tests.TestGroups.SINGLENODE_KERBEROS_HDFS_NO_IMPERSONATION;
+import static com.teradata.tempto.query.QueryExecutor.query;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static org.testng.Assert.assertEquals;
+
+@Requires(ImmutableNationTable.class)
+public class ImpersonationTests
+        extends ProductTest
+{
+    @Inject
+    private HdfsClient hdfsClient;
+    private static final String tableName = "checkTableOwner";
+    private static final String tablepath = "/user/hive/warehouse/checktableowner";
+
+    @Inject
+    @Named("databases.presto.jdbc_user")
+    private String jdbcuserkerberos;
+
+    @Inject
+    @Named("databases.presto.jdbc_user")
+    private String jdbchdfsimpersonation;
+
+    // Without impersonation, the table is created with user specified for
+    // -DHADOOP_USER_NAME in jvm.config
+    @Test(groups = {SINGLENODE, PROFILE_SPECIFIC_TESTS})
+    public void testOwnerSingleNode()
+            throws Exception
+    {
+        checkTableOwner("hive");
+        query(format("DROP TABLE IF EXISTS %s", tableName));
+    }
+
+    @Test(groups = {SINGLENODE_HDFS_IMPERSONATION, PROFILE_SPECIFIC_TESTS})
+    public void testOwnerSingleNodeHdfsImpersonation()
+            throws Exception
+    {
+        requireNonNull(jdbchdfsimpersonation, "databases.presto.jdbc_user is null");
+        checkTableOwner(jdbchdfsimpersonation);
+        query(format("DROP TABLE IF EXISTS %s", tableName));
+    }
+
+    @Test(groups = {SINGLENODE_KERBEROS_HDFS_IMPERSONATION, PROFILE_SPECIFIC_TESTS})
+    public void testOwnerSingleNodeKerberosHdfsImpersonation()
+            throws Exception
+    {
+        requireNonNull(jdbcuserkerberos, "databases.presto.jdbc_user is null");
+        checkTableOwner(jdbcuserkerberos);
+        query(format("DROP TABLE IF EXISTS %s", tableName));
+    }
+
+    // Without hdfs impersonation, the table should be created with user specified for the
+    // principal hive.hdfs.presto.principal in hive.properties
+    @Test(groups = {SINGLENODE_KERBEROS_HDFS_NO_IMPERSONATION, PROFILE_SPECIFIC_TESTS})
+    public void testOwnerSingleNodeKerberosHdfsNoImpersonation()
+            throws Exception
+    {
+        checkTableOwner("hdfs");
+        query(format("DROP TABLE IF EXISTS %s", tableName));
+    }
+
+    private void checkTableOwner(String expectedOwner)
+    {
+        query(format("DROP TABLE IF EXISTS %s", tableName));
+        query(format("create table %s as select * from nation", tableName));
+        String owner = hdfsClient.getOwner(tablepath);
+        assertEquals(owner, expectedOwner);
+    }
+}

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/TestGroups.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/TestGroups.java
@@ -42,6 +42,11 @@ public final class TestGroups
     public static final String STRING_FUNCTIONS = "string_functions";
     public static final String MATH_FUNCTIONS = "math_functions";
     public static final String STORAGE_FORMATS = "storage_formats";
+    public static final String PROFILE_SPECIFIC_TESTS = "profilespecifictests";
+    public static final String SINGLENODE = "singlenode";
+    public static final String SINGLENODE_HDFS_IMPERSONATION = "singlenode-hdfs-impersonation";
+    public static final String SINGLENODE_KERBEROS_HDFS_IMPERSONATION = "singlenode-kerberos-hdfs-impersonation";
+    public static final String SINGLENODE_KERBEROS_HDFS_NO_IMPERSONATION = "singlenode-kerberos-hdfs-no-impersonation";
 
     private TestGroups() {}
 }

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/TestGroups.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/TestGroups.java
@@ -42,11 +42,11 @@ public final class TestGroups
     public static final String STRING_FUNCTIONS = "string_functions";
     public static final String MATH_FUNCTIONS = "math_functions";
     public static final String STORAGE_FORMATS = "storage_formats";
-    public static final String PROFILE_SPECIFIC_TESTS = "profilespecifictests";
+    public static final String PROFILE_SPECIFIC_TESTS = "profile_specific_tests";
     public static final String SINGLENODE = "singlenode";
-    public static final String SINGLENODE_HDFS_IMPERSONATION = "singlenode-hdfs-impersonation";
-    public static final String SINGLENODE_KERBEROS_HDFS_IMPERSONATION = "singlenode-kerberos-hdfs-impersonation";
-    public static final String SINGLENODE_KERBEROS_HDFS_NO_IMPERSONATION = "singlenode-kerberos-hdfs-no-impersonation";
+    public static final String SINGLENODE_HDFS_IMPERSONATION = "singlenode_hdfs_impersonation";
+    public static final String SINGLENODE_KERBEROS_HDFS_IMPERSONATION = "singlenode_kerberos_hdfs_impersonation";
+    public static final String SINGLENODE_KERBEROS_HDFS_NO_IMPERSONATION = "singlenode_kerberos_hdfs_no_impersonation";
 
     private TestGroups() {}
 }

--- a/presto-product-tests/src/main/resources/tempto-configuration.yaml
+++ b/presto-product-tests/src/main/resources/tempto-configuration.yaml
@@ -21,6 +21,7 @@ databases:
     schema: default
     prepare_statement: USE ${databases.hive.schema}
     table_manager_type: hive
+    warehouse_directory_path: /user/hive/warehouse/
 
   presto:
     host: localhost


### PR DESCRIPTION
We don't have any profile specific tests. Need tests to see if the
profile is same as what it claims to be.For e.g.
singlenode-hdfs-impersonation - Tests are working with hdfs
impersonation.
singlenode - No hdfs impersonation.
singlenode-kerberos-hdfs-impersonation - impersonation working
with kerberos.
singlenode-kerberos-hdfs-no-impersonation - Tests working for
Kerberos without impersonation.
