### PR TITLE
Move MySql PostgreSQL to base tempto yaml

### DIFF
--- a/presto-product-tests/conf/tempto/tempto-configuration-for-docker-default.yaml
+++ b/presto-product-tests/conf/tempto/tempto-configuration-for-docker-default.yaml
@@ -4,19 +4,3 @@ databases:
   presto:
     host: presto-master
     configured_hdfs_user: hive
-
-  mysql:
-    jdbc_driver_class: com.mysql.jdbc.Driver
-    jdbc_url: jdbc:mysql://mysql:3306/test
-    jdbc_user: root
-    jdbc_password: swarm
-    jdbc_pooling: true
-    table_manager_type: jdbc
-
-  postgres:
-    jdbc_driver_class: org.postgresql.Driver
-    jdbc_url: jdbc:postgresql://postgres:5432/test
-    jdbc_user: swarm
-    jdbc_password: swarm
-    jdbc_pooling: true
-    table_manager_type: jdbc

--- a/presto-product-tests/conf/tempto/tempto-configuration-for-docker-kerberos.yaml
+++ b/presto-product-tests/conf/tempto/tempto-configuration-for-docker-kerberos.yaml
@@ -27,19 +27,3 @@ databases:
     cli_keystore_password: password
     cli_kerberos_use_canonical_hostname: false
     configured_hdfs_user: hdfs
-
-  mysql:
-    jdbc_driver_class: com.mysql.jdbc.Driver
-    jdbc_url: jdbc:mysql://mysql:3306/test
-    jdbc_user: root
-    jdbc_password: swarm
-    jdbc_pooling: true
-    table_manager_type: jdbc
-
-  postgres:
-    jdbc_driver_class: org.postgresql.Driver
-    jdbc_url: jdbc:postgresql://postgres:5432/test
-    jdbc_user: swarm
-    jdbc_password: swarm
-    jdbc_pooling: true
-    table_manager_type: jdbc

--- a/presto-product-tests/src/main/resources/tempto-configuration.yaml
+++ b/presto-product-tests/src/main/resources/tempto-configuration.yaml
@@ -50,6 +50,22 @@ databases:
     jdbc_password: na
     jdbc_pooling: false
 
+  mysql:
+    jdbc_driver_class: com.mysql.jdbc.Driver
+    jdbc_url: jdbc:mysql://mysql:3306/test
+    jdbc_user: root
+    jdbc_password: swarm
+    jdbc_pooling: true
+    table_manager_type: jdbc
+
+  postgres:
+    jdbc_driver_class: org.postgresql.Driver
+    jdbc_url: jdbc:postgresql://postgres:5432/test
+    jdbc_user: swarm
+    jdbc_password: swarm
+    jdbc_pooling: true
+    table_manager_type: jdbc
+
 tests:
   hdfs:
     path: /product-test


### PR DESCRIPTION
MySql and PostgreSQL tests are running for all the profiles. Instead of
specifying them in each tempto config file, we can move them to base tempto-
configuration.yaml.
