### PR TITLE
Implement group based authorization for openLDAP

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/security/LdapBinder.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/LdapBinder.java
@@ -13,11 +13,9 @@
  */
 package com.facebook.presto.server.security;
 
-import javax.naming.directory.DirContext;
-
 public interface LdapBinder
 {
     String getBindDistinguishedName(String user);
 
-    boolean checkForGroupMembership(String user, String groupDistinguishedName, DirContext context);
+    String getUserSearchInput();
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/security/LdapServerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/LdapServerConfig.java
@@ -20,10 +20,10 @@ public class LdapServerConfig
     private String ldapUrl;
     private String baseDistinguishedName;
     private boolean authenticationEnabled;
-    private String serverType = ServerType.ACTIVE_DIRECTORY.name();
+    private String serverType;
     private String activeDirectoryDomain;
     private String groupDistinguishedName;
-    private String userObjectClass = "person";
+    private String userObjectClass;
 
     public static enum ServerType
     {

--- a/presto-main/src/main/java/com/facebook/presto/server/security/OpenLdapBinder.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/OpenLdapBinder.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.server.security;
 
 import javax.inject.Inject;
-import javax.naming.directory.DirContext;
 
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -37,8 +36,8 @@ public class OpenLdapBinder
     }
 
     @Override
-    public boolean checkForGroupMembership(String user, String groupDistinguishedName, DirContext context)
+    public String getUserSearchInput()
     {
-        throw new UnsupportedOperationException("Group membership based authorization not yet supported");
+        return "uid";
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/server/security/TestLdapServerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/security/TestLdapServerConfig.java
@@ -32,8 +32,8 @@ public class TestLdapServerConfig
                 .setBaseDistinguishedName(null)
                 .setActiveDirectoryDomain(null)
                 .setAuthenticationEnabled(false)
-                .setServerType("ACTIVE_DIRECTORY")
-                .setUserObjectClass("person")
+                .setServerType(null)
+                .setUserObjectClass(null)
                 .setGroupDistinguishedName(null));
     }
 


### PR DESCRIPTION
Once the user's password is validated, the user's credentials will be
used to check if the user belongs to a particular group. The server
property 'authentication.ldap.group-dn' must have the group's
distinguished name.

This commit handles group check for OpenLDAP.
