### PR TITLE
Fix configured_hdfs_user value in kerberos tempto config

### DIFF
--- a/presto-product-tests/conf/tempto/tempto-configuration-for-docker-kerberos.yaml
+++ b/presto-product-tests/conf/tempto/tempto-configuration-for-docker-kerberos.yaml
@@ -26,7 +26,7 @@ databases:
     cli_keystore: /etc/presto/conf/keystore.jks
     cli_keystore_password: password
     cli_kerberos_use_canonical_hostname: false
-    configured_hdfs_user: hive
+    configured_hdfs_user: hdfs
 
   mysql:
     jdbc_driver_class: com.mysql.jdbc.Driver


### PR DESCRIPTION
This commit fixes the failing product test `testHdfsImpersonationDisabled()`.

The product test `testHdfsImpersonationDisabled()` in `ImpersonationTests.java` expects the table owner value, `hdfs`, to match the `configured_hdfs_user` value defined in `tempto-configuration-for-docker-kerberos.yaml` file. This test started failing since the `configured_hdfs_user` was changed to `hive` in https://github.com/prestodb/presto/pull/5621. This commit reverts this value back to its original value, `hdfs`.

Testing: Ran tests in `ImpersonationTests.java` for kerberos profile.
`./presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-impersonation -g hdfs_impersonation`
`./presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-no-impersonation -g hdfs_no_impersonation`
