### PR TITLE
Update tests for Simba's JDBC drivers

### DIFF
--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/JmxConnectorTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/JmxConnectorTests.java
@@ -16,10 +16,13 @@ package com.facebook.presto.tests;
 import com.teradata.tempto.ProductTest;
 import org.testng.annotations.Test;
 
+import java.sql.Connection;
+
 import static com.facebook.presto.tests.TestGroups.JMX_CONNECTOR;
 import static com.facebook.presto.tests.utils.JdbcDriverUtils.usingFacebookJdbcDriver;
 import static com.facebook.presto.tests.utils.JdbcDriverUtils.usingSimbaJdbcDriver;
 import static com.teradata.tempto.assertions.QueryAssert.assertThat;
+import static com.teradata.tempto.query.QueryExecutor.defaultQueryExecutor;
 import static com.teradata.tempto.query.QueryExecutor.query;
 import static java.sql.JDBCType.BIGINT;
 import static java.sql.JDBCType.LONGNVARCHAR;
@@ -31,13 +34,15 @@ public class JmxConnectorTests
     @Test(groups = JMX_CONNECTOR)
     public void selectFromJavaRuntimeJmxMBean()
     {
+        Connection connection = defaultQueryExecutor().getConnection();
         String sql = "SELECT node, vmname, vmversion FROM jmx.current.\"java.lang:type=runtime\"";
-        if (usingFacebookJdbcDriver()) {
+
+        if (usingFacebookJdbcDriver(connection)) {
             assertThat(query(sql))
                     .hasColumns(LONGNVARCHAR, LONGNVARCHAR, LONGNVARCHAR)
                     .hasAnyRows();
         }
-        else if (usingSimbaJdbcDriver()) {
+        else if (usingSimbaJdbcDriver(connection)) {
             assertThat(query(sql))
                     .hasColumns(VARCHAR, VARCHAR, VARCHAR)
                     .hasAnyRows();

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/SystemConnectorTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/SystemConnectorTests.java
@@ -16,10 +16,13 @@ package com.facebook.presto.tests;
 import com.teradata.tempto.ProductTest;
 import org.testng.annotations.Test;
 
+import java.sql.Connection;
+
 import static com.facebook.presto.tests.TestGroups.SYSTEM_CONNECTOR;
 import static com.facebook.presto.tests.utils.JdbcDriverUtils.usingFacebookJdbcDriver;
 import static com.facebook.presto.tests.utils.JdbcDriverUtils.usingSimbaJdbcDriver;
 import static com.teradata.tempto.assertions.QueryAssert.assertThat;
+import static com.teradata.tempto.query.QueryExecutor.defaultQueryExecutor;
 import static com.teradata.tempto.query.QueryExecutor.query;
 import static java.sql.JDBCType.BIGINT;
 import static java.sql.JDBCType.LONGNVARCHAR;
@@ -32,13 +35,14 @@ public class SystemConnectorTests
     @Test(groups = SYSTEM_CONNECTOR)
     public void selectRuntimeNodes()
     {
+        Connection connection = defaultQueryExecutor().getConnection();
         String sql = "SELECT node_id, http_uri, node_version, state FROM system.runtime.nodes";
-        if (usingFacebookJdbcDriver()) {
+        if (usingFacebookJdbcDriver(connection)) {
             assertThat(query(sql))
                     .hasColumns(LONGNVARCHAR, LONGNVARCHAR, LONGNVARCHAR, LONGNVARCHAR)
                     .hasAnyRows();
         }
-        else if (usingSimbaJdbcDriver()) {
+        else if (usingSimbaJdbcDriver(connection)) {
             assertThat(query(sql))
                     .hasColumns(VARCHAR, VARCHAR, VARCHAR, VARCHAR)
                     .hasAnyRows();
@@ -51,6 +55,7 @@ public class SystemConnectorTests
     @Test(groups = SYSTEM_CONNECTOR)
     public void selectRuntimeQueries()
     {
+        Connection connection = defaultQueryExecutor().getConnection();
         String sql = "SELECT" +
                 "  node_id," +
                 "  query_id," +
@@ -65,13 +70,13 @@ public class SystemConnectorTests
                 "  last_heartbeat," +
                 "  'end' " +
                 "FROM system.runtime.queries";
-        if (usingFacebookJdbcDriver()) {
+        if (usingFacebookJdbcDriver(connection)) {
             assertThat(query(sql))
                     .hasColumns(LONGNVARCHAR, LONGNVARCHAR, LONGNVARCHAR, LONGNVARCHAR, LONGNVARCHAR,
                             BIGINT, BIGINT, BIGINT, TIMESTAMP, TIMESTAMP, TIMESTAMP, LONGNVARCHAR)
                     .hasAnyRows();
         }
-        else if (usingSimbaJdbcDriver()) {
+        else if (usingSimbaJdbcDriver(connection)) {
             assertThat(query(sql))
                     .hasColumns(VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR,
                             BIGINT, BIGINT, BIGINT, TIMESTAMP, TIMESTAMP, TIMESTAMP, VARCHAR)
@@ -85,6 +90,7 @@ public class SystemConnectorTests
     @Test(groups = SYSTEM_CONNECTOR)
     public void selectRuntimeTasks()
     {
+        Connection connection = defaultQueryExecutor().getConnection();
         String sql = "SELECT" +
                 "  node_id," +
                 "  task_id," +
@@ -110,14 +116,14 @@ public class SystemConnectorTests
                 "  last_heartbeat," +
                 "  'end' " +
                 "FROM SYSTEM.runtime.tasks";
-        if (usingFacebookJdbcDriver()) {
+        if (usingFacebookJdbcDriver(connection)) {
             assertThat(query(sql))
                     .hasColumns(LONGNVARCHAR, LONGNVARCHAR, LONGNVARCHAR, LONGNVARCHAR, LONGNVARCHAR,
                             BIGINT, BIGINT, BIGINT, BIGINT, BIGINT, BIGINT, BIGINT, BIGINT, BIGINT,
                             BIGINT, BIGINT, BIGINT, BIGINT, BIGINT, TIMESTAMP, TIMESTAMP, TIMESTAMP, LONGNVARCHAR)
                     .hasAnyRows();
         }
-        else if (usingSimbaJdbcDriver()) {
+        else if (usingSimbaJdbcDriver(connection)) {
             assertThat(query(sql))
                     .hasColumns(VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR,
                             BIGINT, BIGINT, BIGINT, BIGINT, BIGINT, BIGINT, BIGINT, BIGINT, BIGINT,
@@ -132,13 +138,15 @@ public class SystemConnectorTests
     @Test(groups = SYSTEM_CONNECTOR)
     public void selectMetadataCatalogs()
     {
+        Connection connection = defaultQueryExecutor().getConnection();
         String sql = "select catalog_name, connector_id from system.metadata.catalogs";
-        if (usingFacebookJdbcDriver()) {
+
+        if (usingFacebookJdbcDriver(connection)) {
             assertThat(query(sql))
                     .hasColumns(LONGNVARCHAR, LONGNVARCHAR)
                     .hasAnyRows();
         }
-        else if (usingSimbaJdbcDriver()) {
+        else if (usingSimbaJdbcDriver(connection)) {
             assertThat(query(sql))
                     .hasColumns(VARCHAR, VARCHAR)
                     .hasAnyRows();

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/TestGroups.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/TestGroups.java
@@ -29,6 +29,7 @@ public final class TestGroups
     public static final String S3_CONNECTOR = "s3_connector";
     public static final String SMOKE = "smoke";
     public static final String JDBC = "jdbc";
+    public static final String SIMBA_JDBC = "simba_jdbc";
     public static final String QUERY_ENGINE = "qe";
     public static final String COMPARISON = "comparison";
     public static final String LOGICAL = "logical";

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestAllDatatypesFromHiveConnector.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestAllDatatypesFromHiveConnector.java
@@ -24,6 +24,7 @@ import com.teradata.tempto.query.QueryType;
 import org.testng.annotations.Test;
 
 import java.math.BigDecimal;
+import java.sql.Connection;
 import java.sql.Date;
 import java.sql.SQLException;
 
@@ -39,6 +40,7 @@ import static com.facebook.presto.tests.utils.JdbcDriverUtils.usingSimbaJdbcDriv
 import static com.teradata.tempto.assertions.QueryAssert.Row.row;
 import static com.teradata.tempto.assertions.QueryAssert.assertThat;
 import static com.teradata.tempto.fulfillment.table.TableRequirements.immutableTable;
+import static com.teradata.tempto.query.QueryExecutor.defaultQueryExecutor;
 import static com.teradata.tempto.query.QueryExecutor.query;
 import static com.teradata.tempto.util.DateTimeUtils.parseTimestampInUTC;
 import static java.sql.JDBCType.BIGINT;
@@ -216,7 +218,8 @@ public class TestAllDatatypesFromHiveConnector
 
     private void assertColumnTypes(QueryResult queryResult)
     {
-        if (usingFacebookJdbcDriver()) {
+        Connection connection = defaultQueryExecutor().getConnection();
+        if (usingFacebookJdbcDriver(connection)) {
             assertThat(queryResult).hasColumns(
                     BIGINT,
                     BIGINT,
@@ -235,7 +238,7 @@ public class TestAllDatatypesFromHiveConnector
                     LONGVARBINARY
             );
         }
-        else if (usingSimbaJdbcDriver()) {
+        else if (usingSimbaJdbcDriver(connection)) {
             assertThat(queryResult).hasColumns(
                     BIGINT,
                     BIGINT,

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveStorageFormats.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveStorageFormats.java
@@ -231,7 +231,7 @@ public class TestHiveStorageFormats
     {
         Connection connection = defaultQueryExecutor().getConnection();
         try {
-            if (usingFacebookJdbcDriver()) {
+            if (usingFacebookJdbcDriver(connection)) {
                 PrestoConnection prestoConnection = connection.unwrap(PrestoConnection.class);
                 // create more than one split
                 prestoConnection.setSessionProperty("task_writer_count", "4");
@@ -240,7 +240,7 @@ public class TestHiveStorageFormats
                     prestoConnection.setSessionProperty(sessionProperty.getKey(), sessionProperty.getValue());
                 }
             }
-            else if (usingSimbaJdbcDriver()) {
+            else if (usingSimbaJdbcDriver(connection)) {
                 try (Statement statement = connection.createStatement()) {
                     statement.execute("set session task_writer_count=4");
                     statement.execute("set session redistribute_writes=false");

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveStorageFormats.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveStorageFormats.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.tests.hive;
 
-import com.facebook.presto.jdbc.PrestoConnection;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
@@ -25,13 +24,11 @@ import org.testng.annotations.Test;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.List;
 import java.util.Map;
 
 import static com.facebook.presto.tests.TestGroups.STORAGE_FORMATS;
-import static com.facebook.presto.tests.utils.JdbcDriverUtils.usingFacebookJdbcDriver;
-import static com.facebook.presto.tests.utils.JdbcDriverUtils.usingSimbaJdbcDriver;
+import static com.facebook.presto.tests.utils.JdbcDriverUtils.setSessionProperty;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.teradata.tempto.assertions.QueryAssert.Row.row;
 import static com.teradata.tempto.assertions.QueryAssert.assertThat;
@@ -231,26 +228,11 @@ public class TestHiveStorageFormats
     {
         Connection connection = defaultQueryExecutor().getConnection();
         try {
-            if (usingFacebookJdbcDriver(connection)) {
-                PrestoConnection prestoConnection = connection.unwrap(PrestoConnection.class);
-                // create more than one split
-                prestoConnection.setSessionProperty("task_writer_count", "4");
-                prestoConnection.setSessionProperty("redistribute_writes", "false");
-                for (Map.Entry<String, String> sessionProperty : sessionProperties.entrySet()) {
-                    prestoConnection.setSessionProperty(sessionProperty.getKey(), sessionProperty.getValue());
-                }
-            }
-            else if (usingSimbaJdbcDriver(connection)) {
-                try (Statement statement = connection.createStatement()) {
-                    statement.execute("set session task_writer_count=4");
-                    statement.execute("set session redistribute_writes=false");
-                    for (Map.Entry<String, String> sessionProperty : sessionProperties.entrySet()) {
-                        statement.execute(String.format("set session %s=%s", sessionProperty.getKey(), sessionProperty.getValue()));
-                    }
-                }
-            }
-            else {
-                throw new IllegalStateException();
+            // create more than one split
+            setSessionProperty(connection, "task_writer_count", "4");
+            setSessionProperty(connection, "redistribute_writes", "false");
+            for (Map.Entry<String, String> sessionProperty : sessionProperties.entrySet()) {
+                setSessionProperty(connection, sessionProperty.getKey(), sessionProperty.getValue());
             }
         }
         catch (SQLException e) {

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveStorageFormats.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveStorageFormats.java
@@ -25,10 +25,13 @@ import org.testng.annotations.Test;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.List;
 import java.util.Map;
 
 import static com.facebook.presto.tests.TestGroups.STORAGE_FORMATS;
+import static com.facebook.presto.tests.utils.JdbcDriverUtils.usingFacebookJdbcDriver;
+import static com.facebook.presto.tests.utils.JdbcDriverUtils.usingSimbaJdbcDriver;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.teradata.tempto.assertions.QueryAssert.Row.row;
 import static com.teradata.tempto.assertions.QueryAssert.assertThat;
@@ -228,12 +231,26 @@ public class TestHiveStorageFormats
     {
         Connection connection = defaultQueryExecutor().getConnection();
         try {
-            PrestoConnection prestoConnection = connection.unwrap(PrestoConnection.class);
-            // create more than one split
-            prestoConnection.setSessionProperty("task_writer_count", "4");
-            prestoConnection.setSessionProperty("redistribute_writes", "false");
-            for (Map.Entry<String, String> sessionProperty : sessionProperties.entrySet()) {
-                prestoConnection.setSessionProperty(sessionProperty.getKey(), sessionProperty.getValue());
+            if (usingFacebookJdbcDriver()) {
+                PrestoConnection prestoConnection = connection.unwrap(PrestoConnection.class);
+                // create more than one split
+                prestoConnection.setSessionProperty("task_writer_count", "4");
+                prestoConnection.setSessionProperty("redistribute_writes", "false");
+                for (Map.Entry<String, String> sessionProperty : sessionProperties.entrySet()) {
+                    prestoConnection.setSessionProperty(sessionProperty.getKey(), sessionProperty.getValue());
+                }
+            }
+            else if (usingSimbaJdbcDriver()) {
+                try (Statement statement = connection.createStatement()) {
+                    statement.execute("set session task_writer_count=4");
+                    statement.execute("set session redistribute_writes=false");
+                    for (Map.Entry<String, String> sessionProperty : sessionProperties.entrySet()) {
+                        statement.execute(String.format("set session %s=%s", sessionProperty.getKey(), sessionProperty.getValue()));
+                    }
+                }
+            }
+            else {
+                throw new IllegalStateException();
             }
         }
         catch (SQLException e) {

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/jdbc/JdbcTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/jdbc/JdbcTests.java
@@ -35,6 +35,10 @@ import static com.facebook.presto.tests.TestGroups.JDBC;
 import static com.facebook.presto.tests.TestGroups.QUARANTINE;
 import static com.facebook.presto.tests.TestGroups.SIMBA_JDBC;
 import static com.facebook.presto.tests.TpchTableResults.PRESTO_NATION_RESULT;
+
+import static com.facebook.presto.tests.utils.JdbcDriverUtils.getSessionProperty;
+import static com.facebook.presto.tests.utils.JdbcDriverUtils.resetSessionProperty;
+import static com.facebook.presto.tests.utils.JdbcDriverUtils.setSessionProperty;
 import static com.facebook.presto.tests.utils.JdbcDriverUtils.usingFacebookJdbcDriver;
 import static com.facebook.presto.tests.utils.JdbcDriverUtils.usingSimbaJdbc4Driver;
 import static com.facebook.presto.tests.utils.JdbcDriverUtils.usingSimbaJdbcDriver;
@@ -49,6 +53,8 @@ import static com.teradata.tempto.fulfillment.table.hive.tpch.TpchTableDefinitio
 import static com.teradata.tempto.internal.convention.SqlResultDescriptor.sqlResultDescriptorForResource;
 import static com.teradata.tempto.query.QueryExecutor.defaultQueryExecutor;
 import static com.teradata.tempto.query.QueryExecutor.query;
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
 import static java.util.Locale.CHINESE;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -227,6 +233,19 @@ public class JdbcTests
             assertThat(query("select {fn timestampdiff(SQL_TSI_DAY,date '2001-01-01',date '2002-01-01')}")).containsExactly(row(365));
             assertThat(query("select {fn ucase('ABC def 123')}")).containsExactly(row("ABC DEF 123"));
         }
+    }
+
+    @Test(groups = JDBC)
+    public void testSessionProperties()
+            throws SQLException
+    {
+        final String distributedJoin = "distributed_join";
+
+        assertThat(getSessionProperty(connection, distributedJoin)).isEqualTo(TRUE.toString());
+        setSessionProperty(connection, distributedJoin, FALSE.toString());
+        assertThat(getSessionProperty(connection, distributedJoin)).isEqualTo(FALSE.toString());
+        resetSessionProperty(connection, distributedJoin);
+        assertThat(getSessionProperty(connection, distributedJoin)).isEqualTo(TRUE.toString());
     }
 
     private QueryResult queryResult(Statement statement, String query)

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/jdbc/JdbcTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/jdbc/JdbcTests.java
@@ -120,7 +120,7 @@ public class JdbcTests
     public void shouldSetTimezone()
             throws SQLException
     {
-        if (usingFacebookJdbcDriver()) {
+        if (usingFacebookJdbcDriver(connection)) {
             String timeZoneId = "Indian/Kerguelen";
             ((PrestoConnection) connection).setTimeZoneId(timeZoneId);
             try (Statement statement = connection.createStatement()) {
@@ -134,7 +134,7 @@ public class JdbcTests
     public void shouldSetLocale()
             throws SQLException
     {
-        if (usingFacebookJdbcDriver()) {
+        if (usingFacebookJdbcDriver(connection)) {
             ((PrestoConnection) connection).setLocale(CHINESE);
             try (Statement statement = connection.createStatement()) {
                 QueryResult result = queryResult(statement, "SELECT date_format(TIMESTAMP '2001-01-09 09:04', '%M')");
@@ -166,14 +166,15 @@ public class JdbcTests
             throws SQLException
     {
         // The JDBC spec is vague on what values getColumns() should return, so accept the values that Facebook or Simba return.
+
         QueryResult result = QueryResult.forResultSet(metaData().getColumns("hive", "default", "nation", null));
-        if (usingFacebookJdbcDriver()) {
+        if (usingFacebookJdbcDriver(connection)) {
             assertThat(result).matches(sqlResultDescriptorForResource("com/facebook/presto/tests/jdbc/get_nation_columns.result"));
         }
-        else if (usingSimbaJdbc4Driver()) {
+        else if (usingSimbaJdbc4Driver(connection)) {
             assertThat(result).matches(sqlResultDescriptorForResource("com/facebook/presto/tests/jdbc/get_nation_columns_simba4.result"));
         }
-        else if (usingSimbaJdbcDriver()) {
+        else if (usingSimbaJdbcDriver(connection)) {
             assertThat(result).matches(sqlResultDescriptorForResource("com/facebook/presto/tests/jdbc/get_nation_columns_simba.result"));
         }
         else {

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/jdbc/JdbcTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/jdbc/JdbcTests.java
@@ -24,13 +24,16 @@ import com.teradata.tempto.configuration.Configuration;
 import com.teradata.tempto.query.QueryResult;
 import org.testng.annotations.Test;
 
+import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
+import java.sql.Date;
 import java.sql.SQLException;
 import java.sql.Statement;
 
 import static com.facebook.presto.tests.TestGroups.JDBC;
 import static com.facebook.presto.tests.TestGroups.QUARANTINE;
+import static com.facebook.presto.tests.TestGroups.SIMBA_JDBC;
 import static com.facebook.presto.tests.TpchTableResults.PRESTO_NATION_RESULT;
 import static com.facebook.presto.tests.utils.JdbcDriverUtils.usingFacebookJdbcDriver;
 import static com.facebook.presto.tests.utils.JdbcDriverUtils.usingSimbaJdbc4Driver;
@@ -185,6 +188,44 @@ public class JdbcTests
     {
         QueryResult result = QueryResult.forResultSet(metaData().getTableTypes());
         assertThat(result).contains(row("TABLE"), row("VIEW"));
+    }
+
+    @Test(groups = {JDBC, SIMBA_JDBC})
+    public void testSqlEscapeFunctions()
+            throws SQLException
+    {
+        if (usingSimbaJdbcDriver(connection)) {
+            // These functions, which are defined in the ODBC standard, are implemented within
+            // the Simba JDBC and ODBC drivers.  The drivers translate them into equivalent Presto syntax.
+            // The translated SQL is executed by Presto.  These tests do not make use of edge-case values or null
+            // values because those code paths are covered by other (non-Simba specifc) tests.
+
+            assertThat(query("select {fn char(40)}")).containsExactly(row("("));
+            assertThat(query("select {fn convert('2016-10-10', SQL_DATE)}")).containsExactly(row(Date.valueOf("2016-10-10")));
+
+            // This translates to: SELECT cast('1234.567' as DECIMAL).
+            // When casting to DECIMAL without parameters, Presto rounds to the nearest integer value.
+            assertThat(query("select {fn convert('1234.567', SQL_DECIMAL)}")).containsExactly(row(new BigDecimal(1235)));
+
+            assertThat(query("select {fn convert('123456', SQL_INTEGER)}")).containsExactly(row(123456));
+            assertThat(query("select {fn convert('123abcd', SQL_VARBINARY)}")).containsExactly(row("123abcd".getBytes()));
+            assertThat(query("select {fn dayofmonth('2016-10-20')}")).containsExactly(row(20));
+            assertThat(query("select {fn dayofweek('2016-10-20')}")).containsExactly(row(5));
+            assertThat(query("select {fn dayofyear('2016-10-20')}")).containsExactly(row(294));
+            assertThat(query("select {fn ifnull({fn ifnull(null, null)}, '2')}")).containsExactly(row("2"));
+            assertThat(query("select {fn ifnull('abc', '2')}")).containsExactly(row("abc"));
+            assertThat(query("select {fn ifnull(null, '2')}")).containsExactly(row("2"));
+            assertThat(query("select {fn lcase('ABC def 123')}")).containsExactly(row("abc def 123"));
+            assertThat(query("select {fn left('abc def', 2)}")).containsExactly(row("ab"));
+            assertThat(query("select {fn locate('d', 'abc def')}")).containsExactly(row(5));
+            assertThat(query("select {fn log(5)}")).containsExactly(row(1.60943791243));
+            assertThat(query("select {fn right('abc def', 2)}")).containsExactly(row("ef"));
+            assertThat(query("select {fn substring('abc def', 2)}")).containsExactly(row("bc def"));
+            assertThat(query("select {fn substring('abc def', 2, 2)}")).containsExactly(row("bc"));
+            assertThat(query("select {fn timestampadd(SQL_TSI_DAY, 21, date '2001-01-01')}")).containsExactly(row(Date.valueOf("2001-01-22")));
+            assertThat(query("select {fn timestampdiff(SQL_TSI_DAY,date '2001-01-01',date '2002-01-01')}")).containsExactly(row(365));
+            assertThat(query("select {fn ucase('ABC def 123')}")).containsExactly(row("ABC DEF 123"));
+        }
     }
 
     private QueryResult queryResult(Statement statement, String query)

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/utils/JdbcDriverUtils.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/utils/JdbcDriverUtils.java
@@ -13,10 +13,30 @@
  */
 package com.facebook.presto.tests.utils;
 
+import com.facebook.presto.jdbc.PrestoConnection;
+
 import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
 
 public class JdbcDriverUtils
 {
+    public static void setSessionProperty(Connection connection, String key, String value) throws SQLException
+    {
+        if (usingFacebookJdbcDriver(connection)) {
+            PrestoConnection prestoConnection = connection.unwrap(PrestoConnection.class);
+            prestoConnection.setSessionProperty(key, value);
+        }
+        else if (usingSimbaJdbcDriver(connection)) {
+            try (Statement statement = connection.createStatement()) {
+                statement.execute(String.format("set session %s=%s", key, value));
+            }
+        }
+        else {
+            throw new IllegalStateException();
+        }
+    }
+
     public static boolean usingFacebookJdbcDriver(Connection connection)
     {
         return getClassNameForJdbcDriver(connection).equals("com.facebook.presto.jdbc.PrestoConnection");

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/utils/JdbcDriverUtils.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/utils/JdbcDriverUtils.java
@@ -13,31 +13,31 @@
  */
 package com.facebook.presto.tests.utils;
 
-import static com.teradata.tempto.query.QueryExecutor.defaultQueryExecutor;
+import java.sql.Connection;
 
 public class JdbcDriverUtils
 {
-    public static boolean usingFacebookJdbcDriver()
+    public static boolean usingFacebookJdbcDriver(Connection connection)
     {
-        return getClassNameForJdbcDriver().equals("com.facebook.presto.jdbc.PrestoConnection");
+        return getClassNameForJdbcDriver(connection).equals("com.facebook.presto.jdbc.PrestoConnection");
     }
 
-    public static boolean usingSimbaJdbcDriver()
+    public static boolean usingSimbaJdbcDriver(Connection connection)
     {
-        String className = getClassNameForJdbcDriver();
+        String className = getClassNameForJdbcDriver(connection);
         return  className.equals("com.teradata.jdbc.jdbc4.S4Connection") ||
                 className.equals("com.teradata.jdbc.jdbc41.S41Connection") ||
                 className.equals("com.teradata.jdbc.jdbc42.S42Connection");
     }
 
-    public static boolean usingSimbaJdbc4Driver()
+    public static boolean usingSimbaJdbc4Driver(Connection connection)
     {
-        return getClassNameForJdbcDriver().contains("jdbc4.");
+        return getClassNameForJdbcDriver(connection).contains("jdbc4.");
     }
 
-    private static String getClassNameForJdbcDriver()
+    private static String getClassNameForJdbcDriver(Connection connection)
     {
-        return defaultQueryExecutor().getConnection().getClass().getCanonicalName();
+        return connection.getClass().getCanonicalName();
     }
 
     private JdbcDriverUtils() {}


### PR DESCRIPTION
These tests are roughly equivalent to those added for ODBC (https://github.td.teradata.com/center-for-hadoop/presto-odbc/tree/master/odbc_test/tests/hive/sql_escape_functions).
