### PR TITLE
Add openLDAP support

### DIFF
--- a/presto-product-tests/bin/run_on_docker.sh
+++ b/presto-product-tests/bin/run_on_docker.sh
@@ -170,6 +170,11 @@ environment_compose up -d hadoop-master
 environment_compose up -d mysql
 environment_compose up -d postgres
 
+# start ldap container
+if [[ "$ENVIRONMENT" == "singlenode-ldap" ]]; then
+  environment_compose up -d ldapserver
+fi
+
 # start docker logs for hadoop container
 environment_compose logs --no-color hadoop-master &
 HADOOP_LOGS_PID=$!

--- a/presto-product-tests/conf/docker/singlenode-ldap/docker-compose.yml
+++ b/presto-product-tests/conf/docker/singlenode-ldap/docker-compose.yml
@@ -11,3 +11,6 @@ services:
     image: 'teradatalabs/centos6-java8-oracle-ldap'
     volumes:
       - ../../../../presto-product-tests/conf/tempto/tempto-configuration-for-docker-ldap.yaml:/docker/volumes/tempto/tempto-configuration-local.yaml
+
+  ldapserver:
+    image: 'teradatalabs/centos6-java8-oracle-openldap'

--- a/presto-product-tests/conf/presto/etc/singlenode-ldap.properties
+++ b/presto-product-tests/conf/presto/etc/singlenode-ldap.properties
@@ -17,13 +17,14 @@ discovery-server.enabled=true
 discovery.uri=http://presto-master:8080
 
 # LDAP specific properties
-# https will have to enabled for ldap authentication
+# https will have to be enabled for ldap authentication
 http-server.https.port=8443
 http-server.https.enabled=true
 http-server.https.keystore.path=/etc/ldap/coordinator.jks
 http-server.https.keystore.key=testldap
 authentication.ldap.enabled=true
-authentication.ldap.url=ldaps://ldap-server:636
-authentication.ldap.ad-domain=presto.testldap.com
-authentication.ldap.base-dn=OU=Asia,DC=presto,DC=testldap,DC=com
-authentication.ldap.group-dn=CN=ParentGroup,OU=America,DC=presto,DC=testldap,DC=com
+authentication.ldap.server-type=OPENLDAP
+authentication.ldap.user-object-class=inetOrgPerson
+authentication.ldap.url=ldaps://ldapserver:636
+authentication.ldap.base-dn=ou=Asia,dc=presto,dc=testldap,dc=com
+authentication.ldap.group-dn=cn=DefaultGroup,ou=America,dc=presto,dc=testldap,dc=com

--- a/presto-product-tests/conf/tempto/tempto-configuration-for-docker-ldap.yaml
+++ b/presto-product-tests/conf/tempto/tempto-configuration-for-docker-ldap.yaml
@@ -7,6 +7,6 @@ databases:
     cli_ldap_authentication: true
     cli_ldap_truststore_path: /etc/ldap/cacerts.jks
     cli_ldap_truststore_password: testldap
-    cli_ldap_user_name: ParentGroupUser
+    cli_ldap_user_name: DefaultGroupUser
     cli_ldap_user_password: LDAPPass123
     cli_ldap_server_address: https://${databases.presto.host}:8443


### PR DESCRIPTION
Added support for running product-tests on openLDAP docker container.
This will enable us to run ldap product-tests on Travis.
