### PR TITLE
Enable reading and writing FLOAT to/from TextFile and RCFile in Hive

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/ColumnarTextHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ColumnarTextHiveRecordCursor.java
@@ -47,6 +47,7 @@ import static com.facebook.presto.hive.HiveUtil.bigintPartitionKey;
 import static com.facebook.presto.hive.HiveUtil.booleanPartitionKey;
 import static com.facebook.presto.hive.HiveUtil.datePartitionKey;
 import static com.facebook.presto.hive.HiveUtil.doublePartitionKey;
+import static com.facebook.presto.hive.HiveUtil.floatPartitionKey;
 import static com.facebook.presto.hive.HiveUtil.getTableObjectInspector;
 import static com.facebook.presto.hive.HiveUtil.integerPartitionKey;
 import static com.facebook.presto.hive.HiveUtil.isStructuralType;
@@ -59,6 +60,7 @@ import static com.facebook.presto.hive.HiveUtil.timestampPartitionKey;
 import static com.facebook.presto.hive.HiveUtil.tinyintPartitionKey;
 import static com.facebook.presto.hive.HiveUtil.varcharPartitionKey;
 import static com.facebook.presto.hive.NumberParser.parseDouble;
+import static com.facebook.presto.hive.NumberParser.parseFloat;
 import static com.facebook.presto.hive.NumberParser.parseLong;
 import static com.facebook.presto.hive.util.SerDeUtils.getBlockObject;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -68,6 +70,7 @@ import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.Decimals.isLongDecimal;
 import static com.facebook.presto.spi.type.Decimals.isShortDecimal;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.FloatType.FLOAT;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
 import static com.facebook.presto.spi.type.StandardTypes.DECIMAL;
@@ -79,6 +82,7 @@ import static com.facebook.presto.spi.type.Varchars.truncateToLength;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Maps.uniqueIndex;
+import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.lang.String.format;
@@ -207,6 +211,9 @@ class ColumnarTextHiveRecordCursor<K>
                 }
                 else if (BIGINT.equals(type)) {
                     longs[columnIndex] = bigintPartitionKey(partitionKey.getValue(), name);
+                }
+                else if (FLOAT.equals(type)) {
+                    longs[columnIndex] = floatPartitionKey(partitionKey.getValue(), name);
                 }
                 else if (DOUBLE.equals(type)) {
                     doubles[columnIndex] = doublePartitionKey(partitionKey.getValue(), name);
@@ -355,10 +362,11 @@ class ColumnarTextHiveRecordCursor<K>
                 !types[fieldId].equals(TINYINT) &&
                 !types[fieldId].equals(DATE) &&
                 !types[fieldId].equals(TIMESTAMP) &&
-                !isShortDecimal(types[fieldId])) {
+                !isShortDecimal(types[fieldId]) &&
+                !types[fieldId].equals(FLOAT)) {
             // we don't use Preconditions.checkArgument because it requires boxing fieldId, which affects inner loop performance
             throw new IllegalArgumentException(
-                    format("Expected field to be %s, %s, %s, %s, %s or %s , actual %s (field %s)", TINYINT, SMALLINT, INTEGER, BIGINT, DECIMAL, DATE, TIMESTAMP, types[fieldId], fieldId));
+                    format("Expected field to be %s, %s, %s, %s, %s, %s or %s , actual %s (field %s)", TINYINT, SMALLINT, INTEGER, BIGINT, DECIMAL, DATE, TIMESTAMP, FLOAT, types[fieldId], fieldId));
         }
 
         if (!loaded[fieldId]) {
@@ -411,6 +419,10 @@ class ColumnarTextHiveRecordCursor<K>
         else if (hiveTypes[column].equals(HiveType.HIVE_TIMESTAMP)) {
             String value = new String(bytes, start, length);
             longs[column] = parseHiveTimestamp(value, hiveStorageTimeZone);
+            wasNull = false;
+        }
+        else if (hiveTypes[column].equals(HiveType.HIVE_FLOAT)) {
+            longs[column] = floatToRawIntBits(parseFloat(bytes, start, length));
             wasNull = false;
         }
         else {
@@ -687,6 +699,9 @@ class ColumnarTextHiveRecordCursor<K>
         }
         else if (type.equals(DOUBLE)) {
             parseDoubleColumn(column);
+        }
+        else if (type.equals(FLOAT)) {
+            parseLongColumn(column);
         }
         else if (isVarcharType(type) || VARBINARY.equals(type)) {
             parseStringColumn(column);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/GenericHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/GenericHiveRecordCursor.java
@@ -48,6 +48,7 @@ import static com.facebook.presto.hive.HiveUtil.bigintPartitionKey;
 import static com.facebook.presto.hive.HiveUtil.booleanPartitionKey;
 import static com.facebook.presto.hive.HiveUtil.datePartitionKey;
 import static com.facebook.presto.hive.HiveUtil.doublePartitionKey;
+import static com.facebook.presto.hive.HiveUtil.floatPartitionKey;
 import static com.facebook.presto.hive.HiveUtil.getDeserializer;
 import static com.facebook.presto.hive.HiveUtil.getTableObjectInspector;
 import static com.facebook.presto.hive.HiveUtil.integerPartitionKey;
@@ -209,6 +210,9 @@ class GenericHiveRecordCursor<K, V extends Writable>
                 }
                 else if (TINYINT.equals(type)) {
                     longs[columnIndex] = tinyintPartitionKey(partitionKey.getValue(), name);
+                }
+                else if (FLOAT.equals(type)) {
+                    longs[columnIndex] = floatPartitionKey(partitionKey.getValue(), name);
                 }
                 else if (DOUBLE.equals(type)) {
                     doubles[columnIndex] = doublePartitionKey(partitionKey.getValue(), name);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/NumberParser.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/NumberParser.java
@@ -41,18 +41,34 @@ public final class NumberParser
         return value * sign;
     }
 
+    public static float parseFloat(byte[] bytes, int start, int length)
+    {
+        String string = getStringOfBytes(bytes, start, length);
+        try {
+            return Float.parseFloat(string);
+        }
+        catch (NumberFormatException e) {
+            throw new PrestoException(HIVE_BAD_DATA, e);
+        }
+    }
+
     public static double parseDouble(byte[] bytes, int start, int length)
     {
-        char[] chars = new char[length];
-        for (int pos = 0; pos < length; pos++) {
-            chars[pos] = (char) bytes[start + pos];
-        }
-        String string = new String(chars);
+        String string = getStringOfBytes(bytes, start, length);
         try {
             return Double.parseDouble(string);
         }
         catch (NumberFormatException e) {
             throw new PrestoException(HIVE_BAD_DATA, e);
         }
+    }
+
+    private static String getStringOfBytes(byte[] bytes, int start, int length)
+    {
+        char[] chars = new char[length];
+        for (int pos = 0; pos < length; pos++) {
+            chars[pos] = (char) bytes[start + pos];
+        }
+        return new String(chars);
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileFormats.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileFormats.java
@@ -90,6 +90,7 @@ import static com.facebook.presto.hive.HiveUtil.isStructuralType;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.FloatType.FLOAT;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
@@ -106,6 +107,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Predicates.not;
 import static com.google.common.collect.Iterables.filter;
 import static com.google.common.collect.Iterables.transform;
+import static java.lang.Float.intBitsToFloat;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.fill;
 import static java.util.Objects.requireNonNull;
@@ -198,7 +200,7 @@ public abstract class AbstractTestHiveFileFormats
             .add(new TestColumn("p_smallint", javaShortObjectInspector, "2", (short) 2, true))
             .add(new TestColumn("p_int", javaIntObjectInspector, "3", 3, true))
             .add(new TestColumn("p_bigint", javaLongObjectInspector, "4", 4L, true))
-            .add(new TestColumn("p_float", javaFloatObjectInspector, "5.1", 5.1, true))
+            .add(new TestColumn("p_float", javaFloatObjectInspector, "5.1", 5.1f, true))
             .add(new TestColumn("p_double", javaDoubleObjectInspector, "6.2", 6.2, true))
             .add(new TestColumn("p_boolean", javaBooleanObjectInspector, "true", true, true))
             .add(new TestColumn("p_date", javaDateObjectInspector, DATE_STRING, DATE_DAYS, true))
@@ -247,7 +249,7 @@ public abstract class AbstractTestHiveFileFormats
             .add(new TestColumn("t_smallint", javaShortObjectInspector, (short) 2, (short) 2))
             .add(new TestColumn("t_int", javaIntObjectInspector, 3, 3))
             .add(new TestColumn("t_bigint", javaLongObjectInspector, 4L, 4L))
-            .add(new TestColumn("t_float", javaFloatObjectInspector, 5.1f, 5.1))
+            .add(new TestColumn("t_float", javaFloatObjectInspector, 5.1f, 5.1f))
             .add(new TestColumn("t_double", javaDoubleObjectInspector, 6.2, 6.2))
             .add(new TestColumn("t_boolean_true", javaBooleanObjectInspector, true, true))
             .add(new TestColumn("t_boolean_false", javaBooleanObjectInspector, false, false))
@@ -279,7 +281,7 @@ public abstract class AbstractTestHiveFileFormats
             .add(new TestColumn("t_map_null_key", getStandardMapObjectInspector(javaLongObjectInspector, javaLongObjectInspector), asMap(new Long[] {null, 2L}, new Long[] {0L,  3L}), mapBlockOf(BIGINT, BIGINT, 2, 3)))
             .add(new TestColumn("t_map_int", getStandardMapObjectInspector(javaIntObjectInspector, javaIntObjectInspector), ImmutableMap.of(3, 3), mapBlockOf(INTEGER, INTEGER, 3, 3)))
             .add(new TestColumn("t_map_bigint", getStandardMapObjectInspector(javaLongObjectInspector, javaLongObjectInspector), ImmutableMap.of(4L, 4L), mapBlockOf(BIGINT, BIGINT, 4L, 4L)))
-            .add(new TestColumn("t_map_float", getStandardMapObjectInspector(javaFloatObjectInspector, javaFloatObjectInspector), ImmutableMap.of(5.0f, 5.0f), mapBlockOf(DOUBLE, DOUBLE, 5.0f, 5.0f)))
+            .add(new TestColumn("t_map_float", getStandardMapObjectInspector(javaFloatObjectInspector, javaFloatObjectInspector), ImmutableMap.of(5.0f, 5.0f), mapBlockOf(FLOAT, FLOAT, 5.0f, 5.0f)))
             .add(new TestColumn("t_map_double", getStandardMapObjectInspector(javaDoubleObjectInspector, javaDoubleObjectInspector), ImmutableMap.of(6.0, 6.0), mapBlockOf(DOUBLE, DOUBLE, 6.0, 6.0)))
             .add(new TestColumn("t_map_boolean",
                     getStandardMapObjectInspector(javaBooleanObjectInspector, javaBooleanObjectInspector),
@@ -329,7 +331,7 @@ public abstract class AbstractTestHiveFileFormats
             .add(new TestColumn("t_array_smallint", getStandardListObjectInspector(javaShortObjectInspector), ImmutableList.of((short) 2), arrayBlockOf(SMALLINT, (short) 2)))
             .add(new TestColumn("t_array_int", getStandardListObjectInspector(javaIntObjectInspector), ImmutableList.of(3), arrayBlockOf(INTEGER, 3)))
             .add(new TestColumn("t_array_bigint", getStandardListObjectInspector(javaLongObjectInspector), ImmutableList.of(4L), arrayBlockOf(BIGINT, 4L)))
-            .add(new TestColumn("t_array_float", getStandardListObjectInspector(javaFloatObjectInspector), ImmutableList.of(5.0f), arrayBlockOf(DOUBLE, 5.0f)))
+            .add(new TestColumn("t_array_float", getStandardListObjectInspector(javaFloatObjectInspector), ImmutableList.of(5.0f), arrayBlockOf(FLOAT, 5.0f)))
             .add(new TestColumn("t_array_double", getStandardListObjectInspector(javaDoubleObjectInspector), ImmutableList.of(6.0), StructuralTestUtil.arrayBlockOf(DOUBLE, 6.0)))
             .add(new TestColumn("t_array_boolean", getStandardListObjectInspector(javaBooleanObjectInspector), ImmutableList.of(true), arrayBlockOf(BOOLEAN, true)))
             .add(new TestColumn(
@@ -562,6 +564,9 @@ public abstract class AbstractTestHiveFileFormats
                 else if (BIGINT.equals(type)) {
                     fieldFromCursor = cursor.getLong(i);
                 }
+                else if (FLOAT.equals(type)) {
+                    fieldFromCursor = cursor.getLong(i);
+                }
                 else if (DOUBLE.equals(type)) {
                     fieldFromCursor = cursor.getDouble(i);
                 }
@@ -596,8 +601,11 @@ public abstract class AbstractTestHiveFileFormats
                 if (fieldFromCursor == null) {
                     assertEquals(null, testColumn.getExpectedValue(), String.format("Expected null for column %s", testColumn.getName()));
                 }
-                else if (testColumn.getObjectInspector().getTypeName().equals("float") ||
-                        testColumn.getObjectInspector().getTypeName().equals("double")) {
+                else if (testColumn.getObjectInspector().getTypeName().equals("float")) {
+                    int intBits = (int) ((long) fieldFromCursor);
+                    assertEquals(intBitsToFloat(intBits), (float) testColumn.getExpectedValue(), (float) EPSILON);
+                }
+                else if (testColumn.getObjectInspector().getTypeName().equals("double")) {
                     assertEquals((double) fieldFromCursor, (double) testColumn.getExpectedValue(), EPSILON);
                 }
                 else if (testColumn.getObjectInspector().getTypeName().equals("tinyint")) {

--- a/presto-main/src/main/java/com/facebook/presto/type/TypeJsonUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TypeJsonUtils.java
@@ -47,6 +47,7 @@ import java.util.Map;
 import static com.fasterxml.jackson.core.JsonFactory.Feature.CANONICALIZE_FIELD_NAMES;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static java.lang.Float.floatToRawIntBits;
 import static java.util.Objects.requireNonNull;
 
 public final class TypeJsonUtils
@@ -283,6 +284,9 @@ public final class TypeJsonUtils
         else if (javaType == long.class) {
             if (element instanceof SqlDecimal) {
                 type.writeLong(blockBuilder, ((SqlDecimal) element).getUnscaledValue().longValue());
+            }
+            else if (element instanceof Float) {
+                type.writeLong(blockBuilder, floatToRawIntBits((Float) element));
             }
             else {
                 type.writeLong(blockBuilder, ((Number) element).longValue());


### PR DESCRIPTION
Test cases:
`SELECT float_col FROM hive.schema.table;`
`INSERT INTO hive.schema.table VALUES(FLOAT '1.23');`

This is next step towards full support of FLOAT in Hive. It won't be merged separately without `float_hive-2315/1` and other readers/writers (`parquet`, `orc` etc.).
