### PR TITLE
Fix bug with empty credentials

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/security/LdapFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/LdapFilter.java
@@ -116,6 +116,9 @@ public class LdapFilter
             try {
                 String user = credentials.get(0);
                 String password = credentials.get(1);
+                if (user.isEmpty() || password.isEmpty()) {
+                    throw new AuthenticationException("Authentication failed. Username or Password is empty");
+                }
 
                 Hashtable<String, String> environment = getBasicEnvironment();
                 String principal = ldapBinder.getBindDistinguishedName(user);

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoCliTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoCliTests.java
@@ -273,6 +273,15 @@ public class PrestoCliTests
         assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("statusMessage=Unauthorized")));
     }
 
+   @Test(groups = {CLI, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
+    public void shouldFailQueryForEmptyUser()
+            throws IOException, InterruptedException
+    {
+        ldapUserName = "";
+        launchPrestoCliWithServerArgument("--execute", "select * from hive.default.nation;");
+        assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("Authentication failed. Username or Password is empty")));
+    }
+
     @Test(groups = {CLI, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
     public void shouldFailQueryForLdapWithoutHttps()
             throws IOException, InterruptedException


### PR DESCRIPTION
JNDI LDAP API returns "unauthenticated" positive response for empty DN
or password. Hence check for empty strings before authenticating.
