### PR TITLE
Fix readme of product tests to enable MySQL and PostgreSQL connectors

### DIFF
--- a/presto-product-tests/README.md
+++ b/presto-product-tests/README.md
@@ -237,7 +237,7 @@ setup outlined below:
     presto-product-tests/conf/docker/singlenode/compose.sh logs
     ```
     
-3. Add an IP-to-host mapping for the `hadoop-master` host in `/etc/hosts`.
+3. Add an IP-to-host mapping for the `hadoop-master`, `mysql` and `postgres` hosts in `/etc/hosts`.
 The format of `/etc/hosts` entries is `<ip> <host>`:
 
     - On GNU/Linux add the following mapping: `<container ip> hadoop-master`.
@@ -247,9 +247,16 @@ The format of `/etc/hosts` entries is `<ip> <host>`:
         docker inspect $(presto-product-tests/conf/docker/singlenode/compose.sh ps -q hadoop-master) | grep -i IPAddress
         ```
 
-    - On OS X add the following mapping: `<docker machine ip> hadoop-master`.
+    Similarly add mappings for MySQL and Postgres containers (`mysql` and `postgres` hostnames respectively). To check IPs for those containers run:
+
+        ```
+        docker inspect $(presto-product-tests/conf/docker/singlenode/compose.sh ps -q mysql) | grep -i IPAddress
+        docker inspect $(presto-product-tests/conf/docker/singlenode/compose.sh ps -q postgres) | grep -i IPAddress
+        ```
+
+    - On OS X add the following mapping: `<docker machine ip> hadoop-master mysql postgres`.
     Since Docker containers run inside a Linux VM, on OS X we map the VM IP to
-    the `hadoop-master` hostname. To obtain the IP of the Linux VM run:
+    the `hadoop-master`, `mysql` and `postgres` hostnames. To obtain the IP of the Linux VM run:
 
         ```
         docker-machine ip <machine>

--- a/presto-product-tests/conf/docker/common/jdbc_db.yml
+++ b/presto-product-tests/conf/docker/common/jdbc_db.yml
@@ -5,17 +5,20 @@ services:
     hostname: postgres
     image: 'postgres'
     ports:
-      - '15432:5432'
+      - '15432:15432'
     environment:
       POSTGRES_PASSWORD: swarm
       POSTGRES_USER: swarm
       POSTGRES_DB: test
+      PGPORT: 15432
 
   mysql:
     hostname: mysql
     image: 'mysql'
     ports:
-      - '13306:3306'
+      - '13306:13306'
+    command:
+      mysqld --port 13306
     environment:
       MYSQL_USER: swarm
       MYSQL_PASSWORD: swarm

--- a/presto-product-tests/conf/presto/etc/catalog/mysql.properties
+++ b/presto-product-tests/conf/presto/etc/catalog/mysql.properties
@@ -1,4 +1,4 @@
 connector.name=mysql
-connection-url=jdbc:mysql://mysql:3306/test
+connection-url=jdbc:mysql://mysql:13306/test
 connection-user=root
 connection-password=swarm

--- a/presto-product-tests/conf/presto/etc/catalog/postgresql.properties
+++ b/presto-product-tests/conf/presto/etc/catalog/postgresql.properties
@@ -1,4 +1,4 @@
 connector.name=postgresql
-connection-url=jdbc:postgresql://postgres:5432/test
+connection-url=jdbc:postgresql://postgres:15432/test
 connection-user=swarm
 connection-password=swarm

--- a/presto-product-tests/conf/presto/etc/config.properties
+++ b/presto-product-tests/conf/presto/etc/config.properties
@@ -31,7 +31,9 @@ plugin.bundles=\
   ../../../presto-hive-cdh5/pom.xml,\
   ../../../presto-teradata-functions/pom.xml,\
   ../../../presto-tpch/pom.xml,\
-  ../../../presto-blackhole/pom.xml
+  ../../../presto-blackhole/pom.xml,\
+  ../../../presto-mysql/pom.xml,\
+  ../../../presto-postgresql/pom.xml
 
 presto.version=testversion
 experimental-syntax-enabled=true

--- a/presto-product-tests/conf/tempto/tempto-configuration-for-docker-default.yaml
+++ b/presto-product-tests/conf/tempto/tempto-configuration-for-docker-default.yaml
@@ -7,7 +7,7 @@ databases:
 
   mysql:
     jdbc_driver_class: com.mysql.jdbc.Driver
-    jdbc_url: jdbc:mysql://mysql:3306/test
+    jdbc_url: jdbc:mysql://mysql:13306/test
     jdbc_user: root
     jdbc_password: swarm
     jdbc_pooling: true
@@ -15,7 +15,7 @@ databases:
 
   postgres:
     jdbc_driver_class: org.postgresql.Driver
-    jdbc_url: jdbc:postgresql://postgres:5432/test
+    jdbc_url: jdbc:postgresql://postgres:15432/test
     jdbc_user: swarm
     jdbc_password: swarm
     jdbc_pooling: true

--- a/presto-product-tests/conf/tempto/tempto-configuration-for-docker-kerberos.yaml
+++ b/presto-product-tests/conf/tempto/tempto-configuration-for-docker-kerberos.yaml
@@ -30,7 +30,7 @@ databases:
 
   mysql:
     jdbc_driver_class: com.mysql.jdbc.Driver
-    jdbc_url: jdbc:mysql://mysql:3306/test
+    jdbc_url: jdbc:mysql://mysql:13306/test
     jdbc_user: root
     jdbc_password: swarm
     jdbc_pooling: true
@@ -38,7 +38,7 @@ databases:
 
   postgres:
     jdbc_driver_class: org.postgresql.Driver
-    jdbc_url: jdbc:postgresql://postgres:5432/test
+    jdbc_url: jdbc:postgresql://postgres:15432/test
     jdbc_user: swarm
     jdbc_password: swarm
     jdbc_pooling: true


### PR DESCRIPTION
This fixes https://github.com/prestodb/presto/issues/5812
