### PR TITLE
Support long prepared statements

### DIFF
--- a/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/BenchmarkQueryRunner.java
+++ b/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/BenchmarkQueryRunner.java
@@ -16,6 +16,7 @@ package com.facebook.presto.benchmark.driver;
 import com.facebook.presto.client.ClientSession;
 import com.facebook.presto.client.QueryError;
 import com.facebook.presto.client.QueryResults;
+import com.facebook.presto.client.QuerySubmission;
 import com.facebook.presto.client.StatementClient;
 import com.facebook.presto.client.StatementStats;
 import com.google.common.base.Throwables;
@@ -61,6 +62,7 @@ public class BenchmarkQueryRunner
     private final HttpClient httpClient;
     private final List<URI> nodes;
     private final JsonCodec<QueryResults> queryResultsCodec;
+    private final JsonCodec<QuerySubmission> querySubmissionCodec;
 
     private int failures;
 
@@ -78,6 +80,7 @@ public class BenchmarkQueryRunner
         this.debug = debug;
 
         this.queryResultsCodec = jsonCodec(QueryResults.class);
+        this.querySubmissionCodec = jsonCodec(QuerySubmission.class);
 
         requireNonNull(socksProxy, "socksProxy is null");
         HttpClientConfig httpClientConfig = new HttpClientConfig();
@@ -149,7 +152,7 @@ public class BenchmarkQueryRunner
         failures = 0;
         while (true) {
             // start query
-            StatementClient client = new StatementClient(httpClient, queryResultsCodec, session, "show schemas");
+            StatementClient client = new StatementClient(httpClient, queryResultsCodec, querySubmissionCodec, session, "show schemas");
 
             // read query output
             ImmutableList.Builder<String> schemas = ImmutableList.builder();
@@ -190,7 +193,7 @@ public class BenchmarkQueryRunner
     private StatementStats execute(ClientSession session, String name, String query)
     {
         // start query
-        StatementClient client = new StatementClient(httpClient, queryResultsCodec, session, query);
+        StatementClient client = new StatementClient(httpClient, queryResultsCodec, querySubmissionCodec, session, query);
 
         // read query output
         while (client.isValid() && client.advance()) {

--- a/presto-cli/src/main/java/com/facebook/presto/cli/QueryRunner.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/QueryRunner.java
@@ -15,6 +15,7 @@ package com.facebook.presto.cli;
 
 import com.facebook.presto.client.ClientSession;
 import com.facebook.presto.client.QueryResults;
+import com.facebook.presto.client.QuerySubmission;
 import com.facebook.presto.client.StatementClient;
 import com.google.common.collect.ImmutableList;
 import com.google.common.net.HostAndPort;
@@ -42,10 +43,12 @@ public class QueryRunner
     private final JsonCodec<QueryResults> queryResultsCodec;
     private final AtomicReference<ClientSession> session;
     private final HttpClient httpClient;
+    private final JsonCodec<QuerySubmission> querySubmissionCodec;
 
     public QueryRunner(
             ClientSession session,
             JsonCodec<QueryResults> queryResultsCodec,
+            JsonCodec<QuerySubmission> querySubmissionCodec,
             Optional<HostAndPort> socksProxy,
             Optional<String> keystorePath,
             Optional<String> keystorePassword,
@@ -58,6 +61,7 @@ public class QueryRunner
     {
         this.session = new AtomicReference<>(requireNonNull(session, "session is null"));
         this.queryResultsCodec = requireNonNull(queryResultsCodec, "queryResultsCodec is null");
+        this.querySubmissionCodec = requireNonNull(querySubmissionCodec, "querySubmissionCodec is null");
         this.httpClient = new JettyHttpClient(
                 getHttpClientConfig(socksProxy, keystorePath, keystorePassword, truststorePath, truststorePassword, kerberosPrincipal, kerberosRemoteServiceName, authenticationEnabled),
                 kerberosConfig,
@@ -82,7 +86,7 @@ public class QueryRunner
 
     public StatementClient startInternalQuery(String query)
     {
-        return new StatementClient(httpClient, queryResultsCodec, session.get(), query);
+        return new StatementClient(httpClient, queryResultsCodec, querySubmissionCodec, session.get(), query);
     }
 
     @Override
@@ -106,6 +110,7 @@ public class QueryRunner
         return new QueryRunner(
                 session,
                 jsonCodec(QueryResults.class),
+                jsonCodec(QuerySubmission.class),
                 socksProxy,
                 keystorePath,
                 keystorePassword,

--- a/presto-client/src/main/java/com/facebook/presto/client/PrestoHeaders.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/PrestoHeaders.java
@@ -38,6 +38,7 @@ public final class PrestoHeaders
     public static final String PRESTO_PAGE_TOKEN = "X-Presto-Page-Sequence-Id";
     public static final String PRESTO_PAGE_NEXT_TOKEN = "X-Presto-Page-End-Sequence-Id";
     public static final String PRESTO_BUFFER_COMPLETE = "X-Presto-Buffer-Complete";
+    public static final String PRESTO_PREPARED_STATEMENT_IN_BODY = "X-Presto-Prepared-Statement-In-Body";
 
     private PrestoHeaders() {}
 }

--- a/presto-client/src/main/java/com/facebook/presto/client/QueryResults.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/QueryResults.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
@@ -77,6 +79,8 @@ public class QueryResults
     private final QueryError error;
     private final String updateType;
     private final Long updateCount;
+    private final Map<String, String> addedPreparedStatements;
+    private final Set<String> deallocatedPreparedStatements;
 
     @JsonCreator
     public QueryResults(
@@ -89,9 +93,11 @@ public class QueryResults
             @JsonProperty("stats") StatementStats stats,
             @JsonProperty("error") QueryError error,
             @JsonProperty("updateType") String updateType,
-            @JsonProperty("updateCount") Long updateCount)
+            @JsonProperty("updateCount") Long updateCount,
+            @JsonProperty("addedPreparedStatements") Map<String, String> addedPreparedStatements,
+            @JsonProperty("deallocatedPreparedStatements") Set<String> deallocatedPreparedStatements)
     {
-        this(id, infoUri, partialCancelUri, nextUri, columns, fixData(columns, data), stats, error, updateType, updateCount);
+        this(id, infoUri, partialCancelUri, nextUri, columns, fixData(columns, data), stats, error, updateType, updateCount, addedPreparedStatements, deallocatedPreparedStatements);
     }
 
     public QueryResults(
@@ -104,7 +110,9 @@ public class QueryResults
             StatementStats stats,
             QueryError error,
             String updateType,
-            Long updateCount)
+            Long updateCount,
+            Map<String, String> addedPreparedStatements,
+            Set<String> deallocatedPreparedStatements)
     {
         this.id = requireNonNull(id, "id is null");
         this.infoUri = requireNonNull(infoUri, "infoUri is null");
@@ -116,6 +124,10 @@ public class QueryResults
         this.error = error;
         this.updateType = updateType;
         this.updateCount = updateCount;
+        requireNonNull(addedPreparedStatements, "addedPreparedStatements is null");
+        this.addedPreparedStatements = ImmutableMap.copyOf(addedPreparedStatements);
+        requireNonNull(deallocatedPreparedStatements, "deallocatedPreparedStatements is null");
+        this.deallocatedPreparedStatements = ImmutableSet.copyOf(deallocatedPreparedStatements);
     }
 
     @NotNull
@@ -188,6 +200,20 @@ public class QueryResults
         return updateCount;
     }
 
+    @NotNull
+    @JsonProperty
+    public Map<String, String> getAddedPreparedStatements()
+    {
+        return addedPreparedStatements;
+    }
+
+    @NotNull
+    @JsonProperty
+    public Set<String> getDeallocatedPreparedStatements()
+    {
+        return deallocatedPreparedStatements;
+    }
+
     @Override
     public String toString()
     {
@@ -202,6 +228,8 @@ public class QueryResults
                 .add("error", error)
                 .add("updateType", updateType)
                 .add("updateCount", updateCount)
+                .add("addedPreparedStatements", addedPreparedStatements)
+                .add("deallocatedPreparedStatements", deallocatedPreparedStatements)
                 .toString();
     }
 

--- a/presto-client/src/main/java/com/facebook/presto/client/QuerySubmission.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/QuerySubmission.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.client;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.Map;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * For use with /v1/statement when you send prepared statements via that
+ */
+@Immutable
+public class QuerySubmission
+{
+    private final String query;
+    private final Map<String, String> preparedStatements;
+
+    @JsonCreator
+    public QuerySubmission(
+            @JsonProperty("query") String query,
+            @JsonProperty("preparedStatements") Map<String, String> preparedStatements)
+    {
+        this.query = requireNonNull(query, "query is null");
+        this.preparedStatements = requireNonNull(preparedStatements, "preparedStatements is null");
+    }
+
+    @JsonProperty
+    public String getQuery()
+    {
+        return query;
+    }
+
+    @JsonProperty
+    public Map<String, String> getPreparedStatements()
+    {
+        return preparedStatements;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("query", query)
+                .add("preparedStatements", preparedStatements)
+                .toString();
+    }
+}

--- a/presto-client/src/main/java/com/facebook/presto/client/StatementClient.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/StatementClient.java
@@ -61,13 +61,13 @@ import static io.airlift.http.client.FullJsonResponseHandler.createFullJsonRespo
 import static io.airlift.http.client.HttpStatus.Family;
 import static io.airlift.http.client.HttpStatus.familyForStatusCode;
 import static io.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
+import static io.airlift.http.client.JsonBodyGenerator.jsonBodyGenerator;
 import static io.airlift.http.client.Request.Builder.prepareDelete;
 import static io.airlift.http.client.Request.Builder.prepareGet;
 import static io.airlift.http.client.Request.Builder.preparePost;
-import static io.airlift.http.client.StaticBodyGenerator.createStaticBodyGenerator;
 import static io.airlift.http.client.StatusResponseHandler.StatusResponse;
 import static io.airlift.http.client.StatusResponseHandler.createStatusResponseHandler;
-import static java.nio.charset.StandardCharsets.UTF_8;
+import static io.airlift.json.JsonCodec.jsonCodec;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
@@ -98,11 +98,18 @@ public class StatementClient
     private final String timeZoneId;
     private final long requestTimeoutNanos;
     private final String user;
+    private final JsonCodec<QuerySubmission> querySubmissionCodec;
 
     public StatementClient(HttpClient httpClient, JsonCodec<QueryResults> queryResultsCodec, ClientSession session, String query)
     {
+        this(httpClient, queryResultsCodec, jsonCodec(QuerySubmission.class), session, query);
+    }
+
+    public StatementClient(HttpClient httpClient, JsonCodec<QueryResults> queryResultsCodec, JsonCodec<QuerySubmission> querySubmissionCodec, ClientSession session, String query)
+    {
         requireNonNull(httpClient, "httpClient is null");
         requireNonNull(queryResultsCodec, "queryResultsCodec is null");
+        requireNonNull(querySubmissionCodec, "querySubmissionCodec is null");
         requireNonNull(session, "session is null");
         requireNonNull(query, "query is null");
 
@@ -113,6 +120,7 @@ public class StatementClient
         this.query = query;
         this.requestTimeoutNanos = session.getClientRequestTimeout().roundTo(NANOSECONDS);
         this.user = session.getUser();
+        this.querySubmissionCodec = querySubmissionCodec;
 
         Request request = buildQueryRequest(session, query);
         JsonResponse<QueryResults> response = httpClient.execute(request, responseHandler);
@@ -127,7 +135,8 @@ public class StatementClient
     private Request buildQueryRequest(ClientSession session, String query)
     {
         Request.Builder builder = prepareRequest(preparePost(), uriBuilderFrom(session.getServer()).replacePath("/v1/statement").build())
-                .setBodyGenerator(createStaticBodyGenerator(query, UTF_8));
+                .setBodyGenerator(jsonBodyGenerator(querySubmissionCodec, new QuerySubmission(query, session.getPreparedStatements())));
+        builder.setHeader(PrestoHeaders.PRESTO_PREPARED_STATEMENT_IN_BODY, "true");
 
         if (session.getSource() != null) {
             builder.setHeader(PrestoHeaders.PRESTO_SOURCE, session.getSource());
@@ -144,11 +153,6 @@ public class StatementClient
         Map<String, String> property = session.getProperties();
         for (Entry<String, String> entry : property.entrySet()) {
             builder.addHeader(PrestoHeaders.PRESTO_SESSION, entry.getKey() + "=" + entry.getValue());
-        }
-
-        Map<String, String> statements = session.getPreparedStatements();
-        for (Entry<String, String> entry : statements.entrySet()) {
-            builder.addHeader(PrestoHeaders.PRESTO_PREPARED_STATEMENT, urlEncode(entry.getKey()) + "=" + urlEncode(entry.getValue()));
         }
 
         builder.setHeader(PrestoHeaders.PRESTO_TRANSACTION_ID, session.getTransactionId() == null ? "NONE" : session.getTransactionId());

--- a/presto-client/src/main/java/com/facebook/presto/client/StatementClient.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/StatementClient.java
@@ -47,10 +47,9 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static com.facebook.presto.client.PrestoHeaders.PRESTO_ADDED_PREPARE;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_CLEAR_SESSION;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_CLEAR_TRANSACTION_ID;
-import static com.facebook.presto.client.PrestoHeaders.PRESTO_DEALLOCATED_PREPARE;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_PREPARED_STATEMENT_IN_BODY;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_SET_SESSION;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_STARTED_TRANSACTION_ID;
 import static com.google.common.base.MoreObjects.firstNonNull;
@@ -246,6 +245,7 @@ public class StatementClient
     {
         builder.setHeader(PrestoHeaders.PRESTO_USER, user);
         builder.setHeader(USER_AGENT, USER_AGENT_VALUE)
+                .setHeader(PRESTO_PREPARED_STATEMENT_IN_BODY, "true")
                 .setUri(nextUri);
 
         return builder;
@@ -320,17 +320,6 @@ public class StatementClient
             resetSessionProperties.add(clearSession);
         }
 
-        for (String entry : response.getHeaders(PRESTO_ADDED_PREPARE)) {
-            List<String> keyValue = SESSION_HEADER_SPLITTER.splitToList(entry);
-            if (keyValue.size() != 2) {
-                continue;
-            }
-            addedPreparedStatements.put(urlDecode(keyValue.get(0)), urlDecode(keyValue.get(1)));
-        }
-        for (String entry : response.getHeaders(PRESTO_DEALLOCATED_PREPARE)) {
-            deallocatedPreparedStatements.add(urlDecode(entry));
-        }
-
         String startedTransactionId = response.getHeader(PRESTO_STARTED_TRANSACTION_ID);
         if (startedTransactionId != null) {
             this.startedtransactionId.set(startedTransactionId);
@@ -339,7 +328,12 @@ public class StatementClient
             clearTransactionId.set(true);
         }
 
-        currentResults.set(response.getValue());
+        QueryResults queryResults = response.getValue();
+
+        this.addedPreparedStatements.putAll(queryResults.getAddedPreparedStatements());
+        this.deallocatedPreparedStatements.addAll(queryResults.getDeallocatedPreparedStatements());
+
+        currentResults.set(queryResults);
     }
 
     private RuntimeException requestFailedException(String task, Request request, JsonResponse<QueryResults> response)

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/QueryExecutor.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/QueryExecutor.java
@@ -15,6 +15,7 @@ package com.facebook.presto.jdbc;
 
 import com.facebook.presto.client.ClientSession;
 import com.facebook.presto.client.QueryResults;
+import com.facebook.presto.client.QuerySubmission;
 import com.facebook.presto.client.ServerInfo;
 import com.facebook.presto.client.StatementClient;
 import com.google.common.collect.ImmutableSet;
@@ -49,17 +50,19 @@ class QueryExecutor
     private final JsonCodec<QueryResults> queryInfoCodec;
     private final JsonCodec<ServerInfo> serverInfoCodec;
     private final HttpClient httpClient;
+    private final JsonCodec<QuerySubmission> querySubmissionCodec;
 
-    private QueryExecutor(JsonCodec<QueryResults> queryResultsCodec, JsonCodec<ServerInfo> serverInfoCodec, HttpClient httpClient)
+    private QueryExecutor(JsonCodec<QueryResults> queryResultsCodec, JsonCodec<ServerInfo> serverInfoCodec, JsonCodec<QuerySubmission> querySubmissionCodec, HttpClient httpClient)
     {
         this.queryInfoCodec = requireNonNull(queryResultsCodec, "queryResultsCodec is null");
         this.serverInfoCodec = requireNonNull(serverInfoCodec, "serverInfoCodec is null");
+        this.querySubmissionCodec = requireNonNull(querySubmissionCodec, "querySubmissionCodec is null");
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
     }
 
     public StatementClient startQuery(ClientSession session, String query)
     {
-        return new StatementClient(httpClient, queryInfoCodec, session, query);
+        return new StatementClient(httpClient, queryInfoCodec, querySubmissionCodec, session, query);
     }
 
     @Override
@@ -95,7 +98,7 @@ class QueryExecutor
 
     static QueryExecutor create(HttpClient httpClient)
     {
-        return new QueryExecutor(jsonCodec(QueryResults.class), jsonCodec(ServerInfo.class), httpClient);
+        return new QueryExecutor(jsonCodec(QueryResults.class), jsonCodec(ServerInfo.class), jsonCodec(QuerySubmission.class), httpClient);
     }
 
     @Nullable

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestProgressMonitor.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestProgressMonitor.java
@@ -19,6 +19,8 @@ import com.facebook.presto.client.QueryResults;
 import com.facebook.presto.client.StatementStats;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.net.HttpHeaders;
 import io.airlift.http.client.HttpClient;
 import io.airlift.http.client.HttpStatus;
@@ -78,7 +80,9 @@ public class TestProgressMonitor
                 new StatementStats(state, state.equals("QUEUED"), true, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null),
                 null,
                 null,
-                null);
+                null,
+                ImmutableMap.of(),
+                ImmutableSet.of());
 
         return QUERY_RESULTS_CODEC.toJson(queryResults);
     }

--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.server;
 
 import com.facebook.presto.client.QueryResults;
+import com.facebook.presto.client.QuerySubmission;
 import com.facebook.presto.execution.AddColumnTask;
 import com.facebook.presto.execution.CallTask;
 import com.facebook.presto.execution.CommitTask;
@@ -131,6 +132,7 @@ public class CoordinatorModule
         jsonCodecBinder(binder).bindJsonCodec(QueryInfo.class);
         jsonCodecBinder(binder).bindJsonCodec(TaskInfo.class);
         jsonCodecBinder(binder).bindJsonCodec(QueryResults.class);
+        jsonCodecBinder(binder).bindJsonCodec(QuerySubmission.class);
         jaxrsBinder(binder).bind(StatementResource.class);
 
         // execute resource

--- a/presto-main/src/main/java/com/facebook/presto/server/ExecuteResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ExecuteResource.java
@@ -17,7 +17,6 @@ import com.facebook.presto.Session;
 import com.facebook.presto.client.ClientSession;
 import com.facebook.presto.client.Column;
 import com.facebook.presto.client.QueryResults;
-import com.facebook.presto.client.QuerySubmission;
 import com.facebook.presto.client.StatementClient;
 import com.facebook.presto.execution.QueryIdGenerator;
 import com.facebook.presto.metadata.SessionPropertyManager;

--- a/presto-main/src/main/java/com/facebook/presto/server/ExecuteResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ExecuteResource.java
@@ -17,6 +17,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.client.ClientSession;
 import com.facebook.presto.client.Column;
 import com.facebook.presto.client.QueryResults;
+import com.facebook.presto.client.QuerySubmission;
 import com.facebook.presto.client.StatementClient;
 import com.facebook.presto.execution.QueryIdGenerator;
 import com.facebook.presto.metadata.SessionPropertyManager;

--- a/presto-main/src/test/java/com/facebook/presto/server/TestResourceUtil.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestResourceUtil.java
@@ -61,7 +61,7 @@ public class TestResourceUtil
                         .build(),
                 "testRemote");
 
-        Session session = createSessionForRequest(request, new AllowAllAccessControl(), new SessionPropertyManager(), new QueryId("test_query_id"));
+        Session session = createSessionForRequest(request, new AllowAllAccessControl(), new SessionPropertyManager(), new QueryId("test_query_id"), ImmutableMap.of());
 
         assertEquals(session.getQueryId(), new QueryId("test_query_id"));
         assertEquals(session.getUser(), "testUser");
@@ -97,6 +97,6 @@ public class TestResourceUtil
                         .put(PRESTO_PREPARED_STATEMENT, "query1=abcdefg")
                         .build(),
                 "testRemote");
-        createSessionForRequest(request, new AllowAllAccessControl(), new SessionPropertyManager(), new QueryId("test_query_id"));
+        createSessionForRequest(request, new AllowAllAccessControl(), new SessionPropertyManager(), new QueryId("test_query_id"), ImmutableMap.of());
     }
 }

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/TestGroups.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/TestGroups.java
@@ -51,6 +51,7 @@ public final class TestGroups
     public static final String BASIC_SQL = "basic_sql";
     public static final String AUTHORIZATION = "authorization";
     public static final String HIVE_1_1_0 = "hive_1_1_0";
+    public static final String PREPARED_STATEMENTS = "prepared_statements";
 
     private TestGroups() {}
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestingPrestoClient.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestingPrestoClient.java
@@ -18,6 +18,7 @@ import com.facebook.presto.client.ClientSession;
 import com.facebook.presto.client.Column;
 import com.facebook.presto.client.QueryError;
 import com.facebook.presto.client.QueryResults;
+import com.facebook.presto.client.QuerySubmission;
 import com.facebook.presto.client.StatementClient;
 import com.facebook.presto.metadata.MetadataUtil;
 import com.facebook.presto.metadata.QualifiedObjectName;
@@ -47,6 +48,7 @@ public abstract class AbstractTestingPrestoClient<T>
         implements Closeable
 {
     private static final JsonCodec<QueryResults> QUERY_RESULTS_CODEC = jsonCodec(QueryResults.class);
+    private static final JsonCodec<QuerySubmission> QUERY_SUBMISSION_CODEC = jsonCodec(QuerySubmission.class);
 
     private final TestingPrestoServer prestoServer;
     private final Session defaultSession;
@@ -84,7 +86,7 @@ public abstract class AbstractTestingPrestoClient<T>
 
         ClientSession clientSession = session.toClientSession(prestoServer.getBaseUrl(), true, false, new Duration(2, TimeUnit.MINUTES));
 
-        try (StatementClient client = new StatementClient(httpClient, QUERY_RESULTS_CODEC, clientSession, sql)) {
+        try (StatementClient client = new StatementClient(httpClient, QUERY_RESULTS_CODEC, QUERY_SUBMISSION_CODEC, clientSession, sql)) {
             while (client.isValid()) {
                 QueryResults results = client.current();
 


### PR DESCRIPTION
When passing prepared statements in the HTTP headers, we run into limits of 4k characters (because of Jetty) -- and the theoretical limit is 64K. In order to get around that, pass the prepared statements in the HTTP body.
