### PR TITLE
Add product test for grant and revoke

### DIFF
--- a/presto-product-tests/conf/tempto/tempto-configuration.yaml
+++ b/presto-product-tests/conf/tempto/tempto-configuration.yaml
@@ -3,3 +3,23 @@ databases:
     host: hadoop-master
   presto:
     host: presto-master
+
+  prestoConfigUserAlice:
+    host: localhost
+    server_address: ${databases.presto.host}:8080
+    cli_server_address: ${databases.presto.host}:8080
+    jdbc_driver_class: com.facebook.presto.jdbc.PrestoDriver
+    jdbc_url: jdbc:presto://${databases.presto.server_address}/hive/${databases.hive.schema}
+    jdbc_user: alice
+    jdbc_password: na
+    jdbc_pooling: false
+
+  prestoConfigUserBob:
+    host: localhost
+    server_address: ${databases.presto.host}:8080
+    cli_server_address: ${databases.presto.host}:8080
+    jdbc_driver_class: com.facebook.presto.jdbc.PrestoDriver
+    jdbc_url: jdbc:presto://${databases.presto.server_address}/hive/${databases.hive.schema}
+    jdbc_user: bob
+    jdbc_password: na
+    jdbc_pooling: false

--- a/presto-product-tests/conf/tempto/tempto-configuration.yaml
+++ b/presto-product-tests/conf/tempto/tempto-configuration.yaml
@@ -4,21 +4,19 @@ databases:
   presto:
     host: presto-master
 
-  prestoConfigUserAlice:
+  alice@presto:
     host: localhost
     server_address: ${databases.presto.host}:8080
-    cli_server_address: ${databases.presto.host}:8080
-    jdbc_driver_class: com.facebook.presto.jdbc.PrestoDriver
+    jdbc_driver_class: $[databases.presto.jdbc_driver_class}
     jdbc_url: jdbc:presto://${databases.presto.server_address}/hive/${databases.hive.schema}
     jdbc_user: alice
     jdbc_password: na
     jdbc_pooling: false
 
-  prestoConfigUserBob:
+  bob@presto:
     host: localhost
     server_address: ${databases.presto.host}:8080
-    cli_server_address: ${databases.presto.host}:8080
-    jdbc_driver_class: com.facebook.presto.jdbc.PrestoDriver
+    jdbc_driver_class: $[databases.presto.jdbc_driver_class}
     jdbc_url: jdbc:presto://${databases.presto.server_address}/hive/${databases.hive.schema}
     jdbc_user: bob
     jdbc_password: na

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoCliTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoCliTests.java
@@ -55,6 +55,10 @@ public class PrestoCliTests
     @Named("databases.presto.server_address")
     private String serverAddress;
 
+    @Inject
+    @Named("databases.presto.jdbc_user")
+    private String jdbcUser;
+
     private PrestoCliProcess presto;
 
     public PrestoCliTests()
@@ -130,7 +134,12 @@ public class PrestoCliTests
     private void launchPrestoCliWithServerArgument(String... arguments)
             throws IOException, InterruptedException
     {
-        launchPrestoCli(ImmutableList.<String>builder().add("--server", serverAddress).add(arguments).build());
+        ImmutableList.Builder<String> prestoClientOptions = ImmutableList.builder();
+        prestoClientOptions.add(
+                "--server", serverAddress,
+                "--user", jdbcUser);
+        prestoClientOptions.add(arguments);
+        launchPrestoCli(prestoClientOptions.build());
     }
 
     private void launchPrestoCli(String... arguments)

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestGrantRevoke.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestGrantRevoke.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.tests.hive;
+
+import com.teradata.tempto.ProductTest;
+import com.teradata.tempto.query.QueryExecutor;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.tests.TestGroups.HIVE_CONNECTOR;
+import static com.facebook.presto.tests.TestGroups.QUARANTINE;
+import static com.facebook.presto.tests.utils.QueryExecutors.connectToPresto;
+import static com.teradata.tempto.assertions.QueryAssert.assertThat;
+import static java.lang.String.format;
+
+public class TestGrantRevoke
+    extends ProductTest
+{
+    /* This test has been quarantined since hive.security property is NOT set by default and
+     * doing so may affect other tests.
+     *
+     * Pre-requisites for the test:
+     * (1) In hive.properties file, set this property: hive.security=sql-standard;
+     * (2) tempto-configuration.yaml file should have two connections to Presto server:
+     * "prestoConfigUserAlice" that has "jdbc_user: alice" and
+     * "prestoConfigUserBob" that has "jdbc_user: bob"
+     * (all other values of the connection are same as the default "presto" connection).
+     * You can get these configurations from presto-product-tests/conf/tempto/tempto-configuration.yaml file.
+     *
+    */
+    @Test(groups = {HIVE_CONNECTOR, QUARANTINE})
+    public void testGrantRevoke()
+    {
+        String tableName = "alice_owned_table";
+        QueryExecutor queryExecutorForAlice = connectToPresto("prestoConfigUserAlice");
+        QueryExecutor queryExecutorForBob = connectToPresto("prestoConfigUserBob");
+
+        queryExecutorForAlice.executeQuery(format("DROP TABLE IF EXISTS %s", tableName));
+        queryExecutorForAlice.executeQuery(format("CREATE TABLE %s(month varchar, day bigint)", tableName));
+        assertThat(queryExecutorForAlice.executeQuery(format("SELECT * from %s", tableName))).hasNoRows();
+        assertThat(() -> queryExecutorForBob.executeQuery(format("SELECT * from %s", tableName))).
+                failsWithMessage(format("Access Denied: Cannot select from table default.%s", tableName));
+
+        //test GRANT
+        queryExecutorForAlice.executeQuery(format("GRANT INSERT, SELECT ON %s to bob", tableName));
+        assertThat(queryExecutorForBob.executeQuery(format("INSERT INTO %s values ('t', 3)", tableName))).hasRowsCount(1);
+        assertThat(queryExecutorForBob.executeQuery(format("SELECT * from %s", tableName))).hasRowsCount(1);
+
+        //test REVOKE
+        queryExecutorForAlice.executeQuery(format("REVOKE INSERT on %s from bob", tableName));
+        assertThat(() -> queryExecutorForBob.executeQuery(format("INSERT into %s values ('y', 5)", tableName))).
+                failsWithMessage(format("Access Denied: Cannot insert into table default.%s", tableName));
+        assertThat(queryExecutorForBob.executeQuery(format("SELECT * from %s", tableName))).hasRowsCount(1);
+    }
+}

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestGrantRevoke.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestGrantRevoke.java
@@ -56,6 +56,8 @@ public class TestGrantRevoke
         queryExecutorForAlice.executeQuery(format("GRANT INSERT, SELECT ON %s to bob", tableName));
         assertThat(queryExecutorForBob.executeQuery(format("INSERT INTO %s values ('t', 3)", tableName))).hasRowsCount(1);
         assertThat(queryExecutorForBob.executeQuery(format("SELECT * from %s", tableName))).hasRowsCount(1);
+        assertThat(() -> queryExecutorForBob.executeQuery(format("DELETE from %s WHERE day=3", tableName))).
+                failsWithMessage(format("Access Denied: Cannot delete from table default.%s", tableName));
 
         //test REVOKE
         queryExecutorForAlice.executeQuery(format("REVOKE INSERT on %s from bob", tableName));

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/utils/QueryExecutors.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/utils/QueryExecutors.java
@@ -24,5 +24,10 @@ public class QueryExecutors
         return testContext().getDependency(QueryExecutor.class, "presto");
     }
 
+    public static QueryExecutor connectToPresto(String prestoConfig)
+    {
+        return testContext().getDependency(QueryExecutor.class, prestoConfig);
+    }
+
     private QueryExecutors() {}
 }


### PR DESCRIPTION
@kokosing @anusudarsan Please review.

I have quarantined the test for grant/revoke. Here is the reasoning behind doing so. 

Running the grant/revoke test requires one to set the property `hive.security=sql-standard` in hive.properties file. If we set this property by default, this essentially turns on the access control checks for ALL the tests.

If in future, someone is writing a new product test that makes a new connection to Presto server, they have to be cognizant of the fact that access control checks have been turned on by default. If not, there is a chance that their test will fail. Such a failure of their test is no indication of the failure of the functionality that they want to test, but has to do with the fact that the testing code is not respecting the access control checks. The additional code that needs to be written so as to respect access control checks is unnecessary as far as testing their specific functionality is concerned. 

I ended up debugging the existing product tests when the hive.security property is turned on. The reasons for these failures had nothing to do with the specific functionalities for which the tests were written. To fix the failing tests, I have added new configuration properties in hive-site.xml file (in a separate PR). I also changed the code in PrestoCLITests to pass `—-user` option when opening connection to Presto server. Although these changes make sure that the existing tests pass if we turn on the property, there is no guarantee that this will hold true for tests that will be written in future.
