### PR TITLE
Add documentation for GRANT and REVOKE

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive-security.rst
+++ b/presto-docs/src/main/sphinx/connector/hive-security.rst
@@ -2,9 +2,36 @@
 Hive Security Configuration
 ===========================
 
+Authorization
+=============
+You can enable authorization checks for queries that are running in Presto and
+using the Hive connector, by setting the ``hive.security`` property in
+``hive.properties`` file. This property takes three values:
+
+================================================== ============================================================
+Property Value                                     Description
+================================================== ============================================================
+``none`` (default value)                           No authorization checks are enforced, thus allowing any
+                                                   operation.
+
+``read-only``                                      Operations that read data or metadata, such as ``SELECT``,
+                                                   are permitted, but none of the operations that write data or
+                                                   metadata, such as ``CREATE``, ``INSERT`` or ``DELETE``, are
+                                                   allowed.
+
+``sql-standard``                                   Users are permitted to perform the operations as long as
+                                                   they have the required privileges as per the SQL standard.
+                                                   In this mode, Presto enforces the authorization checks for
+                                                   queries based on the privileges defined in Hive metastore.
+                                                   To alter these privileges, use the :doc:`/sql/grant` and
+                                                   :doc:`/sql/revoke` commands.
+================================================== ============================================================
+
+Authentication
+==============
 The default security configuration of the :doc:`/connector/hive` does not use
 authentication when connecting to a Hadoop cluster. All queries are executed as
-the user who runs the Presto process, regardless of which user who submits the
+the user who runs the Presto process, regardless of which user submits the
 query.
 
 The Hive connector provides additional security options to support Hadoop

--- a/presto-docs/src/main/sphinx/sql.rst
+++ b/presto-docs/src/main/sphinx/sql.rst
@@ -19,8 +19,10 @@ This chapter describes the SQL syntax used in Presto.
     sql/drop-view
     sql/explain
     sql/explain-analyze
+    sql/grant
     sql/insert
     sql/reset-session
+    sql/revoke
     sql/rollback
     sql/select
     sql/set-session

--- a/presto-docs/src/main/sphinx/sql/grant.rst
+++ b/presto-docs/src/main/sphinx/sql/grant.rst
@@ -1,0 +1,51 @@
+=====
+GRANT
+=====
+
+Synopsis
+--------
+
+.. code-block:: none
+
+    GRANT ( privilege [, ...] | ( ALL PRIVILEGES ) )
+    ON [ TABLE ] table_name TO ( grantee | PUBLIC )
+    [ WITH GRANT OPTION ]
+
+Usage of the term ``grantee`` denotes both users and roles.
+
+Description
+-----------
+
+Grants the specified privileges to the specified grantee.
+
+Specifying ``ALL PRIVILEGES`` grants ``DELETE, INSERT`` and ``SELECT`` privileges.
+
+Specifying ``PUBLIC`` grants privileges to all grantees.
+
+The optional ``WITH GRANT OPTION`` clause allows the grantee to grant these same privileges to others.
+
+For ``Grant`` statement to succeed, the user executing it should possess the specified privileges as well as the ``GRANT OPTION`` for those privileges.
+
+Limitation
+----------
+
+``GRANT`` is currently supported only for hive connector.
+
+Examples
+--------
+
+Grant ``INSERT`` and ``SELECT`` privileges on the table ``orders`` to user ``alice``::
+
+    GRANT INSERT, SELECT
+    ON orders TO alice;
+
+Grant ``SELECT`` privilege on the table ``nation`` to user ``alice``, additionally allowing ``alice`` to grant ``SELECT`` privilege to others::
+
+    GRANT SELECT
+    ON nation to alice
+    WITH GRANT OPTION;
+
+GRANT ``SELECT`` privilege on the table ``orders`` to everyone::
+
+    GRANT SELECT
+    ON orders to PUBLIC;

--- a/presto-docs/src/main/sphinx/sql/revoke.rst
+++ b/presto-docs/src/main/sphinx/sql/revoke.rst
@@ -1,0 +1,53 @@
+======
+REVOKE
+======
+
+Synopsis
+--------
+
+.. code-block:: none
+
+    REVOKE [ GRANT OPTION FOR ]
+    (privilege [, ...] | ALL PRIVILEGES)
+    ON [ TABLE ] table_name FROM ( grantee | PUBLIC )
+
+Usage of the term ``grantee`` denotes both users and roles.
+
+Description
+-----------
+
+Revokes the specified privileges from the specified grantee.
+
+Specifying ``ALL PRIVILEGES`` revokes ``DELETE, INSERT`` and ``SELECT`` privileges.
+
+Specifying ``PUBLIC`` revokes privileges from all grantees.
+
+The optional ``GRANT OPTION FOR`` clause also revokes the privileges to grant the specified privileges.
+
+For ``Revoke`` statement to succeed, the user executing it should possess the specified privileges as well as the ``GRANT OPTION`` for those privileges.
+
+Limitation
+----------
+
+``REVOKE`` is currently supported only for hive connector.
+
+Examples
+--------
+
+Revoke ``INSERT`` and ``SELECT`` privileges on the table ``orders`` from user ``alice``::
+
+    REVOKE
+    INSERT, SELECT
+    ON orders FROM alice;
+
+Revoke ``SELECT`` privilege on the table ``nation`` from everyone, additionally revoking the privilege to grant ``SELECT`` privilege::
+
+    REVOKE GRANT OPTION FOR
+    SELECT
+    ON nation FROM PUBLIC;
+
+REVOKE all privileges on the table ``test`` from user ``alice``::
+
+    REVOKE
+    ALL PRIVILEGES
+    ON test FROM alice;


### PR DESCRIPTION
@petroav can you please take a look?

A note about grant/revoke limitation: At present, the grant and revoke commands are only supported for hive connector. There are two places where I can mention this limitation: 
(1) On the “Grant” and “Revoke” pages, which will describe the respective syntax, and will go under “SQL Statement Syntax” in here https://prestodb.io/docs/current/sql.html 
(2) On individual connector pages, there is a section called "<Connector Name> Limitations”. For ex., for MySQL connector, if you scroll all the way to the bottom on this page https://prestodb.io/docs/current/connector/mysql.html, there is a section called "MySQL Connector Limitations” which lists the SQL statements not yet supported for MySQL. I can similarly list grant/revoke as a limitation for every connector except hive. 
I am leaning towards approach (1), since I think, not explicitly mentioning it on the syntax page would be misleading. But the current Presto documentation seems to follow (2).

Let me know what you think.
