### PR TITLE
Make Spiller Factory pluggable

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -135,6 +135,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import static com.facebook.presto.execution.scheduler.NodeSchedulerConfig.NetworkTopologyType.FLAT;
 import static com.facebook.presto.execution.scheduler.NodeSchedulerConfig.NetworkTopologyType.LEGACY;
 import static com.facebook.presto.server.ConditionalModule.conditionalModule;
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.SpillerImplementation.BINARY_FILE;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.nullToEmpty;
 import static com.google.common.reflect.Reflection.newProxy;
@@ -391,7 +392,10 @@ public class ServerMainModule
         binder.bind(FinalizerService.class).in(Scopes.SINGLETON);
 
         // Spiller
-        binder.bind(SpillerFactory.class).to(BinarySpillerFactory.class).in(Scopes.SINGLETON);
+        install(conditionalModule(
+                FeaturesConfig.class,
+                config -> BINARY_FILE.equalsIgnoreCase(config.getSpillerImplementation()),
+                moduleBinder -> moduleBinder.bind(SpillerFactory.class).to(BinarySpillerFactory.class).in(Scopes.SINGLETON)));
     }
 
     @Provides

--- a/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
@@ -30,6 +30,7 @@ import com.facebook.presto.server.ServerMainModule;
 import com.facebook.presto.server.ShutdownAction;
 import com.facebook.presto.spi.Node;
 import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.spiller.SpillerFactory;
 import com.facebook.presto.split.SplitManager;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.parser.SqlParserOptions;
@@ -106,6 +107,7 @@ public class TestingPrestoServer
     private final Announcer announcer;
     private final QueryManager queryManager;
     private final TaskManager taskManager;
+    private final SpillerFactory spillerFactory;
     private final GracefulShutdownHandler gracefulShutdownHandler;
     private final ShutdownAction shutdownAction;
     private final boolean coordinator;
@@ -258,6 +260,7 @@ public class TestingPrestoServer
         serviceSelectorManager = injector.getInstance(ServiceSelectorManager.class);
         gracefulShutdownHandler = injector.getInstance(GracefulShutdownHandler.class);
         taskManager = injector.getInstance(TaskManager.class);
+        spillerFactory = injector.getInstance(SpillerFactory.class);
         shutdownAction = injector.getInstance(ShutdownAction.class);
         announcer = injector.getInstance(Announcer.class);
 
@@ -372,6 +375,11 @@ public class TestingPrestoServer
     public TaskManager getTaskManager()
     {
         return taskManager;
+    }
+
+    public SpillerFactory getSpillerFactory()
+    {
+        return spillerFactory;
     }
 
     public ShutdownAction getShutdownAction()

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -37,6 +37,11 @@ public class FeaturesConfig
         public static final List<String> AVAILABLE_OPTIONS = ImmutableList.of(DISABLED, COLUMNAR, COLUMNAR_DICTIONARY);
     }
 
+    public static class SpillerImplementation
+    {
+        public static final String BINARY_FILE = "binary_file";
+    }
+
     public static final String FILE_BASED_RESOURCE_GROUP_MANAGER = "file";
     private boolean experimentalSyntaxEnabled;
     private boolean distributedIndexJoinsEnabled;
@@ -58,6 +63,7 @@ public class FeaturesConfig
     private int re2JDfaRetries = 5;
     private RegexLibrary regexLibrary = JONI;
     private DataSize operatorMemoryLimitBeforeSpill = new DataSize(0, DataSize.Unit.MEGABYTE);
+    private String spillerImplementation = SpillerImplementation.BINARY_FILE;
 
     @NotNull
     public String getResourceGroupManager()
@@ -268,6 +274,19 @@ public class FeaturesConfig
     public FeaturesConfig setOperatorMemoryLimitBeforeSpill(DataSize operatorMemoryLimitBeforeSpill)
     {
         this.operatorMemoryLimitBeforeSpill = operatorMemoryLimitBeforeSpill;
+        return this;
+    }
+
+    @NotNull
+    public String getSpillerImplementation()
+    {
+        return spillerImplementation;
+    }
+
+    @Config("experimental.spiller-implementation")
+    public FeaturesConfig setSpillerImplementation(String spillerImplementation)
+    {
+        this.spillerImplementation = spillerImplementation;
         return this;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/spiller/TestSpillerFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/spiller/TestSpillerFactory.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.spiller;
+
+import com.facebook.presto.server.testing.TestingPrestoServer;
+import com.facebook.presto.spi.spiller.Spiller;
+import com.facebook.presto.spi.spiller.SpillerFactory;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static io.airlift.testing.Assertions.assertInstanceOf;
+
+public class TestSpillerFactory
+{
+    @Test
+    public void testOverrideDefaultSpiller()
+            throws Exception
+    {
+        ImmutableList<Module> additionalModules = ImmutableList.of(new CustomSpillerModule());
+        ImmutableMap<String, String> serverProperties = ImmutableMap.of("experimental.spiller-implementation", "custom");
+        try (TestingPrestoServer server = new TestingPrestoServer(true, serverProperties, null, null, additionalModules)) {
+            assertInstanceOf(server.getSpillerFactory(), CustomSpillerFactory.class);
+        }
+    }
+
+    private static class CustomSpillerModule
+            implements Module
+    {
+        @Override
+        public void configure(Binder binder)
+        {
+            binder.bind(SpillerFactory.class).to(CustomSpillerFactory.class).in(Scopes.SINGLETON);
+        }
+    }
+
+    private static class CustomSpillerFactory
+            implements SpillerFactory
+    {
+        @Override
+        public Spiller create(List<Type> types)
+        {
+            throw new IllegalStateException("Must not be called");
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.FILE_BASED_RESOURCE_GROUP_MANAGER;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.ProcessingOptimization.COLUMNAR_DICTIONARY;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.ProcessingOptimization.DISABLED;
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.SpillerImplementation.BINARY_FILE;
 import static com.facebook.presto.sql.analyzer.RegexLibrary.JONI;
 import static com.facebook.presto.sql.analyzer.RegexLibrary.RE2J;
 import static io.airlift.configuration.testing.ConfigAssertions.assertDeprecatedEquivalence;
@@ -51,7 +52,8 @@ public class TestFeaturesConfig
                 .setRe2JDfaStatesLimit(Integer.MAX_VALUE)
                 .setRe2JDfaRetries(5)
                 .setResourceGroupManager(FILE_BASED_RESOURCE_GROUP_MANAGER)
-                .setOperatorMemoryLimitBeforeSpill(DataSize.valueOf("0MB")));
+                .setOperatorMemoryLimitBeforeSpill(DataSize.valueOf("0MB"))
+                .setSpillerImplementation(BINARY_FILE));
     }
 
     @Test
@@ -75,6 +77,7 @@ public class TestFeaturesConfig
                 .put("re2j.dfa-retries", "42")
                 .put("resource-group-manager", "test")
                 .put("experimental.operator-memory-limit-before-spill", "100MB")
+                .put("experimental.spiller-implementation", "custom")
                 .build();
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("experimental-syntax-enabled", "true")
@@ -94,6 +97,7 @@ public class TestFeaturesConfig
                 .put("re2j.dfa-retries", "42")
                 .put("resource-group-manager", "test")
                 .put("experimental.operator-memory-limit-before-spill", "100MB")
+                .put("experimental.spiller-implementation", "custom")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -113,7 +117,8 @@ public class TestFeaturesConfig
                 .setRe2JDfaStatesLimit(42)
                 .setRe2JDfaRetries(42)
                 .setResourceGroupManager("test")
-                .setOperatorMemoryLimitBeforeSpill(DataSize.valueOf("100MB"));
+                .setOperatorMemoryLimitBeforeSpill(DataSize.valueOf("100MB"))
+                .setSpillerImplementation("custom");
 
         assertFullMapping(properties, expected);
         assertDeprecatedEquivalence(FeaturesConfig.class, properties, propertiesLegacy);


### PR DESCRIPTION
Implemented by analogy to NetworkTopology.
To replace the default SpillerFactory implementation, which is
BinaryFileSpillerFactory, the `experimental.spiller-implementation`
property must be set to `custom`, and the custom implementation must be
provided by the additional module in `PrestoServer#getAdditionalModules`.
