### PR TITLE
Add ReorderWindows optimizer

### DIFF
--- a/presto-docs/src/main/sphinx/admin.rst
+++ b/presto-docs/src/main/sphinx/admin.rst
@@ -9,3 +9,4 @@ Administration
     admin/tuning
     admin/queue
     admin/resource-groups
+    admin/feature-toggles

--- a/presto-docs/src/main/sphinx/admin/feature-toggles.rst
+++ b/presto-docs/src/main/sphinx/admin/feature-toggles.rst
@@ -1,0 +1,16 @@
+===============
+Feature Toggles
+===============
+
+The default Presto settings should work well for most workloads. The following
+information may help you if some of the features are not working correctly for you.
+Though, if you think the behavior of a feature is unexpected, don't hesitate to file a bug report regardless if it's enabled or disabled by default.
+
+Config Properties
+-----------------
+
++--------------------------+---------------+------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|Name of property          | Default value | Description                                                                                                                                                |
++==========================+===============+=======================================================================================================+++==================================================+
+|optimizer.reorder-windows | true          |Allow reordering windows in order to put those with the same partitioning next to each other. This may sometimes allow minimizing number of repartitionings.|
++--------------------------+---------------+------------------------------------------------------------------------------------------------------------------------------------------------------------+

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -61,6 +61,7 @@ public final class SystemSessionProperties
     public static final String SPLIT_CONCURRENCY_ADJUSTMENT_INTERVAL = "split_concurrency_adjustment_interval";
     public static final String OPTIMIZE_METADATA_QUERIES = "optimize_metadata_queries";
     public static final String QUERY_PRIORITY = "query_priority";
+    public static final String REORDER_WINDOWS = "reorder_windows";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -219,6 +220,11 @@ public final class SystemSessionProperties
                         COLOCATED_JOIN,
                         "Experimental: Use a colocated join when possible",
                         featuresConfig.isColocatedJoinsEnabled(),
+                        false),
+                booleanSessionProperty(
+                        REORDER_WINDOWS,
+                        "Allow reordering window functions in query",
+                        featuresConfig.isReorderWindows(),
                         false));
     }
 
@@ -332,6 +338,11 @@ public final class SystemSessionProperties
         Integer priority = session.getProperty(QUERY_PRIORITY, Integer.class);
         checkArgument(priority > 0, "Query priority must be positive");
         return priority;
+    }
+
+    public static boolean isReorderWindowsEnabled(Session session)
+    {
+        return session.getProperty(REORDER_WINDOWS, Boolean.class);
     }
 
     public static Duration getSplitConcurrencyAdjustmentInterval(Session session)

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -45,6 +45,7 @@ public class FeaturesConfig
     private boolean optimizeMetadataQueries;
     private boolean optimizeHashGeneration = true;
     private boolean optimizeSingleDistinct = true;
+    private boolean optimizerReorderWindows = true;
     private boolean pushTableWriteThroughUnion = true;
     private boolean legacyArrayAgg;
 
@@ -229,6 +230,18 @@ public class FeaturesConfig
     public FeaturesConfig setDictionaryAggregation(boolean dictionaryAggregation)
     {
         this.dictionaryAggregation = dictionaryAggregation;
+        return this;
+    }
+
+    public boolean isReorderWindows()
+    {
+        return optimizerReorderWindows;
+    }
+
+    @Config("optimizer.reorder-windows")
+    public FeaturesConfig setReorderWindows(boolean reorderWindows)
+    {
+        this.optimizerReorderWindows = reorderWindows;
         return this;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizersFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizersFactory.java
@@ -39,6 +39,7 @@ import com.facebook.presto.sql.planner.optimizations.ProjectionPushDown;
 import com.facebook.presto.sql.planner.optimizations.PruneIdentityProjections;
 import com.facebook.presto.sql.planner.optimizations.PruneUnreferencedOutputs;
 import com.facebook.presto.sql.planner.optimizations.PushTableWriteThroughUnion;
+import com.facebook.presto.sql.planner.optimizations.ReorderWindows;
 import com.facebook.presto.sql.planner.optimizations.SetFlatteningOptimizer;
 import com.facebook.presto.sql.planner.optimizations.SimplifyExpressions;
 import com.facebook.presto.sql.planner.optimizations.SingleDistinctOptimizer;
@@ -87,6 +88,7 @@ public class PlanOptimizersFactory
                 new CountConstantOptimizer(),
                 new WindowFilterPushDown(metadata), // This must run after PredicatePushDown and LimitPushDown so that it squashes any successive filter nodes and limits
                 new MergeIdenticalWindows(),
+                new ReorderWindows(), // Should be after MergeIdenticalWindows to avoid unnecessary reordering of mergeable windows
                 new MergeProjections(),
                 new PruneUnreferencedOutputs(), // Make sure to run this at the end to help clean the plan for logging/execution and not remove info that other optimizers might need at an earlier point
                 new PruneIdentityProjections(), // This MUST run after PruneUnreferencedOutputs as it may introduce new redundant projections

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ReorderWindows.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ReorderWindows.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.sql.planner.optimizations;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.SystemSessionProperties;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
@@ -96,6 +97,10 @@ public class ReorderWindows
     @Override
     public PlanNode optimize(PlanNode plan, Session session, Map<Symbol, Type> types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator)
     {
+        if (!SystemSessionProperties.isReorderWindowsEnabled(session)) {
+            return plan;
+        }
+
         return SimplePlanRewriter.rewriteWith(new Rewriter(), plan, new PriorityQueue<>(new PartitionByComparator()));
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ReorderWindows.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ReorderWindows.java
@@ -144,9 +144,14 @@ public class ReorderWindows
         @Override
         public int compare(WindowNode o1, WindowNode o2)
         {
-            String firstPartitionBy = o1.getPartitionBy().stream().map(Symbol::getName).collect(Collectors.joining(","));
-            String secondPartitionBy = o2.getPartitionBy().stream().map(Symbol::getName).collect(Collectors.joining(","));
-            return firstPartitionBy.compareTo(secondPartitionBy);
+            return stringifyPartitionBy(o1).compareTo(stringifyPartitionBy(o2));
+        }
+
+        private static String stringifyPartitionBy(WindowNode node)
+        {
+            return node.getPartitionBy().stream()
+                .map(Symbol::getName)
+                .collect(Collectors.joining(","));
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ReorderWindows.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ReorderWindows.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
+import com.facebook.presto.sql.planner.plan.WindowNode;
+
+import java.util.Comparator;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkState;
+
+/**
+ * Reorder windows such as those with the same `partition by` clause are adjacent.
+ * For example:
+ * OutputNode
+ * `--...
+ *    `--WindowNode(PartitionBy A OrderBy B)
+ *       `--WindowNode(PartitionBy C OrderBy D)
+ *          `--WindowNode(PartitionBy A OrderBy E)
+ *             `--...
+ *
+ * Will be transformed into:
+ * OutputNode
+ * `--...
+ *    `--WindowNode(PartitionBy C OrderBy D)
+ *       `--WindowNode(PartitionBy A OrderBy B)
+ *          `--WindowNode(PartitionBy A OrderBy E)
+ *             `--...
+ *
+ * What is more, if one `PartitionBy` is a prefix of another, the shorter is preferred, e.g.:
+ * OutputNode
+ * `--...
+ *    `--WindowNode(PartitionBy A OrderBy B)
+ *       `--WindowNode(PartitionBy C OrderBy D)
+ *          `--WindowNode(PartitionBy A,E OrderBy F)
+ *             `--...
+ *
+ * Will be transformed into:
+ * OutputNode
+ * `--...
+ *    `--WindowNode(PartitionBy C OrderBy D)
+ *       `--WindowNode(PartitionBy A,E OrderBy F)
+ *          `--WindowNode(PartitionBy A OrderBy B)
+ *             `--...
+ *
+ * This will NOT reorder WindowNodes across non-Window nodes.
+ * In the following example, the WindowNode with PartitionBy = A
+ * won't be carried over beyond ProjectNode to precede WindowNode with PartitionBy = A,B:
+ * OutputNode
+ * `--...
+ *    `--WindowNode(PartitionBy A OrderBy F)
+ *       `--ProjectNode(...)
+ *          `--WindowNode(PartitionBy A,B OrderBy C)
+ *             `--...
+ *
+ * The optimizer may reorder windows even if no window partitioning is a prefix of the other.
+ * E.g.:
+ * OutputNode
+ * `--...
+ *    `--WindowNode(PartitionBy A OrderBy B)
+ *       `--WindowNode(PartitionBy C OrderBy D)
+ *          `--...
+ *
+ * May be transformed into:
+ * * OutputNode
+ * `--...
+ *    `--WindowNode(PartitionBy C OrderBy D)
+ *       `--WindowNode(PartitionBy A OrderBy B)
+ *          `--...
+ *
+ * Even though there are no identical `partition by` clauses in such a plan.
+ */
+public class ReorderWindows
+        implements PlanOptimizer
+{
+    @Override
+    public PlanNode optimize(PlanNode plan, Session session, Map<Symbol, Type> types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator)
+    {
+        return SimplePlanRewriter.rewriteWith(new Rewriter(), plan, new PriorityQueue<>(new PartitionByComparator()));
+    }
+
+    private static class Rewriter
+            extends SimplePlanRewriter<PriorityQueue<WindowNode>>
+    {
+        @Override
+        protected PlanNode visitPlan(PlanNode node, RewriteContext<PriorityQueue<WindowNode>> context)
+        {
+            PriorityQueue<WindowNode> windowNodes = context.get();
+
+            PlanNode sourceNode = context.defaultRewrite(node, new PriorityQueue<>(new PartitionByComparator()));
+            while (windowNodes.peek() != null) {
+                WindowNode windowNode = windowNodes.poll();
+                sourceNode = new WindowNode(
+                        windowNode.getId(),
+                        sourceNode,
+                        windowNode.getSpecification(),
+                        windowNode.getWindowFunctions(),
+                        windowNode.getHashSymbol(),
+                        windowNode.getPrePartitionedInputs(),
+                        windowNode.getPreSortedOrderPrefix());
+            }
+            return sourceNode;
+        }
+
+        @Override
+        public PlanNode visitWindow(WindowNode node, RewriteContext<PriorityQueue<WindowNode>> context)
+        {
+            checkState(!node.getHashSymbol().isPresent(), "ReorderWindows should be run before HashGenerationOptimizer");
+            checkState(node.getPrePartitionedInputs().isEmpty() && node.getPreSortedOrderPrefix() == 0, "ReorderWindows should be run before AddExchanges");
+
+            context.get().add(node);
+            return context.rewrite(node.getSource(), context.get());
+        }
+    }
+
+    private static class PartitionByComparator
+            implements Comparator<WindowNode>
+    {
+        @Override
+        public int compare(WindowNode o1, WindowNode o2)
+        {
+            String firstPartitionBy = o1.getPartitionBy().stream().map(Symbol::getName).collect(Collectors.joining(","));
+            String secondPartitionBy = o2.getPartitionBy().stream().map(Symbol::getName).collect(Collectors.joining(","));
+            return firstPartitionBy.compareTo(secondPartitionBy);
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -30,7 +30,6 @@ import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.SymbolReference;
-import com.facebook.presto.sql.tree.Window;
 import com.facebook.presto.sql.tree.WindowFrame;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestReorderWindows.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestReorderWindows.java
@@ -1,0 +1,257 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.spi.block.SortOrder;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.planner.Plan;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.assertions.PlanAssert;
+import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
+import com.facebook.presto.sql.planner.plan.WindowNode;
+import com.facebook.presto.sql.tree.SymbolReference;
+import com.facebook.presto.sql.tree.WindowFrame;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.facebook.presto.tpch.TpchConnectorFactory;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Provider;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.functionCall;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.window;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static java.lang.String.format;
+
+public class TestReorderWindows
+{
+    private final LocalQueryRunner queryRunner;
+
+    private final Optional<WindowFrame> commonFrame;
+
+    private final WindowNode.Specification windowA;
+    private final WindowNode.Specification windowAp;
+    private final WindowNode.Specification windowApp;
+    private final WindowNode.Specification windowB;
+
+    private final Symbol tax;
+    private final Symbol suppkey;
+    private final Symbol orderkey;
+    private final Symbol partkey;
+    private final Symbol shipdate;
+    private final Symbol receiptdate;
+
+    private final SymbolReference discountReference;
+    private final SymbolReference quantityReference;
+    private final SymbolReference taxReference;
+
+    public TestReorderWindows()
+    {
+        queryRunner = new LocalQueryRunner(testSessionBuilder()
+                .setCatalog("local")
+                .setSchema("tiny")
+                .build());
+
+        queryRunner.createCatalog(queryRunner.getDefaultSession().getCatalog().get(),
+                new TpchConnectorFactory(queryRunner.getNodeManager(), 1),
+                ImmutableMap.of());
+
+        commonFrame = Optional.empty();
+
+        suppkey = new Symbol("suppkey");
+        orderkey = new Symbol("orderkey");
+        partkey = new Symbol("partkey");
+        shipdate = new Symbol("shipdate");
+        receiptdate = new Symbol("receiptdate");
+        tax = new Symbol("tax");
+
+        discountReference = new SymbolReference("discount");
+        quantityReference = new SymbolReference("quantity");
+        taxReference = new SymbolReference("tax");
+
+        windowA = new WindowNode.Specification(
+                ImmutableList.of(suppkey),
+                ImmutableList.of(orderkey),
+                ImmutableMap.of(orderkey, SortOrder.ASC_NULLS_LAST));
+
+        windowAp = new WindowNode.Specification(
+                ImmutableList.of(suppkey),
+                ImmutableList.of(shipdate),
+                ImmutableMap.of(shipdate, SortOrder.ASC_NULLS_LAST));
+
+        windowApp = new WindowNode.Specification(
+                ImmutableList.of(suppkey, tax),
+                ImmutableList.of(receiptdate),
+                ImmutableMap.of(receiptdate, SortOrder.ASC_NULLS_LAST));
+
+        windowB = new WindowNode.Specification(
+                ImmutableList.of(partkey),
+                ImmutableList.of(receiptdate),
+                ImmutableMap.of(receiptdate, SortOrder.ASC_NULLS_LAST));
+    }
+
+    private static String getWindowDescription(WindowNode.Specification specification)
+    {
+        return format("partition by %s order by %s",
+                specification.getPartitionBy().stream().map(Symbol::getName).collect(Collectors.joining(", ")),
+                specification.getOrderBy().stream().map(orderSymbol -> sortItemToString(orderSymbol, specification.getOrderings())).collect(Collectors.joining(", ")));
+    }
+
+    private static String sortItemToString(Symbol sortItem, Map<Symbol, SortOrder> orderings)
+    {
+        SortOrder sortOrder = orderings.get(sortItem);
+        return format("%s %s %s", sortItem, (sortOrder.isAscending() ? "ASC" : "DESC"), (sortOrder.isNullsFirst() ? "NULLS FIRST" : "NULLS LAST"));
+    }
+
+    @Test
+    public void testNonMergeableABAReordersToAABAllOptimizers()
+    {
+        @Language("SQL") String sql = "select " +
+                "sum(quantity) over(" + getWindowDescription(windowA) + ") sum_quantity_A, " +
+                "avg(discount) over(" + getWindowDescription(windowB) + ") avg_discount_B, " +
+                "min(tax) over(" + getWindowDescription(windowAp) + ") min_tax_A " +
+                "from lineitem";
+
+        PlanMatchPattern pattern =
+                anyTree(
+                        window(windowAp,
+                                ImmutableList.of(
+                                        functionCall("min", commonFrame, taxReference)),
+                                window(windowA,
+                                        ImmutableList.of(
+                                                functionCall("sum", commonFrame, quantityReference)),
+                                        anyTree(
+                                        window(windowB,
+                                                ImmutableList.of(
+                                                        functionCall("avg", commonFrame, discountReference)),
+                                                anyTree())))));
+
+        Plan actualPlan = queryRunner.inTransaction(transactionSession -> queryRunner.createPlan(transactionSession, sql));
+        queryRunner.inTransaction(transactionSession -> {
+            PlanAssert.assertPlan(transactionSession, queryRunner.getMetadata(), actualPlan, pattern);
+            return null;
+        });
+    }
+
+    @Test
+    public void testNonMergeableABAReordersToAAB()
+    {
+        @Language("SQL") String sql = "select " +
+                "sum(quantity) over(" + getWindowDescription(windowA) + ") sum_quantity_A, " +
+                "avg(discount) over(" + getWindowDescription(windowB) + ") avg_discount_B, " +
+                "min(tax) over(" + getWindowDescription(windowAp) + ") min_tax_A " +
+                "from lineitem";
+
+        assertUnitPlan(sql,
+                anyTree(
+                        window(windowAp,
+                                ImmutableList.of(
+                                        functionCall("min", commonFrame, taxReference)),
+                                        window(windowA,
+                                                ImmutableList.of(
+                                                        functionCall("sum", commonFrame, quantityReference)),
+                                                        window(windowB,
+                                                                ImmutableList.of(
+                                                                        functionCall("avg", commonFrame, discountReference)),
+                                                anyTree())))));
+    }
+
+    @Test
+    public void testPrefixOfPartitionComesFirstRegardlessOfTheirOrderInSQL()
+    {
+        {
+            @Language("SQL") String sql = "select " +
+                    "avg(discount) over(" + getWindowDescription(windowApp) + ") avg_discount_A, " +
+                    "sum(quantity) over(" + getWindowDescription(windowA) + ") sum_quantity_A " +
+                    "from lineitem";
+
+            assertUnitPlan(sql,
+                    anyTree(window(windowApp,
+                            ImmutableList.of(
+                                    functionCall("avg", commonFrame, discountReference)),
+                            window(windowA,
+                                    ImmutableList.of(
+                                            functionCall("sum", commonFrame, quantityReference)),
+                                    anyTree()))));
+        }
+
+        {
+            @Language("SQL") String sql = "select " +
+                    "sum(quantity) over(" + getWindowDescription(windowA) + ") sum_quantity_A, " +
+                    "avg(discount) over(" + getWindowDescription(windowApp) + ") avg_discount_A " +
+                    "from lineitem";
+
+            assertUnitPlan(sql,
+                    anyTree(window(windowApp,
+                            ImmutableList.of(
+                                    functionCall("avg", commonFrame, discountReference)),
+                            window(windowA,
+                                    ImmutableList.of(
+                                            functionCall("sum", commonFrame, quantityReference)),
+                                    anyTree()))));
+        }
+    }
+
+    @Test
+    public void testNotReorderAcrossNonWindowNodes()
+    {
+        @Language("SQL") String sql = "select " +
+                "avg(discount) over(" + getWindowDescription(windowApp) + ") avg_discount_A, " +
+                "lag(quantity, 1) over(" + getWindowDescription(windowA) + ") lag_quantity_A " + // produces ProjectNode because of constant 1
+                "from lineitem";
+
+        assertUnitPlan(sql,
+                anyTree(window(windowA,
+                        ImmutableList.of(
+                                functionCall("lag", commonFrame, quantityReference, new SymbolReference("expr"))),
+                        project(
+                        window(windowApp,
+                                ImmutableList.of(
+                                        functionCall("avg", commonFrame, discountReference)),
+                                anyTree())))));
+    }
+
+    private void assertUnitPlan(@Language("SQL") String sql, PlanMatchPattern pattern)
+    {
+        Plan actualPlan = unitPlan(sql);
+        queryRunner.inTransaction(transactionSession -> {
+            PlanAssert.assertPlan(transactionSession, queryRunner.getMetadata(), actualPlan, pattern);
+            return null;
+        });
+    }
+
+    private Plan unitPlan(@Language("SQL") String sql)
+    {
+        FeaturesConfig featuresConfig = new FeaturesConfig()
+                .setExperimentalSyntaxEnabled(true)
+                .setDistributedIndexJoinsEnabled(false)
+                .setOptimizeHashGeneration(true);
+        Provider<List<PlanOptimizer>> optimizerProvider = () -> ImmutableList.of(
+                new UnaliasSymbolReferences(),
+                new PruneIdentityProjections(),
+                new ReorderWindows(),
+                new PruneUnreferencedOutputs()
+        );
+
+        return queryRunner.inTransaction(transactionSession -> queryRunner.createPlan(transactionSession, sql, featuresConfig, optimizerProvider));
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -3301,6 +3301,47 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testWindowsSameOrdering()
+            throws Exception
+    {
+        assertQuery("SELECT " +
+                    "sum(quantity) OVER(PARTITION BY suppkey ORDER BY orderkey)," +
+                    "min(tax) OVER(PARTITION BY suppkey ORDER BY shipdate)" +
+                    "FROM lineitem");
+    }
+
+    @Test
+    public void testWindowsPrefixPartitioning()
+            throws Exception
+    {
+        assertQuery("SELECT " +
+                    "avg(discount) OVER(PARTITION BY suppkey, tax ORDER BY receiptdate)," +
+                    "sum(quantity) OVER(PARTITION BY suppkey ORDER BY orderkey)" +
+                    "FROM lineitem");
+    }
+
+    @Test
+    public void testWindowsDifferentPartitions()
+            throws Exception
+    {
+        assertQuery("SELECT " +
+                "sum(quantity) OVER(PARTITION BY suppkey ORDER BY orderkey)," +
+                "avg(discount) OVER(PARTITION BY partkey ORDER BY receiptdate)," +
+                "min(tax) OVER(PARTITION BY suppkey, tax ORDER BY receiptdate)" +
+                "FROM lineitem");
+    }
+
+    @Test
+    public void testWindowsConstantExpression()
+            throws Exception
+    {
+        assertQuery("SELECT " +
+                "avg(discount) OVER(PARTITION BY suppkey ORDER BY receiptdate)," +
+                "lag(quantity, 1) OVER(PARTITION BY suppkey ORDER BY orderkey)" +
+                "FROM lineitem");
+    }
+
+    @Test
     public void testHaving()
             throws Exception
     {


### PR DESCRIPTION
Adjacent windows of the same partition by clause should be next to each other in the plan,
to avoid unnecessary repartitionings.

What's more, whenever there are partitions where one is a prefix of another, the shorter comes first because of the same reasons.

This optimizer is limited to operate on adjacent windows only.
It does not reorder windows across other PlanNodes than WindowNode.

---

This closes #5955.
