### PR TITLE
Remove s3_tests from quarantine

### DIFF
--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/TestGroups.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/TestGroups.java
@@ -26,6 +26,7 @@ public final class TestGroups
     public static final String SYSTEM_CONNECTOR = "system";
     public static final String JMX_CONNECTOR = "jmx";
     public static final String BLACKHOLE_CONNECTOR = "blackhole";
+    public static final String S3_CONNECTOR = "s3_connector";
     public static final String SMOKE = "smoke";
     public static final String JDBC = "jdbc";
     public static final String SIMBA_JDBC = "simba_jdbc";

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveS3Connector.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveS3Connector.java
@@ -1,0 +1,221 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.tests.hive;
+
+import com.teradata.tempto.ProductTest;
+import com.teradata.tempto.query.QueryResult;
+import com.teradata.tempto.query.QueryType;
+import org.testng.annotations.Test;
+
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.sql.SQLException;
+
+import static com.facebook.presto.tests.TestGroups.QUARANTINE;
+import static com.facebook.presto.tests.TestGroups.S3_CONNECTOR;
+import static com.teradata.tempto.assertions.QueryAssert.Row.row;
+import static com.teradata.tempto.assertions.QueryAssert.assertThat;
+import static com.teradata.tempto.query.QueryExecutor.query;
+import static com.teradata.tempto.util.DateTimeUtils.parseTimestampInUTC;
+import static java.lang.String.format;
+
+// Tests in this class are all quarantined so that they only run as part of the s3 connector job
+// These tests require access to an s3 cluster as well as some predefined tables with data loaded in s3.
+public class TestHiveS3Connector
+        extends ProductTest
+{
+    @Test(groups = {S3_CONNECTOR, QUARANTINE})
+    public void testSelectFromTextFile()
+            throws SQLException
+    {
+        // This test uses a standard tpch nation table.  It assumes that table is already created in the hive catalog
+        // and has data loaded.
+        QueryResult queryResult = query("SELECT n_name FROM hive.default.nation where n_nationkey = 7");
+        assertThat(queryResult).containsOnly(row("GERMANY"));
+    }
+
+    @Test(groups = {S3_CONNECTOR, QUARANTINE})
+    public void testAllDataTypesTextFile()
+            throws SQLException
+    {
+        // This test uses the all_types table as defined in the AllSimpleTypesTableDefinition class and
+        // data from hive/data/all_types/data.textfile. The table is create with the name 'alltypes_text'.
+        // The test assumes that table is already created in the hive catalog and has data loaded.
+
+        assertProperAllDatatypesSchema("alltypes_text");
+        QueryResult queryResult = query("SELECT * FROM alltypes_text");
+
+        assertThat(queryResult).containsOnly(
+                row(
+                        127,
+                        32767,
+                        2147483647,
+                        9223372036854775807L,
+                        123.345f,
+                        234.567,
+                        new BigDecimal("346"),
+                        new BigDecimal("345.67800"),
+                        parseTimestampInUTC("2015-05-10 12:15:35.123"),
+                        Date.valueOf("2015-05-10"),
+                        "ala ma kota",
+                        "ala ma kot",
+                        "ala ma    ",
+                        true,
+                        "kot binarny".getBytes()
+                )
+        );
+    }
+
+    @Test(groups = {S3_CONNECTOR, QUARANTINE})
+    public void testAllDataTypesRcFile()
+            throws SQLException
+    {
+        // This test uses the all_types table as defined in the AllSimpleTypesTableDefinition class with data
+        // from hive/data/all_types/data.rcfile.  the table is created with the name alltypes_rcfile.
+        // The test assumes that table is already created in the hive catalog and has data loaded.
+
+        assertProperAllDatatypesSchema("alltypes_rcfile");
+        QueryResult queryResult = query("SELECT * FROM alltypes_rcfile");
+
+        assertThat(queryResult).containsOnly(
+                row(
+                        127,
+                        32767,
+                        2147483647,
+                        9223372036854775807L,
+                        123.345f,
+                        234.567,
+                        new BigDecimal("346"),
+                        new BigDecimal("345.67800"),
+                        parseTimestampInUTC("2015-05-10 12:15:35.123"),
+                        Date.valueOf("2015-05-10"),
+                        "ala ma kota",
+                        "ala ma kot",
+                        "ala ma    ",
+                        true,
+                        "kot binarny".getBytes()
+                )
+        );
+    }
+
+    @Test(groups = {S3_CONNECTOR, QUARANTINE})
+    public void testAllDataTypesOrc()
+            throws SQLException
+    {
+        // This test uses the all_types table as defined in the AllSimpleTypesTableDefinition class and
+        // with data from hive/data/all_types/data.orc.  The table is created with the name alltypes_orc.
+        // The test assumes that table is already created in the hive catalog and has data loaded.
+
+        assertProperAllDatatypesSchema("alltypes_orc");
+        QueryResult queryResult = query("SELECT * FROM alltypes_orc");
+
+        assertThat(queryResult).containsOnly(
+                row(
+                        127,
+                        32767,
+                        2147483647,
+                        9223372036854775807L,
+                        123.345f,
+                        234.567,
+                        new BigDecimal("346"),
+                        new BigDecimal("345.67800"),
+                        parseTimestampInUTC("2015-05-10 12:15:35.123"),
+                        Date.valueOf("2015-05-10"),
+                        "ala ma kota",
+                        "ala ma kot",
+                        "ala ma    ",
+                        true,
+                        "kot binarny".getBytes()
+                )
+        );
+    }
+
+    @Test(groups = {S3_CONNECTOR, QUARANTINE})
+    public void testAllDataTypesParquet()
+            throws SQLException
+    {
+        // This test uses all_types table for parquet as defined in the AllSimpleTypesTableDefinition class.  The data
+        // was generated by inserting and relevant columns into a parquet table using the data in
+        // hive/data/all_types/data.textfile. The table is created with the name alltypes_parquet.
+        // The test assumes that table is already created in the hive catalog and has data loaded.
+
+        assertProperParquetDatatypesSchema("alltypes_parquet");
+        QueryResult queryResult = query("SELECT * FROM alltypes_parquet");
+
+        assertThat(queryResult).containsOnly(
+                row(
+                        127,
+                        32767,
+                        2147483647,
+                        9223372036854775807L,
+                        123.345f,
+                        234.567,
+                        parseTimestampInUTC("2015-05-10 12:15:35.123"),
+                        "ala ma kota",
+                        "ala ma kot",
+                        "ala ma    ",
+                        true
+                )
+        );
+    }
+
+    @Test(groups = {S3_CONNECTOR, QUARANTINE})
+    public void shouldCreateTableAsSelect()
+            throws Exception
+    {
+        String tableName = "create_table_as_select";
+        query(format("DROP TABLE IF EXISTS %s", tableName));
+        query(format("CREATE TABLE %s AS SELECT * FROM nation", tableName));
+        assertThat(query(format("SELECT * FROM %s", tableName))).hasRowsCount(25);
+    }
+
+    private void assertProperAllDatatypesSchema(String tableName)
+    {
+        assertThat(query("SHOW COLUMNS FROM " + tableName, QueryType.SELECT).project(1, 2)).containsExactly(
+                row("c_tinyint", "tinyint"),
+                row("c_smallint", "smallint"),
+                row("c_int", "integer"),
+                row("c_bigint", "bigint"),
+                row("c_float", "real"),
+                row("c_double", "double"),
+                row("c_decimal", "decimal(10,0)"),
+                row("c_decimal_w_params", "decimal(10,5)"),
+                row("c_timestamp", "timestamp"),
+                row("c_date", "date"),
+                row("c_string", "varchar"),
+                row("c_varchar", "varchar(10)"),
+                row("c_char", "char(10)"),
+                row("c_boolean", "boolean"),
+                row("c_binary", "varbinary")
+        );
+    }
+
+    private void assertProperParquetDatatypesSchema(String tableName)
+    {
+        assertThat(query("SHOW COLUMNS FROM " + tableName, QueryType.SELECT).project(1, 2)).containsExactly(
+                row("c_tinyint", "tinyint"),
+                row("c_smallint", "smallint"),
+                row("c_int", "integer"),
+                row("c_bigint", "bigint"),
+                row("c_float", "real"),
+                row("c_double", "double"),
+                row("c_timestamp", "timestamp"),
+                row("c_string", "varchar"),
+                row("c_varchar", "varchar(10)"),
+                row("c_char", "char(10)"),
+                row("c_boolean", "boolean")
+        );
+    }
+}

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveS3Connector.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveS3Connector.java
@@ -15,70 +15,89 @@
 package com.facebook.presto.tests.hive;
 
 import com.teradata.tempto.ProductTest;
+import com.teradata.tempto.query.QueryExecutionException;
 import com.teradata.tempto.query.QueryResult;
 import com.teradata.tempto.query.QueryType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
 import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.SQLException;
 
-import static com.facebook.presto.tests.TestGroups.QUARANTINE;
 import static com.facebook.presto.tests.TestGroups.S3_CONNECTOR;
 import static com.teradata.tempto.assertions.QueryAssert.Row.row;
 import static com.teradata.tempto.assertions.QueryAssert.assertThat;
+import static com.teradata.tempto.query.QueryExecutor.defaultQueryExecutor;
 import static com.teradata.tempto.query.QueryExecutor.query;
 import static com.teradata.tempto.util.DateTimeUtils.parseTimestampInUTC;
 import static java.lang.String.format;
 
-// Tests in this class are all quarantined so that they only run as part of the s3 connector job
-// These tests require access to an s3 cluster as well as some predefined tables with data loaded in s3.
+// This class is intended to be used to test the s3 connector (in particular, to test tables stored
+// in s3, and available in the Hive metastore). The tests in this class require some predefined tables
+// with data loaded. Though they are meant to test an s3 configuration, they can run on any cluster
+// that has the required tables loaded in hive. If the tables do not exist, these tests will log a warning
+// and move on.
 public class TestHiveS3Connector
         extends ProductTest
 {
-    @Test(groups = {S3_CONNECTOR, QUARANTINE})
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestHiveS3Connector.class);
+
+    @Test(groups = {S3_CONNECTOR})
     public void testSelectFromTextFile()
             throws SQLException
     {
         // This test uses a standard tpch nation table.  It assumes that table is already created in the hive catalog
         // and has data loaded.
-        QueryResult queryResult = query("SELECT n_name FROM hive.default.nation where n_nationkey = 7");
-        assertThat(queryResult).containsOnly(row("GERMANY"));
+        String tableName = "hive.default.nation";
+        if (isCreated(tableName)) {
+            QueryResult queryResult = query("SELECT n_name FROM hive.default.nation where n_nationkey = 7");
+            assertThat(queryResult).containsOnly(row("GERMANY"));
+        }
+        else {
+            LOGGER.warn(format("Skipping test. Table %s does not exist.", tableName));
+        }
     }
 
-    @Test(groups = {S3_CONNECTOR, QUARANTINE})
+    @Test(groups = {S3_CONNECTOR})
     public void testAllDataTypesTextFile()
             throws SQLException
     {
         // This test uses the all_types table as defined in the AllSimpleTypesTableDefinition class and
         // data from hive/data/all_types/data.textfile. The table is create with the name 'alltypes_text'.
         // The test assumes that table is already created in the hive catalog and has data loaded.
+        String tableName = "alltypes_text";
+        if (isCreated(tableName)) {
+            assertProperAllDatatypesSchema("alltypes_text");
+            QueryResult queryResult = query("SELECT * FROM alltypes_text");
 
-        assertProperAllDatatypesSchema("alltypes_text");
-        QueryResult queryResult = query("SELECT * FROM alltypes_text");
-
-        assertThat(queryResult).containsOnly(
-                row(
-                        127,
-                        32767,
-                        2147483647,
-                        9223372036854775807L,
-                        123.345f,
-                        234.567,
-                        new BigDecimal("346"),
-                        new BigDecimal("345.67800"),
-                        parseTimestampInUTC("2015-05-10 12:15:35.123"),
-                        Date.valueOf("2015-05-10"),
-                        "ala ma kota",
-                        "ala ma kot",
-                        "ala ma    ",
-                        true,
-                        "kot binarny".getBytes()
-                )
-        );
+            assertThat(queryResult).containsOnly(
+                    row(
+                            127,
+                            32767,
+                            2147483647,
+                            9223372036854775807L,
+                            123.345f,
+                            234.567,
+                            new BigDecimal("346"),
+                            new BigDecimal("345.67800"),
+                            parseTimestampInUTC("2015-05-10 12:15:35.123"),
+                            Date.valueOf("2015-05-10"),
+                            "ala ma kota",
+                            "ala ma kot",
+                            "ala ma    ",
+                            true,
+                            "kot binarny".getBytes()
+                    )
+            );
+        }
+        else {
+            LOGGER.warn(format("Skipping test. Table %s does not exist.", tableName));
+        }
     }
 
-    @Test(groups = {S3_CONNECTOR, QUARANTINE})
+    @Test(groups = {S3_CONNECTOR})
     public void testAllDataTypesRcFile()
             throws SQLException
     {
@@ -86,31 +105,37 @@ public class TestHiveS3Connector
         // from hive/data/all_types/data.rcfile.  the table is created with the name alltypes_rcfile.
         // The test assumes that table is already created in the hive catalog and has data loaded.
 
-        assertProperAllDatatypesSchema("alltypes_rcfile");
-        QueryResult queryResult = query("SELECT * FROM alltypes_rcfile");
+        String tableName = "alltypes_rcfile";
+        if (isCreated(tableName)) {
+            assertProperAllDatatypesSchema(tableName);
+            QueryResult queryResult = query(format("SELECT * FROM %s", tableName));
 
-        assertThat(queryResult).containsOnly(
-                row(
-                        127,
-                        32767,
-                        2147483647,
-                        9223372036854775807L,
-                        123.345f,
-                        234.567,
-                        new BigDecimal("346"),
-                        new BigDecimal("345.67800"),
-                        parseTimestampInUTC("2015-05-10 12:15:35.123"),
-                        Date.valueOf("2015-05-10"),
-                        "ala ma kota",
-                        "ala ma kot",
-                        "ala ma    ",
-                        true,
-                        "kot binarny".getBytes()
-                )
-        );
+            assertThat(queryResult).containsOnly(
+                    row(
+                            127,
+                            32767,
+                            2147483647,
+                            9223372036854775807L,
+                            123.345f,
+                            234.567,
+                            new BigDecimal("346"),
+                            new BigDecimal("345.67800"),
+                            parseTimestampInUTC("2015-05-10 12:15:35.123"),
+                            Date.valueOf("2015-05-10"),
+                            "ala ma kota",
+                            "ala ma kot",
+                            "ala ma    ",
+                            true,
+                            "kot binarny".getBytes()
+                    )
+            );
+        }
+        else {
+            LOGGER.warn(format("Skipping test. Table %s does not exist.", tableName));
+        }
     }
 
-    @Test(groups = {S3_CONNECTOR, QUARANTINE})
+    @Test(groups = {S3_CONNECTOR})
     public void testAllDataTypesOrc()
             throws SQLException
     {
@@ -118,31 +143,37 @@ public class TestHiveS3Connector
         // with data from hive/data/all_types/data.orc.  The table is created with the name alltypes_orc.
         // The test assumes that table is already created in the hive catalog and has data loaded.
 
-        assertProperAllDatatypesSchema("alltypes_orc");
-        QueryResult queryResult = query("SELECT * FROM alltypes_orc");
+        String tableName = "alltypes_orc";
+        if (isCreated(tableName)) {
+            assertProperAllDatatypesSchema(tableName);
+            QueryResult queryResult = query(format("SELECT * FROM %s", tableName));
 
-        assertThat(queryResult).containsOnly(
-                row(
-                        127,
-                        32767,
-                        2147483647,
-                        9223372036854775807L,
-                        123.345f,
-                        234.567,
-                        new BigDecimal("346"),
-                        new BigDecimal("345.67800"),
-                        parseTimestampInUTC("2015-05-10 12:15:35.123"),
-                        Date.valueOf("2015-05-10"),
-                        "ala ma kota",
-                        "ala ma kot",
-                        "ala ma    ",
-                        true,
-                        "kot binarny".getBytes()
-                )
-        );
+            assertThat(queryResult).containsOnly(
+                    row(
+                            127,
+                            32767,
+                            2147483647,
+                            9223372036854775807L,
+                            123.345f,
+                            234.567,
+                            new BigDecimal("346"),
+                            new BigDecimal("345.67800"),
+                            parseTimestampInUTC("2015-05-10 12:15:35.123"),
+                            Date.valueOf("2015-05-10"),
+                            "ala ma kota",
+                            "ala ma kot",
+                            "ala ma    ",
+                            true,
+                            "kot binarny".getBytes()
+                    )
+            );
+        }
+        else {
+            LOGGER.warn(format("Skipping test. Table %s does not exist.", tableName));
+        }
     }
 
-    @Test(groups = {S3_CONNECTOR, QUARANTINE})
+    @Test(groups = {S3_CONNECTOR})
     public void testAllDataTypesParquet()
             throws SQLException
     {
@@ -151,34 +182,46 @@ public class TestHiveS3Connector
         // hive/data/all_types/data.textfile. The table is created with the name alltypes_parquet.
         // The test assumes that table is already created in the hive catalog and has data loaded.
 
-        assertProperParquetDatatypesSchema("alltypes_parquet");
-        QueryResult queryResult = query("SELECT * FROM alltypes_parquet");
+        String tableName = "alltypes_parquet";
+        if (isCreated(tableName)) {
+            assertProperParquetDatatypesSchema(tableName);
+            QueryResult queryResult = query(format("SELECT * FROM %s", tableName));
 
-        assertThat(queryResult).containsOnly(
-                row(
-                        127,
-                        32767,
-                        2147483647,
-                        9223372036854775807L,
-                        123.345f,
-                        234.567,
-                        parseTimestampInUTC("2015-05-10 12:15:35.123"),
-                        "ala ma kota",
-                        "ala ma kot",
-                        "ala ma    ",
-                        true
-                )
-        );
+            assertThat(queryResult).containsOnly(
+                    row(
+                            127,
+                            32767,
+                            2147483647,
+                            9223372036854775807L,
+                            123.345f,
+                            234.567,
+                            parseTimestampInUTC("2015-05-10 12:15:35.123"),
+                            "ala ma kota",
+                            "ala ma kot",
+                            "ala ma    ",
+                            true
+                    )
+            );
+        }
+        else {
+            LOGGER.warn(format("Skipping test. Table %s does not exist.", tableName));
+        }
     }
 
-    @Test(groups = {S3_CONNECTOR, QUARANTINE})
+    @Test(groups = {S3_CONNECTOR})
     public void shouldCreateTableAsSelect()
             throws Exception
     {
-        String tableName = "create_table_as_select";
-        query(format("DROP TABLE IF EXISTS %s", tableName));
-        query(format("CREATE TABLE %s AS SELECT * FROM nation", tableName));
-        assertThat(query(format("SELECT * FROM %s", tableName))).hasRowsCount(25);
+        String selectTable = "nation";
+        if (isCreated(selectTable)) {
+            String createTable = "create_table_as_select";
+            query(format("DROP TABLE IF EXISTS %s", createTable));
+            query(format("CREATE TABLE %s AS SELECT * FROM %s", createTable, selectTable));
+            assertThat(query(format("SELECT * FROM %s", createTable))).hasRowsCount(25);
+        }
+        else {
+            LOGGER.warn(format("Skipping test. Table %s does not exist.", selectTable));
+        }
     }
 
     private void assertProperAllDatatypesSchema(String tableName)
@@ -217,5 +260,16 @@ public class TestHiveS3Connector
                 row("c_char", "char(10)"),
                 row("c_boolean", "boolean")
         );
+    }
+
+    private boolean isCreated(String tableName)
+    {
+        try {
+            defaultQueryExecutor().executeQuery(format("SELECT * FROM %s LIMIT 1", tableName));
+            return true;
+        }
+        catch (QueryExecutionException e) {
+            return false;
+        }
     }
 }

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveS3Connector.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveS3Connector.java
@@ -18,8 +18,7 @@ import com.teradata.tempto.ProductTest;
 import com.teradata.tempto.query.QueryExecutionException;
 import com.teradata.tempto.query.QueryResult;
 import com.teradata.tempto.query.QueryType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.airlift.log.Logger;
 import org.testng.annotations.Test;
 
 import java.math.BigDecimal;
@@ -42,7 +41,7 @@ import static java.lang.String.format;
 public class TestHiveS3Connector
         extends ProductTest
 {
-    private static final Logger LOGGER = LoggerFactory.getLogger(TestHiveS3Connector.class);
+    private static final Logger LOGGER = Logger.get(TestHiveS3Connector.class);
 
     @Test(groups = {S3_CONNECTOR})
     public void testSelectFromTextFile()
@@ -50,9 +49,9 @@ public class TestHiveS3Connector
     {
         // This test uses a standard tpch nation table.  It assumes that table is already created in the hive catalog
         // and has data loaded.
-        String tableName = "hive.default.nation";
+        String tableName = "hive.default.nation_s3";
         if (isCreated(tableName)) {
-            QueryResult queryResult = query("SELECT n_name FROM hive.default.nation where n_nationkey = 7");
+            QueryResult queryResult = query(format("SELECT n_name FROM %s WHERE n_nationkey = 7", tableName));
             assertThat(queryResult).containsOnly(row("GERMANY"));
         }
         else {
@@ -67,10 +66,10 @@ public class TestHiveS3Connector
         // This test uses the all_types table as defined in the AllSimpleTypesTableDefinition class and
         // data from hive/data/all_types/data.textfile. The table is create with the name 'alltypes_text'.
         // The test assumes that table is already created in the hive catalog and has data loaded.
-        String tableName = "alltypes_text";
+        String tableName = "alltypes_s3_text";
         if (isCreated(tableName)) {
-            assertProperAllDatatypesSchema("alltypes_text");
-            QueryResult queryResult = query("SELECT * FROM alltypes_text");
+            assertProperAllDatatypesSchema(tableName);
+            QueryResult queryResult = query(format("SELECT * FROM %s", tableName));
 
             assertThat(queryResult).containsOnly(
                     row(
@@ -105,7 +104,7 @@ public class TestHiveS3Connector
         // from hive/data/all_types/data.rcfile.  the table is created with the name alltypes_rcfile.
         // The test assumes that table is already created in the hive catalog and has data loaded.
 
-        String tableName = "alltypes_rcfile";
+        String tableName = "alltypes_s3_rcfile";
         if (isCreated(tableName)) {
             assertProperAllDatatypesSchema(tableName);
             QueryResult queryResult = query(format("SELECT * FROM %s", tableName));
@@ -182,7 +181,7 @@ public class TestHiveS3Connector
         // hive/data/all_types/data.textfile. The table is created with the name alltypes_parquet.
         // The test assumes that table is already created in the hive catalog and has data loaded.
 
-        String tableName = "alltypes_parquet";
+        String tableName = "alltypes_s3_parquet";
         if (isCreated(tableName)) {
             assertProperParquetDatatypesSchema(tableName);
             QueryResult queryResult = query(format("SELECT * FROM %s", tableName));
@@ -212,9 +211,9 @@ public class TestHiveS3Connector
     public void shouldCreateTableAsSelect()
             throws Exception
     {
-        String selectTable = "nation";
+        String selectTable = "nation_s3";
         if (isCreated(selectTable)) {
-            String createTable = "create_table_as_select";
+            String createTable = "create_table_as_select_s3";
             query(format("DROP TABLE IF EXISTS %s", createTable));
             query(format("CREATE TABLE %s AS SELECT * FROM %s", createTable, selectTable));
             assertThat(query(format("SELECT * FROM %s", createTable))).hasRowsCount(25);


### PR DESCRIPTION
Instead only run the tests if the tables exist, and warn if they do not
exist.

My concern with this is that we won't notice if the tests stop working since they'll pass anyway.  
@brian-rickman 
