### PR TITLE
Add singlenode-ldap profile

### DIFF
--- a/presto-product-tests/bin/run.sh
+++ b/presto-product-tests/bin/run.sh
@@ -7,12 +7,6 @@ function absolutepath() {
     [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
 }
 
-# If profile is singlenode-ldap, import the root certificate of presto-coordinator
-if [ "$PROFILE" = "singlenode-ldap" ]
-then
-    keytool -import -v -alias caroot -file "$LDAP_FILES_PATH"/caroot.cer -keystore "$LDAP_FILES_PATH"/cacerts.jks -storepass testldap -noprompt
-fi
-
 SCRIPT_DIR=$(dirname $(absolutepath "$0"))
 PRODUCT_TESTS_ROOT="${SCRIPT_DIR}/.."
 REPORT_DIR="${PRODUCT_TESTS_ROOT}/target/test-reports"

--- a/presto-product-tests/bin/run.sh
+++ b/presto-product-tests/bin/run.sh
@@ -7,6 +7,12 @@ function absolutepath() {
     [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
 }
 
+# If profile is singlenode-ldap, import the root certificate of presto-coordinator
+if [ "$PROFILE" = "singlenode-ldap" ]
+then
+    keytool -import -v -alias caroot -file "$LDAP_FILES_PATH"/caroot.cer -keystore "$LDAP_FILES_PATH"/cacerts.jks -storepass testldap -noprompt
+fi
+
 SCRIPT_DIR=$(dirname $(absolutepath "$0"))
 PRODUCT_TESTS_ROOT="${SCRIPT_DIR}/.."
 REPORT_DIR="${PRODUCT_TESTS_ROOT}/target/test-reports"

--- a/presto-product-tests/conf/docker/files/presto-launcher-wrapper.sh
+++ b/presto-product-tests/conf/docker/files/presto-launcher-wrapper.sh
@@ -4,8 +4,8 @@ set -e
 
 CONFIG=$1
 
-if [[ "$CONFIG" != "singlenode" && "$CONFIG" != "multinode-master" && "$CONFIG" != "multinode-worker" && "$CONFIG" != "singlenode-kerberized" ]]; then
-   echo "Usage: launcher-wrapper <singlenode|multinode-master|multinode-worker|singlenode-kerberized> <launcher args>"
+if [[ "$CONFIG" != "singlenode" && "$CONFIG" != "multinode-master" && "$CONFIG" != "multinode-worker" && "$CONFIG" != "singlenode-kerberized" && "$CONFIG" != "singlenode-ldap" ]]; then
+   echo "Usage: launcher-wrapper <singlenode|multinode-master|multinode-worker|singlenode-kerberized|singlenode-ldap> <launcher args>"
    exit 1
 fi
 

--- a/presto-product-tests/conf/docker/singlenode-ldap/compose.sh
+++ b/presto-product-tests/conf/docker/singlenode-ldap/compose.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+docker-compose \
+-f ${BASH_SOURCE%/*}/../common/standard.yml \
+-f ${BASH_SOURCE%/*}/../common/jdbc_db.yml \
+-f ${BASH_SOURCE%/*}/docker-compose.yml \
+"$@"

--- a/presto-product-tests/conf/docker/singlenode-ldap/docker-compose.yml
+++ b/presto-product-tests/conf/docker/singlenode-ldap/docker-compose.yml
@@ -1,0 +1,38 @@
+version: '2'
+services:
+  hadoop-master:
+    extends:
+      file: ../common/standard.yml
+      service: hadoop-master-common
+
+  presto-master:
+    extends:
+      file: ../common/standard.yml
+      service: presto-master-ldap
+    command: /docker/volumes/presto/presto-product-tests/conf/docker/files/presto-launcher-wrapper.sh singlenode-ldap run
+    depends_on:
+       - hadoop-master
+    extra_hosts:
+       - "ad-test.presto.testldap.com:10.25.171.180"
+
+  application-runner:
+    extends:
+      file: ../common/standard.yml
+      service: application-runner-common
+    depends_on:
+      - 'presto-master'
+    volumes_from:
+      - presto-master
+    environment:
+      - PROFILE=singlenode-ldap
+      - LDAP_FILES_PATH=/etc/ldap/rootca
+
+  postgres:
+    extends:
+      file: ../common/jdbc_db.yml
+      service: postgres-common
+
+  mysql:
+    extends:
+      file: ../common/jdbc_db.yml
+      service: mysql-common

--- a/presto-product-tests/conf/docker/singlenode-ldap/docker-compose.yml
+++ b/presto-product-tests/conf/docker/singlenode-ldap/docker-compose.yml
@@ -1,38 +1,13 @@
 version: '2'
 services:
-  hadoop-master:
-    extends:
-      file: ../common/standard.yml
-      service: hadoop-master-common
 
   presto-master:
-    extends:
-      file: ../common/standard.yml
-      service: presto-master-ldap
+    image: 'teradatalabs/centos6-java8-oracle-ldap'
     command: /docker/volumes/presto/presto-product-tests/conf/docker/files/presto-launcher-wrapper.sh singlenode-ldap run
-    depends_on:
-       - hadoop-master
     extra_hosts:
-       - "ad-test.presto.testldap.com:10.25.171.180"
+       - "${LDAP_SERVER_HOST}:${LDAP_SERVER_IP}"
 
   application-runner:
-    extends:
-      file: ../common/standard.yml
-      service: application-runner-common
-    depends_on:
-      - 'presto-master'
-    volumes_from:
-      - presto-master
-    environment:
-      - PROFILE=singlenode-ldap
-      - LDAP_FILES_PATH=/etc/ldap/rootca
-
-  postgres:
-    extends:
-      file: ../common/jdbc_db.yml
-      service: postgres-common
-
-  mysql:
-    extends:
-      file: ../common/jdbc_db.yml
-      service: mysql-common
+    image: 'teradatalabs/centos6-java8-oracle-ldap'
+    volumes:
+      - ../../../../presto-product-tests/conf/tempto/tempto-configuration-for-docker-ldap.yaml:/docker/volumes/tempto/tempto-configuration-local.yaml

--- a/presto-product-tests/conf/presto/etc/singlenode-ldap.properties
+++ b/presto-product-tests/conf/presto/etc/singlenode-ldap.properties
@@ -23,7 +23,7 @@ http-server.https.enabled=true
 http-server.https.keystore.path=/etc/ldap/coordinator.jks
 http-server.https.keystore.key=testldap
 authentication.ldap.enabled=true
-authentication.ldap.url=ldaps://ad-test.presto.testldap.com:636
+authentication.ldap.url=ldaps://ldap-server:636
 authentication.ldap.ad-domain=presto.testldap.com
 authentication.ldap.base-dn=OU=America,DC=presto,DC=testldap,DC=com
 authentication.ldap.group-dn=CN=finance,OU=America,DC=presto,DC=testldap,DC=com

--- a/presto-product-tests/conf/presto/etc/singlenode-ldap.properties
+++ b/presto-product-tests/conf/presto/etc/singlenode-ldap.properties
@@ -1,0 +1,29 @@
+#
+# WARNING
+# ^^^^^^^
+# This configuration file is for development only and should NOT be used be
+# used in production. For example configuration, see the Presto documentation.
+#
+
+node.id=will-be-overwritten
+node.environment=test
+
+coordinator=true
+node-scheduler.include-coordinator=true
+http-server.http.port=8080
+query.max-memory=1GB
+query.max-memory-per-node=512MB
+discovery-server.enabled=true
+discovery.uri=http://presto-master:8080
+
+# LDAP specific properties
+# https will have to enabled for ldap authentication
+http-server.https.port=8443
+http-server.https.enabled=true
+http-server.https.keystore.path=/etc/ldap/coordinator.jks
+http-server.https.keystore.key=testldap
+authentication.ldap.enabled=true
+authentication.ldap.url=ldaps://ad-test.presto.testldap.com:636
+authentication.ldap.ad-domain=presto.testldap.com
+authentication.ldap.base-dn=OU=America,DC=presto,DC=testldap,DC=com
+authentication.ldap.group-dn=CN=finance,OU=America,DC=presto,DC=testldap,DC=com

--- a/presto-product-tests/conf/tempto/tempto-configuration-for-docker-kerberos.yaml
+++ b/presto-product-tests/conf/tempto/tempto-configuration-for-docker-kerberos.yaml
@@ -18,7 +18,7 @@ databases:
     host: presto-master
     jdbc_user: hive
     cli_server_address: https://${databases.presto.host}:7778
-    cli_authentication: true
+    cli_kerberos_authentication: true
     cli_kerberos_principal: presto-client/presto-master@LABS.TERADATA.COM
     cli_kerberos_keytab: /etc/presto/conf/presto-client.keytab
     cli_kerberos_config_path: /etc/krb5.conf

--- a/presto-product-tests/conf/tempto/tempto-configuration-for-docker-ldap.yaml
+++ b/presto-product-tests/conf/tempto/tempto-configuration-for-docker-ldap.yaml
@@ -1,0 +1,28 @@
+databases:
+  hive:
+    host: hadoop-master
+  presto:
+    host: presto-master
+    configured_hdfs_user: hive
+    cli_ldap_authentication: true
+    cli_ldap_truststore_path: /etc/ldap/rootca/cacerts.jks
+    cli_ldap_truststore_password: testldap
+    cli_ldap_user_name: financeuser1
+    cli_ldap_user_password: TCAMPass123
+    cli_ldap_server_address: https://${databases.presto.host}:8443
+
+  mysql:
+    jdbc_driver_class: com.mysql.jdbc.Driver
+    jdbc_url: jdbc:mysql://mysql:3306/test
+    jdbc_user: root
+    jdbc_password: swarm
+    jdbc_pooling: true
+    table_manager_type: jdbc
+
+  postgres:
+    jdbc_driver_class: org.postgresql.Driver
+    jdbc_url: jdbc:postgresql://postgres:5432/test
+    jdbc_user: swarm
+    jdbc_password: swarm
+    jdbc_pooling: true
+    table_manager_type: jdbc

--- a/presto-product-tests/conf/tempto/tempto-configuration-for-docker-ldap.yaml
+++ b/presto-product-tests/conf/tempto/tempto-configuration-for-docker-ldap.yaml
@@ -5,10 +5,10 @@ databases:
     host: presto-master
     configured_hdfs_user: hive
     cli_ldap_authentication: true
-    cli_ldap_truststore_path: /etc/ldap/rootca/cacerts.jks
+    cli_ldap_truststore_path: /etc/ldap/cacerts.jks
     cli_ldap_truststore_password: testldap
     cli_ldap_user_name: financeuser1
-    cli_ldap_user_password: TCAMPass123
+    cli_ldap_user_password: password
     cli_ldap_server_address: https://${databases.presto.host}:8443
 
   mysql:

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoCliProcess.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoCliProcess.java
@@ -26,6 +26,7 @@ public final class PrestoCliProcess
         extends LocalCliProcess
 {
     private static final String PRESTO_PROMPT = "presto>";
+    private static final String LDAP_PASSWORD_PROMPT = "Enter password:";
     private static final Pattern PRESTO_PROMPT_PATTERN = Pattern.compile(quote(PRESTO_PROMPT));
 
     public PrestoCliProcess(Process process)
@@ -46,5 +47,10 @@ public final class PrestoCliProcess
     public void waitForPrompt()
     {
         assertThat(nextOutputToken()).isEqualTo(PRESTO_PROMPT);
+    }
+
+    public void waitForLdapPasswordPrompt()
+    {
+        assertThat((nextOutputToken().concat(" ")).concat(nextOutputToken())).isEqualTo(LDAP_PASSWORD_PROMPT);
     }
 }

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoCliTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoCliTests.java
@@ -92,6 +92,30 @@ public class PrestoCliTests
     @Named("databases.presto.jdbc_user")
     private String jdbcUser;
 
+    @Inject(optional = true)
+    @Named("databases.presto.cli_ldap_authentication")
+    private boolean ldapAuthentication;
+
+    @Inject(optional = true)
+    @Named("databases.presto.cli_ldap_truststore_path")
+    private String ldapTruststorePath;
+
+    @Inject(optional = true)
+    @Named("databases.presto.cli_ldap_truststore_password")
+    private String ldapTruststorePassword;
+
+    @Inject(optional = true)
+    @Named("databases.presto.cli_ldap_user_name")
+    private String ldapUserName;
+
+    @Inject(optional = true)
+    @Named("databases.presto.cli_ldap_server_address")
+    private String ldapServerAddress;
+
+    @Inject(optional = true)
+    @Named("databases.presto.cli_ldap_user_password")
+    private String ldapUserPassword;
+
     private PrestoCliProcess presto;
 
     public PrestoCliTests()
@@ -131,6 +155,7 @@ public class PrestoCliTests
             throws IOException, InterruptedException
     {
         launchPrestoCliWithServerArgument();
+        setLdapPassword();
         presto.waitForPrompt();
         presto.getProcessInput().println("select * from hive.default.nation;");
         assertThat(trimLines(presto.readLinesUntilPrompt())).containsAll(nationTableInteractiveLines);
@@ -141,6 +166,7 @@ public class PrestoCliTests
             throws IOException, InterruptedException
     {
         launchPrestoCliWithServerArgument("--execute", "select * from hive.default.nation;");
+        setLdapPassword();
         assertThat(trimLines(presto.readRemainingOutputLines())).containsAll(nationTableBatchLines);
     }
 
@@ -149,6 +175,7 @@ public class PrestoCliTests
             throws IOException, InterruptedException
     {
         launchPrestoCliWithServerArgument("--catalog", "hive", "--schema", "default", "--execute", "select * from nation;");
+        setLdapPassword();
         assertThat(trimLines(presto.readRemainingOutputLines())).containsAll(nationTableBatchLines);
     }
 
@@ -161,21 +188,32 @@ public class PrestoCliTests
         Files.write("select * from hive.default.nation;\n", temporayFile, UTF_8);
 
         launchPrestoCliWithServerArgument("--file", temporayFile.getAbsolutePath());
+        setLdapPassword();
         assertThat(trimLines(presto.readRemainingOutputLines())).containsAll(nationTableBatchLines);
     }
 
     private void launchPrestoCliWithServerArgument(String... arguments)
             throws IOException, InterruptedException
     {
-        if (!authentication) {
+        if (ldapAuthentication) {
+            requireNonNull(ldapTruststorePath, "databases.presto.cli_ldap_truststore_path is null");
+            requireNonNull(ldapTruststorePassword, "databases.presto.cli_ldap_truststore_password is null");
+            requireNonNull(ldapUserName, "databases.presto.cli_ldap_user_name is null");
+            requireNonNull(ldapServerAddress, "databases.presto.cli_ldap_server_address is null");
+            requireNonNull(ldapUserPassword, "databases.presto.cli_ldap_user_password is null");
+
             ImmutableList.Builder<String> prestoClientOptions = ImmutableList.builder();
             prestoClientOptions.add(
-                    "--server", serverAddress,
-                    "--user", jdbcUser);
+                    "--server", ldapServerAddress,
+                    "--truststore-path", ldapTruststorePath,
+                    "--truststore-password", ldapTruststorePassword,
+                    "--user", ldapUserName,
+                    "--password");
+
             prestoClientOptions.add(arguments);
             launchPrestoCli(prestoClientOptions.build());
         }
-        else {
+        else if (authentication) {
             requireNonNull(kerberosPrincipal, "databases.presto.cli_kerberos_principal is null");
             requireNonNull(kerberosKeytab, "databases.presto.cli_kerberos_keytab is null");
             requireNonNull(kerberosServiceName, "databases.presto.cli_kerberos_service_name is null");
@@ -200,6 +238,14 @@ public class PrestoCliTests
             prestoClientOptions.add(arguments);
             launchPrestoCli(prestoClientOptions.build());
         }
+        else {
+            ImmutableList.Builder<String> prestoClientOptions = ImmutableList.builder();
+            prestoClientOptions.add(
+                    "--server", serverAddress,
+                    "--user", jdbcUser);
+            prestoClientOptions.add(arguments);
+            launchPrestoCli(prestoClientOptions.build());
+        }
     }
 
     private void launchPrestoCli(String... arguments)
@@ -212,5 +258,14 @@ public class PrestoCliTests
             throws IOException, InterruptedException
     {
         presto = new PrestoCliProcess(defaultJavaProcessLauncher().launch(Presto.class, arguments));
+    }
+
+    private void setLdapPassword()
+    {
+        if (ldapAuthentication) {
+            presto.waitForLdapPasswordPrompt();
+            presto.getProcessInput().println(ldapUserPassword);
+            presto.nextOutputToken();
+        }
     }
 }


### PR DESCRIPTION
A new profile is created for testing ldap authentication.
Add basic infrastructure to support writing additional
product-test for LDAP authentication.
