### PR TITLE
Enforce use of secure LDAP

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/security/ServerSecurityModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/ServerSecurityModule.java
@@ -66,6 +66,10 @@ public class ServerSecurityModule
             checkState(ldapServerConfig.getUserObjectClass() != null, "Missing property 'authentication.ldap.user-object-class'");
         }
 
+        if (ldapServerConfig.getLdapUrl().startsWith("ldap://")) {
+            throw new IllegalArgumentException("Expected \"ldaps://\" but found \"ldap://\" in the property authentication.ldap.url");
+        }
+
         if (ldapServerConfig.getServerType().equalsIgnoreCase(OPENLDAP.name())) {
             checkState(ldapServerConfig.getBaseDistinguishedName() != null, "Missing property 'authentication.ldap.base-dn'");
 


### PR DESCRIPTION
Enforce use of secure LDAP and reject connection attempt if secure LDAP has not been enabled.

@anusudarsan Take a look, please.
