### PR TITLE
Add LDAP authentication tests for Simba JDBC driver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -766,6 +766,12 @@
 
             <dependency>
                 <groupId>com.teradata.tempto</groupId>
+                <artifactId>tempto-ldap</artifactId>
+                <version>${dep.tempto.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.teradata.tempto</groupId>
                 <artifactId>tempto-runner</artifactId>
                 <version>${dep.tempto.version}</version>
             </dependency>

--- a/presto-product-tests/README.md
+++ b/presto-product-tests/README.md
@@ -147,6 +147,10 @@ where [profile](#profile) is one of either:
  installation running on a single Docker container and a single node
  installation of kerberized Presto also running on a single Docker container.
  This profile runs Kerberos without impersonation.
+- **singlenode-ldap** - Three single node Docker containers, one running an
+ OpenLDAP server, one running with SSL/TLS certificates installed on top of a
+ single node Presto installation, and one with a pseudo-distributed Hadoop
+ installation.
 
 Please keep in mind that if you run tests on Hive of version not greater than 1.0.1, you should exclude test from `post_hive_1_0_1` group by passing the following flag to tempto: `-x post_hive_1_0_1`.
 First version of Hive capable of running tests from `post_hive_1_0_1` group is Hive 1.1.0.
@@ -198,6 +202,7 @@ groups.
 | Authorization         | ``authorization``         | ``singlenode-kerberos-hdfs-impersonation``                                       |
 | HDFS impersonation    | ``hdfs_impersonation``    | ``singlenode-hdfs-impersonation``, ``singlenode-kerberos-hdfs-impersonation``    |
 | No HDFS impersonation | ``hdfs_no_impersonation`` | ``singlenode``, ``singlenode-kerberos-hdfs-no_impersonation``                    |
+| LDAP                  | ``ldap``                  | ``singlenode-ldap``                                                              |
 
 Below is a list of commands that explain how to run these profile specific tests
 and also the entire test suite:
@@ -218,6 +223,11 @@ and also the entire test suite:
 
     ```
     presto-product-tests/bin/run_on_docker.sh <profile> -g hdfs_no_impersonation
+    ```
+* Run **LDAP** tests:
+
+    ```
+    presto-product-tests/bin/run_on_docker.sh singlenode-ldap -g ldap
     ```
 * Run the **entire test suite** excluding all profile specific tests, where &lt;profile> can
 be any one of the available profiles:

--- a/presto-product-tests/bin/run_on_docker.sh
+++ b/presto-product-tests/bin/run_on_docker.sh
@@ -190,6 +190,11 @@ environment_compose up -d hadoop-master
 environment_compose up -d mysql
 environment_compose up -d postgres
 
+# start ldap container
+if [[ "$ENVIRONMENT" == "singlenode-ldap" ]]; then
+  environment_compose up -d ldapserver
+fi
+
 # start docker logs for hadoop container
 environment_compose logs --no-color hadoop-master &
 HADOOP_LOGS_PID=$!

--- a/presto-product-tests/conf/docker/files/presto-launcher-wrapper.sh
+++ b/presto-product-tests/conf/docker/files/presto-launcher-wrapper.sh
@@ -4,8 +4,8 @@ set -e
 
 CONFIG=$1
 
-if [[ "$CONFIG" != "singlenode" && "$CONFIG" != "multinode-master" && "$CONFIG" != "multinode-worker" && "$CONFIG" != "singlenode-kerberized" ]]; then
-   echo "Usage: launcher-wrapper <singlenode|multinode-master|multinode-worker|singlenode-kerberized> <launcher args>"
+if [[ "$CONFIG" != "singlenode" && "$CONFIG" != "multinode-master" && "$CONFIG" != "multinode-worker" && "$CONFIG" != "singlenode-kerberized" && "$CONFIG" != "singlenode-ldap" ]]; then
+   echo "Usage: launcher-wrapper <singlenode|multinode-master|multinode-worker|singlenode-kerberized|singlenode-ldap> <launcher args>"
    exit 1
 fi
 

--- a/presto-product-tests/conf/docker/singlenode-ldap/compose.sh
+++ b/presto-product-tests/conf/docker/singlenode-ldap/compose.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+source ${BASH_SOURCE%/*}/../common/compose-commons.sh
+
 docker-compose \
 -f ${BASH_SOURCE%/*}/../common/standard.yml \
 -f ${BASH_SOURCE%/*}/../common/jdbc_db.yml \

--- a/presto-product-tests/conf/docker/singlenode-ldap/compose.sh
+++ b/presto-product-tests/conf/docker/singlenode-ldap/compose.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+docker-compose \
+-f ${BASH_SOURCE%/*}/../common/standard.yml \
+-f ${BASH_SOURCE%/*}/../common/jdbc_db.yml \
+-f ${BASH_SOURCE%/*}/docker-compose.yml \
+"$@"

--- a/presto-product-tests/conf/docker/singlenode-ldap/docker-compose.yml
+++ b/presto-product-tests/conf/docker/singlenode-ldap/docker-compose.yml
@@ -11,3 +11,6 @@ services:
     image: 'teradatalabs/centos6-java8-oracle-ldap'
     volumes:
       - ../../../conf/tempto/tempto-configuration-for-docker-ldap.yaml:/docker/volumes/tempto/tempto-configuration-local.yaml
+
+  ldapserver:
+    image: 'teradatalabs/centos6-java8-oracle-openldap'

--- a/presto-product-tests/conf/docker/singlenode-ldap/docker-compose.yml
+++ b/presto-product-tests/conf/docker/singlenode-ldap/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '2'
+services:
+
+  presto-master:
+    image: 'teradatalabs/centos6-java8-oracle-ldap'
+    command: /docker/volumes/presto/presto-product-tests/conf/docker/files/presto-launcher-wrapper.sh singlenode-ldap run
+    extra_hosts:
+       - "${LDAP_SERVER_HOST}:${LDAP_SERVER_IP}"
+
+  application-runner:
+    image: 'teradatalabs/centos6-java8-oracle-ldap'
+    volumes:
+      - ../../../../presto-product-tests/conf/tempto/tempto-configuration-for-docker-ldap.yaml:/docker/volumes/tempto/tempto-configuration-local.yaml

--- a/presto-product-tests/conf/docker/singlenode-ldap/docker-compose.yml
+++ b/presto-product-tests/conf/docker/singlenode-ldap/docker-compose.yml
@@ -3,11 +3,11 @@ services:
 
   presto-master:
     image: 'teradatalabs/centos6-java8-oracle-ldap'
-    command: /docker/volumes/presto/presto-product-tests/conf/docker/files/presto-launcher-wrapper.sh singlenode-ldap run
+    command: /docker/volumes/conf/docker/files/presto-launcher-wrapper.sh singlenode-ldap run
     extra_hosts:
        - "${LDAP_SERVER_HOST}:${LDAP_SERVER_IP}"
 
   application-runner:
     image: 'teradatalabs/centos6-java8-oracle-ldap'
     volumes:
-      - ../../../../presto-product-tests/conf/tempto/tempto-configuration-for-docker-ldap.yaml:/docker/volumes/tempto/tempto-configuration-local.yaml
+      - ../../../conf/tempto/tempto-configuration-for-docker-ldap.yaml:/docker/volumes/tempto/tempto-configuration-local.yaml

--- a/presto-product-tests/conf/presto/etc/singlenode-ldap.properties
+++ b/presto-product-tests/conf/presto/etc/singlenode-ldap.properties
@@ -26,4 +26,4 @@ authentication.ldap.enabled=true
 authentication.ldap.url=ldaps://ldap-server:636
 authentication.ldap.ad-domain=presto.testldap.com
 authentication.ldap.base-dn=OU=Asia,DC=presto,DC=testldap,DC=com
-authentication.ldap.group-dn=CN=FinanceSubGroup,OU=America,DC=presto,DC=testldap,DC=com
+authentication.ldap.group-dn=CN=ParentGroup,OU=America,DC=presto,DC=testldap,DC=com

--- a/presto-product-tests/conf/presto/etc/singlenode-ldap.properties
+++ b/presto-product-tests/conf/presto/etc/singlenode-ldap.properties
@@ -1,0 +1,29 @@
+#
+# WARNING
+# ^^^^^^^
+# This configuration file is for development only and should NOT be used be
+# used in production. For example configuration, see the Presto documentation.
+#
+
+node.id=will-be-overwritten
+node.environment=test
+
+coordinator=true
+node-scheduler.include-coordinator=true
+http-server.http.port=8080
+query.max-memory=1GB
+query.max-memory-per-node=512MB
+discovery-server.enabled=true
+discovery.uri=http://presto-master:8080
+
+# LDAP specific properties
+# https will have to enabled for ldap authentication
+http-server.https.port=8443
+http-server.https.enabled=true
+http-server.https.keystore.path=/etc/ldap/coordinator.jks
+http-server.https.keystore.key=testldap
+authentication.ldap.enabled=true
+authentication.ldap.url=ldaps://ldap-server:636
+authentication.ldap.ad-domain=presto.testldap.com
+authentication.ldap.base-dn=OU=America,DC=presto,DC=testldap,DC=com
+authentication.ldap.group-dn=CN=finance,OU=America,DC=presto,DC=testldap,DC=com

--- a/presto-product-tests/conf/presto/etc/singlenode-ldap.properties
+++ b/presto-product-tests/conf/presto/etc/singlenode-ldap.properties
@@ -25,5 +25,5 @@ http-server.https.keystore.key=testldap
 authentication.ldap.enabled=true
 authentication.ldap.url=ldaps://ldap-server:636
 authentication.ldap.ad-domain=presto.testldap.com
-authentication.ldap.base-dn=OU=America,DC=presto,DC=testldap,DC=com
-authentication.ldap.group-dn=CN=finance,OU=America,DC=presto,DC=testldap,DC=com
+authentication.ldap.base-dn=OU=Asia,DC=presto,DC=testldap,DC=com
+authentication.ldap.group-dn=CN=FinanceSubGroup,OU=America,DC=presto,DC=testldap,DC=com

--- a/presto-product-tests/conf/presto/etc/singlenode-ldap.properties
+++ b/presto-product-tests/conf/presto/etc/singlenode-ldap.properties
@@ -17,13 +17,14 @@ discovery-server.enabled=true
 discovery.uri=http://presto-master:8080
 
 # LDAP specific properties
-# https will have to enabled for ldap authentication
+# https will have to be enabled for ldap authentication
 http-server.https.port=8443
 http-server.https.enabled=true
 http-server.https.keystore.path=/etc/ldap/coordinator.jks
 http-server.https.keystore.key=testldap
 authentication.ldap.enabled=true
-authentication.ldap.url=ldaps://ldap-server:636
-authentication.ldap.ad-domain=presto.testldap.com
-authentication.ldap.base-dn=OU=Asia,DC=presto,DC=testldap,DC=com
-authentication.ldap.group-dn=CN=ParentGroup,OU=America,DC=presto,DC=testldap,DC=com
+authentication.ldap.server-type=OPENLDAP
+authentication.ldap.user-object-class=inetOrgPerson
+authentication.ldap.url=ldaps://ldapserver:636
+authentication.ldap.base-dn=ou=Asia,dc=presto,dc=testldap,dc=com
+authentication.ldap.group-dn=cn=DefaultGroup,ou=America,dc=presto,dc=testldap,dc=com

--- a/presto-product-tests/conf/tempto/tempto-configuration-for-docker-kerberos.yaml
+++ b/presto-product-tests/conf/tempto/tempto-configuration-for-docker-kerberos.yaml
@@ -18,7 +18,7 @@ databases:
     host: presto-master
     jdbc_user: hive
     cli_server_address: https://${databases.presto.host}:7778
-    cli_authentication: true
+    cli_kerberos_authentication: true
     cli_kerberos_principal: presto-client/presto-master@LABS.TERADATA.COM
     cli_kerberos_keytab: /etc/presto/conf/presto-client.keytab
     cli_kerberos_config_path: /etc/krb5.conf

--- a/presto-product-tests/conf/tempto/tempto-configuration-for-docker-ldap.yaml
+++ b/presto-product-tests/conf/tempto/tempto-configuration-for-docker-ldap.yaml
@@ -4,7 +4,6 @@ databases:
   presto:
     host: presto-master
     configured_hdfs_user: hive
-    cli_ldap_authentication: true
     cli_ldap_truststore_path: /etc/ldap/cacerts.jks
     cli_ldap_truststore_password: testldap
     cli_ldap_user_name: DefaultGroupUser

--- a/presto-product-tests/conf/tempto/tempto-configuration-for-docker-ldap.yaml
+++ b/presto-product-tests/conf/tempto/tempto-configuration-for-docker-ldap.yaml
@@ -1,0 +1,12 @@
+databases:
+  hive:
+    host: hadoop-master
+  presto:
+    host: presto-master
+    configured_hdfs_user: hive
+    cli_ldap_authentication: true
+    cli_ldap_truststore_path: /etc/ldap/cacerts.jks
+    cli_ldap_truststore_password: testldap
+    cli_ldap_user_name: financeuser1
+    cli_ldap_user_password: password
+    cli_ldap_server_address: https://${databases.presto.host}:8443

--- a/presto-product-tests/conf/tempto/tempto-configuration-for-docker-ldap.yaml
+++ b/presto-product-tests/conf/tempto/tempto-configuration-for-docker-ldap.yaml
@@ -7,6 +7,6 @@ databases:
     cli_ldap_authentication: true
     cli_ldap_truststore_path: /etc/ldap/cacerts.jks
     cli_ldap_truststore_password: testldap
-    cli_ldap_user_name: ParentGroupUser
+    cli_ldap_user_name: DefaultGroupUser
     cli_ldap_user_password: LDAPPass123
     cli_ldap_server_address: https://${databases.presto.host}:8443

--- a/presto-product-tests/conf/tempto/tempto-configuration-for-docker-ldap.yaml
+++ b/presto-product-tests/conf/tempto/tempto-configuration-for-docker-ldap.yaml
@@ -7,6 +7,6 @@ databases:
     cli_ldap_authentication: true
     cli_ldap_truststore_path: /etc/ldap/cacerts.jks
     cli_ldap_truststore_password: testldap
-    cli_ldap_user_name: financeuser1
+    cli_ldap_user_name: FinanceSubGroupUserInAsia
     cli_ldap_user_password: password
     cli_ldap_server_address: https://${databases.presto.host}:8443

--- a/presto-product-tests/conf/tempto/tempto-configuration-for-docker-ldap.yaml
+++ b/presto-product-tests/conf/tempto/tempto-configuration-for-docker-ldap.yaml
@@ -7,6 +7,6 @@ databases:
     cli_ldap_authentication: true
     cli_ldap_truststore_path: /etc/ldap/cacerts.jks
     cli_ldap_truststore_password: testldap
-    cli_ldap_user_name: FinanceSubGroupUserInAsia
-    cli_ldap_user_password: password
+    cli_ldap_user_name: ParentGroupUser
+    cli_ldap_user_password: LDAPPass123
     cli_ldap_server_address: https://${databases.presto.host}:8443

--- a/presto-product-tests/conf/tempto/tempto-configuration-for-docker-simba.yaml
+++ b/presto-product-tests/conf/tempto/tempto-configuration-for-docker-simba.yaml
@@ -1,0 +1,15 @@
+databases:
+  hive:
+    host: hadoop-master
+  presto:
+    host: presto-master
+    configured_hdfs_user: hive
+    jdbc_driver_class: com.teradata.presto.jdbc42.Driver
+    jdbc_url: jdbc:presto://${databases.presto.server_address}/hive/${databases.hive.schema};TimeZoneID=Africa/Abidjan;
+    cli_ldap_truststore_path: /etc/ldap/cacerts.jks
+    cli_ldap_truststore_password: testldap
+    cli_ldap_user_name: DefaultGroupUser
+    cli_ldap_user_password: LDAPPass123
+    cli_ldap_server_address: https://${databases.presto.host}:8443
+    ssl_port: 8443
+

--- a/presto-product-tests/pom.xml
+++ b/presto-product-tests/pom.xml
@@ -40,6 +40,10 @@
         </dependency>
         <dependency>
             <groupId>com.teradata.tempto</groupId>
+            <artifactId>tempto-ldap</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.teradata.tempto</groupId>
             <artifactId>tempto-runner</artifactId>
         </dependency>
         <dependency>

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/ImmutableLdapObjectDefinitions.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/ImmutableLdapObjectDefinitions.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.google.common.collect.ImmutableMap;
+import com.teradata.tempto.fulfillment.ldap.LdapObjectDefinition;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static java.lang.String.format;
+
+public final class ImmutableLdapObjectDefinitions
+{
+    private static final String domain = "dc=presto,dc=testldap,dc=com";
+    private static final String americaOrgDistinguishedName = format("ou=America,%s", domain);
+    private static final String asiaOrgDistinguishedName = format("ou=Asia,%s", domain);
+    private static final String password = "LDAPPass123";
+
+    private ImmutableLdapObjectDefinitions()
+    {}
+
+    public static final LdapObjectDefinition AMERICA_ORG = buildLdapOrganizationObject("America", americaOrgDistinguishedName, "America");
+
+    public static final LdapObjectDefinition ASIA_ORG = buildLdapOrganizationObject("Asia", asiaOrgDistinguishedName, "Asia");
+
+    public static final LdapObjectDefinition DEFAULT_GROUP = buildLdapGroupObject("DefaultGroup", "DefaultGroupUser");
+
+    public static final LdapObjectDefinition PARENT_GROUP = buildLdapGroupObject("ParentGroup", "ParentGroupUser");
+
+    public static final LdapObjectDefinition CHILD_GROUP = buildLdapGroupObject("ChildGroup", "ChildGroupUser");
+
+    public static final LdapObjectDefinition DEFAULT_GROUP_USER = buildLdapUserObject("DefaultGroupUser", Optional.of("DefaultGroup"));
+
+    public static final LdapObjectDefinition PARENT_GROUP_USER = buildLdapUserObject("ParentGroupUser", Optional.of("ParentGroup"));
+
+    public static final LdapObjectDefinition CHILD_GROUP_USER = buildLdapUserObject("ChildGroupUser", Optional.of("ChildGroup"));
+
+    public static final LdapObjectDefinition ORPHAN_USER = buildLdapUserObject("OrphanUser", Optional.<String>empty());
+
+    private static LdapObjectDefinition buildLdapOrganizationObject(String id, String distinguishedName, String unit)
+    {
+        return LdapObjectDefinition.builder(id)
+                .setDistinguishedName(distinguishedName)
+                .setAttributes(ImmutableMap.of("ou", unit))
+                .addObjectClasses(Arrays.asList("top", "organizationalUnit"))
+                .build();
+    }
+
+    private static LdapObjectDefinition buildLdapGroupObject(String groupName, String userName)
+    {
+        return buildLdapGroupObject(groupName, americaOrgDistinguishedName, userName, asiaOrgDistinguishedName);
+    }
+
+    private static LdapObjectDefinition buildLdapGroupObject(String groupName, String groupOrganizationName,
+                                                             String userName, String userOrganizationName)
+    {
+        return LdapObjectDefinition.builder(groupName)
+                .setDistinguishedName(format("cn=%s,%s", groupName, groupOrganizationName))
+                .setAttributes(ImmutableMap.of(
+                        "cn", groupName,
+                        "member", format("uid=%s,%s", userName, userOrganizationName)))
+                .addObjectClasses(Arrays.asList("groupOfNames"))
+                .build();
+    }
+
+    private static LdapObjectDefinition buildLdapUserObject(String userName, Optional<String> groupName)
+    {
+        if (groupName.isPresent()) {
+            return buildLdapUserObject(userName, asiaOrgDistinguishedName,
+                    groupName, Optional.of(americaOrgDistinguishedName));
+        }
+        else {
+            return buildLdapUserObject(userName, asiaOrgDistinguishedName,
+                    Optional.<String>empty(), Optional.<String>empty());
+        }
+    }
+
+    private static LdapObjectDefinition buildLdapUserObject(String userName, String userOrganizationName,
+                                                            Optional<String> groupName, Optional<String> groupOrganizationName)
+    {
+        if (groupName.isPresent() && groupOrganizationName.isPresent()) {
+            return LdapObjectDefinition.builder(userName)
+                    .setDistinguishedName(format("uid=%s,%s", userName, userOrganizationName))
+                    .setAttributes(ImmutableMap.of(
+                            "cn", userName,
+                            "sn", userName,
+                            "userPassword", password,
+                            "memberOf", format("cn=%s,%s", groupName.get(), groupOrganizationName.get())
+                    ))
+                    .addObjectClasses(Arrays.asList("person", "inetOrgPerson"))
+                    .build();
+        }
+        else {
+            return LdapObjectDefinition.builder(userName)
+                    .setDistinguishedName(format("uid=%s,%s", userName, userOrganizationName))
+                    .setAttributes(ImmutableMap.of(
+                            "cn", userName,
+                            "sn", userName,
+                            "userPassword", password
+                    )).addObjectClasses(Arrays.asList("person", "inetOrgPerson"))
+                    .build();
+        }
+    }
+}

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/TestGroups.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/TestGroups.java
@@ -52,6 +52,7 @@ public final class TestGroups
     public static final String AUTHORIZATION = "authorization";
     public static final String POST_HIVE_1_0_1 = "post_hive_1_0_1";
     public static final String PREPARED_STATEMENTS = "prepared_statements";
+    public static final String LDAP = "ldap";
 
     private TestGroups() {}
 }

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/TestGroups.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/TestGroups.java
@@ -15,6 +15,7 @@ package com.facebook.presto.tests;
 
 public final class TestGroups
 {
+    public static final String ACTIVE_DIRECTORY = "active_directory";
     public static final String CREATE_TABLE = "create_table";
     public static final String CREATE_DROP_VIEW = "create_drop_view";
     public static final String ALTER_TABLE = "alter_table";

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoCliLauncher.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoCliLauncher.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests.cli;
+
+import com.facebook.presto.cli.Presto;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import com.teradata.tempto.ProductTest;
+
+import java.io.IOException;
+import java.util.List;
+
+import static com.google.common.io.Resources.getResource;
+import static com.google.common.io.Resources.readLines;
+import static com.teradata.tempto.process.JavaProcessLauncher.defaultJavaProcessLauncher;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.asList;
+
+public class PrestoCliLauncher
+        extends ProductTest
+{
+    protected static final long TIMEOUT = 300 * 1000; // 30 secs per test
+    protected static final String EXIT_COMMAND = "exit";
+    protected final List<String> nationTableInteractiveLines;
+    protected final List<String> nationTableBatchLines;
+
+    @Inject
+    @Named("databases.presto.host")
+    protected String serverHost;
+
+    @Inject
+    @Named("databases.presto.server_address")
+    protected String serverAddress;
+
+    protected PrestoCliProcess presto;
+
+    protected PrestoCliLauncher()
+            throws IOException
+    {
+        nationTableInteractiveLines = readLines(getResource("com/facebook/presto/tests/cli/interactive_query.results"), UTF_8);
+        nationTableBatchLines = readLines(getResource("com/facebook/presto/tests/cli/batch_query.results"), UTF_8);
+    }
+
+    protected void stopPresto()
+            throws InterruptedException
+    {
+        if (presto != null) {
+            presto.getProcessInput().println(EXIT_COMMAND);
+            presto.waitForWithTimeoutAndKill();
+        }
+    }
+
+    protected void launchPrestoCli(String... arguments)
+            throws IOException, InterruptedException
+    {
+        launchPrestoCli(asList(arguments));
+    }
+
+    protected void launchPrestoCli(List<String> arguments)
+            throws IOException, InterruptedException
+    {
+        presto = new PrestoCliProcess(defaultJavaProcessLauncher().launch(Presto.class, arguments));
+    }
+}

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoCliProcess.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoCliProcess.java
@@ -26,6 +26,7 @@ public final class PrestoCliProcess
         extends LocalCliProcess
 {
     private static final String PRESTO_PROMPT = "presto>";
+    private static final String LDAP_PASSWORD_PROMPT = "Enter password:";
     private static final Pattern PRESTO_PROMPT_PATTERN = Pattern.compile(quote(PRESTO_PROMPT));
 
     public PrestoCliProcess(Process process)
@@ -46,5 +47,10 @@ public final class PrestoCliProcess
     public void waitForPrompt()
     {
         assertThat(nextOutputToken()).isEqualTo(PRESTO_PROMPT);
+    }
+
+    public void waitForLdapPasswordPrompt()
+    {
+        assertThat((nextOutputToken().concat(" ")).concat(nextOutputToken())).isEqualTo(LDAP_PASSWORD_PROMPT);
     }
 }

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoCliTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoCliTests.java
@@ -60,8 +60,8 @@ public class PrestoCliTests
     private String serverAddress;
 
     @Inject(optional = true)
-    @Named("databases.presto.cli_authentication")
-    private boolean authentication;
+    @Named("databases.presto.cli_kerberos_authentication")
+    private boolean kerberosAuthentication;
 
     @Inject(optional = true)
     @Named("databases.presto.cli_kerberos_principal")
@@ -94,6 +94,30 @@ public class PrestoCliTests
     @Inject
     @Named("databases.presto.jdbc_user")
     private String jdbcUser;
+
+    @Inject(optional = true)
+    @Named("databases.presto.cli_ldap_authentication")
+    private boolean ldapAuthentication;
+
+    @Inject(optional = true)
+    @Named("databases.presto.cli_ldap_truststore_path")
+    private String ldapTruststorePath;
+
+    @Inject(optional = true)
+    @Named("databases.presto.cli_ldap_truststore_password")
+    private String ldapTruststorePassword;
+
+    @Inject(optional = true)
+    @Named("databases.presto.cli_ldap_user_name")
+    private String ldapUserName;
+
+    @Inject(optional = true)
+    @Named("databases.presto.cli_ldap_server_address")
+    private String ldapServerAddress;
+
+    @Inject(optional = true)
+    @Named("databases.presto.cli_ldap_user_password")
+    private String ldapUserPassword;
 
     private PrestoCliProcess presto;
 
@@ -144,6 +168,7 @@ public class PrestoCliTests
             throws IOException, InterruptedException
     {
         launchPrestoCliWithServerArgument("--execute", "select * from hive.default.nation;");
+
         assertThat(trimLines(presto.readRemainingOutputLines())).containsAll(nationTableBatchLines);
     }
 
@@ -200,15 +225,26 @@ public class PrestoCliTests
     private void launchPrestoCliWithServerArgument(String... arguments)
             throws IOException, InterruptedException
     {
-        if (!authentication) {
+        if (ldapAuthentication) {
+            requireNonNull(ldapTruststorePath, "databases.presto.cli_ldap_truststore_path is null");
+            requireNonNull(ldapTruststorePassword, "databases.presto.cli_ldap_truststore_password is null");
+            requireNonNull(ldapUserName, "databases.presto.cli_ldap_user_name is null");
+            requireNonNull(ldapServerAddress, "databases.presto.cli_ldap_server_address is null");
+            requireNonNull(ldapUserPassword, "databases.presto.cli_ldap_user_password is null");
+
             ImmutableList.Builder<String> prestoClientOptions = ImmutableList.builder();
             prestoClientOptions.add(
-                    "--server", serverAddress,
-                    "--user", jdbcUser);
+                    "--server", ldapServerAddress,
+                    "--truststore-path", ldapTruststorePath,
+                    "--truststore-password", ldapTruststorePassword,
+                    "--user", ldapUserName,
+                    "--password");
+
             prestoClientOptions.add(arguments);
             launchPrestoCli(prestoClientOptions.build());
+            setLdapPassword();
         }
-        else {
+        else if (kerberosAuthentication) {
             requireNonNull(kerberosPrincipal, "databases.presto.cli_kerberos_principal is null");
             requireNonNull(kerberosKeytab, "databases.presto.cli_kerberos_keytab is null");
             requireNonNull(kerberosServiceName, "databases.presto.cli_kerberos_service_name is null");
@@ -233,6 +269,14 @@ public class PrestoCliTests
             prestoClientOptions.add(arguments);
             launchPrestoCli(prestoClientOptions.build());
         }
+        else {
+            ImmutableList.Builder<String> prestoClientOptions = ImmutableList.builder();
+            prestoClientOptions.add(
+                    "--server", serverAddress,
+                    "--user", jdbcUser);
+            prestoClientOptions.add(arguments);
+            launchPrestoCli(prestoClientOptions.build());
+        }
     }
 
     private void launchPrestoCli(String... arguments)
@@ -245,5 +289,12 @@ public class PrestoCliTests
             throws IOException, InterruptedException
     {
         presto = new PrestoCliProcess(defaultJavaProcessLauncher().launch(Presto.class, arguments));
+    }
+
+    private void setLdapPassword()
+    {
+        presto.waitForLdapPasswordPrompt();
+        presto.getProcessInput().println(ldapUserPassword);
+        presto.nextOutputToken();
     }
 }

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoCliTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoCliTests.java
@@ -30,10 +30,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
-import static com.facebook.presto.tests.TestGroups.ACTIVE_DIRECTORY;
 import static com.facebook.presto.tests.TestGroups.CLI;
 import static com.facebook.presto.tests.TestGroups.PREPARED_STATEMENTS;
-import static com.facebook.presto.tests.TestGroups.PROFILE_SPECIFIC_TESTS;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Strings.repeat;
 import static com.google.common.io.Resources.getResource;
@@ -46,21 +44,20 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.testng.Assert.assertTrue;
 
 public class PrestoCliTests
         extends ProductTest
         implements RequirementsProvider
 {
-    private static final long TIMEOUT = 300 * 1000; // 30 secs per test
-    private static final String EXIT_COMMAND = "exit";
+    protected static final long TIMEOUT = 300 * 1000; // 30 secs per test
+    protected static final String EXIT_COMMAND = "exit";
 
-    private final List<String> nationTableInteractiveLines;
-    private final List<String> nationTableBatchLines;
+    protected final List<String> nationTableInteractiveLines;
+    protected final List<String> nationTableBatchLines;
 
     @Inject
     @Named("databases.presto.host")
-    private String serverHost;
+    protected String serverHost;
 
     @Inject
     @Named("databases.presto.server_address")
@@ -102,31 +99,7 @@ public class PrestoCliTests
     @Named("databases.presto.jdbc_user")
     private String jdbcUser;
 
-    @Inject(optional = true)
-    @Named("databases.presto.cli_ldap_authentication")
-    private boolean ldapAuthentication;
-
-    @Inject(optional = true)
-    @Named("databases.presto.cli_ldap_truststore_path")
-    private String ldapTruststorePath;
-
-    @Inject(optional = true)
-    @Named("databases.presto.cli_ldap_truststore_password")
-    private String ldapTruststorePassword;
-
-    @Inject(optional = true)
-    @Named("databases.presto.cli_ldap_user_name")
-    private String ldapUserName;
-
-    @Inject(optional = true)
-    @Named("databases.presto.cli_ldap_server_address")
-    private String ldapServerAddress;
-
-    @Inject(optional = true)
-    @Named("databases.presto.cli_ldap_user_password")
-    private String ldapUserPassword;
-
-    private PrestoCliProcess presto;
+    protected PrestoCliProcess presto;
 
     public PrestoCliTests()
             throws IOException
@@ -229,158 +202,10 @@ public class PrestoCliTests
         assertThat(trimLines(presto.readRemainingErrorLines())).containsExactly("PREPARE", "DEALLOCATE");
     }
 
-    @Test(groups = {CLI, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
-    public void shouldPassQueryForLdapUserInMultipleGroups()
+    protected void launchPrestoCliWithServerArgument(String... arguments)
             throws IOException, InterruptedException
     {
-        ldapUserName = "UserInMultipleGroups";
-        launchPrestoCliWithServerArgument("--catalog", "hive", "--schema", "default", "--execute", "select * from nation;");
-        assertThat(trimLines(presto.readRemainingOutputLines())).containsAll(nationTableBatchLines);
-    }
-
-    @Test(groups = {CLI, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
-    public void shouldFailQueryForLdapUserInChildGroup()
-            throws IOException, InterruptedException
-    {
-        ldapUserName = "ChildGroupUser";
-        launchPrestoCliWithServerArgument("--catalog", "hive", "--schema", "default", "--execute", "select * from nation;");
-        assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("User " + ldapUserName + " not a member of the group")));
-    }
-
-    @Test(groups = {CLI, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
-    public void shouldFailQueryForLdapUserInParentGroup()
-            throws IOException, InterruptedException
-    {
-        ldapUserName = "GrandParentGroupUser";
-        launchPrestoCliWithServerArgument("--catalog", "hive", "--schema", "default", "--execute", "select * from nation;");
-        assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("User " + ldapUserName + " not a member of the group")));
-    }
-
-    @Test(groups = {CLI, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
-    public void shouldFailQueryForOrphanLdapUser()
-            throws IOException, InterruptedException
-    {
-        ldapUserName = "OrphanUser";
-        launchPrestoCliWithServerArgument("--catalog", "hive", "--schema", "default", "--execute", "select * from nation;");
-        assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("User " + ldapUserName + " not a member of the group")));
-    }
-
-    @Test(groups = {CLI, ACTIVE_DIRECTORY, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
-    public void shouldFailQueryForWrongLdapPassword()
-            throws IOException, InterruptedException
-    {
-        ldapUserPassword = "wrong_password";
-        launchPrestoCliWithServerArgument("--execute", "select * from hive.default.nation;");
-        assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("Invalid credentials")));
-    }
-
-    @Test(groups = {CLI, ACTIVE_DIRECTORY, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
-    public void shouldFailQueryForWrongLdapUser()
-            throws IOException, InterruptedException
-    {
-        ldapUserName = "invalid_user";
-        launchPrestoCliWithServerArgument("--execute", "select * from hive.default.nation;");
-        assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("Invalid credentials")));
-    }
-
-    @Test(groups = {CLI, ACTIVE_DIRECTORY, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
-    public void shouldFailForComputerContextType()
-            throws IOException, InterruptedException
-    {
-        ldapUserPassword = "ad-test";
-        launchPrestoCliWithServerArgument("--execute", "select * from hive.default.nation;");
-        assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("Invalid credentials")));
-    }
-
-    @Test(groups = {CLI, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
-    public void shouldFailQueryForEmptyUser()
-            throws IOException, InterruptedException
-    {
-        ldapUserName = "";
-        launchPrestoCliWithServerArgument("--execute", "select * from hive.default.nation;");
-        assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("Invalid credentials")));
-    }
-
-    @Test(groups = {CLI, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
-    public void shouldFailQueryForLdapWithoutPassword()
-            throws IOException, InterruptedException
-    {
-        launchPrestoCli("--server", ldapServerAddress,
-                "--truststore-path", ldapTruststorePath,
-                "--truststore-password", ldapTruststorePassword,
-                "--user", ldapUserName,
-                "--execute", "select * from hive.default.nation;");
-        assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("statusMessage=Unauthorized")));
-    }
-
-    @Test(groups = {CLI, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
-    public void shouldFailQueryForLdapWithoutHttps()
-            throws IOException, InterruptedException
-    {
-        ldapServerAddress = format("http://%s:8443", serverHost);
-        launchPrestoCliWithServerArgument("--execute", "select * from hive.default.nation;");
-        assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("Authentication using username/password requires HTTPS to be enabled")));
-        skipAfterTestWithContext();
-    }
-
-    private void skipAfterTestWithContext()
-    {
-        presto.close();
-        presto = null;
-    }
-
-    @Test(groups = {CLI, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
-    public void shouldFailForIncorrectTrustStore()
-            throws IOException, InterruptedException
-    {
-        ldapTruststorePassword = "wrong_password";
-        launchPrestoCliWithServerArgument("--execute", "select * from hive.default.nation;");
-        assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("Keystore was tampered with, or password was incorrect")));
-        skipAfterTestWithContext();
-    }
-
-    @Test(groups = {CLI, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
-    public void shouldPassForCredentialsWithSpecialCharacters()
-            throws IOException, InterruptedException
-    {
-        ldapUserName = "User WithSpecialPwd";
-        ldapUserPassword = "LDAP:Pass ~!@#$%^&*()_+{}|:\"<>?/.,';\\][=-`";
-        launchPrestoCliWithServerArgument("--catalog", "hive", "--schema", "default", "--execute", "select * from nation;");
-        assertThat(trimLines(presto.readRemainingOutputLines())).containsAll(nationTableBatchLines);
-    }
-
-    @Test(groups = {CLI, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
-    public void shouldFailForUserWithColon()
-            throws IOException, InterruptedException
-    {
-        ldapUserName = "UserWith:Colon";
-        launchPrestoCliWithServerArgument("--execute", "select * from hive.default.nation;");
-        assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("Illegal character ':' found in user name")));
-    }
-
-    private void launchPrestoCliWithServerArgument(String... arguments)
-            throws IOException, InterruptedException
-    {
-        if (ldapAuthentication) {
-            requireNonNull(ldapTruststorePath, "databases.presto.cli_ldap_truststore_path is null");
-            requireNonNull(ldapTruststorePassword, "databases.presto.cli_ldap_truststore_password is null");
-            requireNonNull(ldapUserName, "databases.presto.cli_ldap_user_name is null");
-            requireNonNull(ldapServerAddress, "databases.presto.cli_ldap_server_address is null");
-            requireNonNull(ldapUserPassword, "databases.presto.cli_ldap_user_password is null");
-
-            ImmutableList.Builder<String> prestoClientOptions = ImmutableList.builder();
-            prestoClientOptions.add(
-                    "--server", ldapServerAddress,
-                    "--truststore-path", ldapTruststorePath,
-                    "--truststore-password", ldapTruststorePassword,
-                    "--user", ldapUserName,
-                    "--password");
-
-            prestoClientOptions.add(arguments);
-            launchPrestoCli(prestoClientOptions.build());
-            setLdapPassword();
-        }
-        else if (kerberosAuthentication) {
+        if (kerberosAuthentication) {
             requireNonNull(kerberosPrincipal, "databases.presto.cli_kerberos_principal is null");
             requireNonNull(kerberosKeytab, "databases.presto.cli_kerberos_keytab is null");
             requireNonNull(kerberosServiceName, "databases.presto.cli_kerberos_service_name is null");
@@ -415,22 +240,15 @@ public class PrestoCliTests
         }
     }
 
-    private void launchPrestoCli(String... arguments)
+    protected void launchPrestoCli(String... arguments)
             throws IOException, InterruptedException
     {
         launchPrestoCli(asList(arguments));
     }
 
-    private void launchPrestoCli(List<String> arguments)
+    protected void launchPrestoCli(List<String> arguments)
             throws IOException, InterruptedException
     {
         presto = new PrestoCliProcess(defaultJavaProcessLauncher().launch(Presto.class, arguments));
-    }
-
-    private void setLdapPassword()
-    {
-        presto.waitForLdapPasswordPrompt();
-        presto.getProcessInput().println(ldapUserPassword);
-        presto.nextOutputToken();
     }
 }

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoCliTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoCliTests.java
@@ -19,7 +19,6 @@ import com.google.common.io.Files;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import com.teradata.tempto.AfterTestWithContext;
-import com.teradata.tempto.ProductTest;
 import com.teradata.tempto.Requirement;
 import com.teradata.tempto.RequirementsProvider;
 import com.teradata.tempto.configuration.Configuration;
@@ -28,41 +27,22 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.List;
 
 import static com.facebook.presto.tests.TestGroups.CLI;
 import static com.facebook.presto.tests.TestGroups.PREPARED_STATEMENTS;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Strings.repeat;
-import static com.google.common.io.Resources.getResource;
-import static com.google.common.io.Resources.readLines;
 import static com.teradata.tempto.fulfillment.table.hive.tpch.TpchTableDefinitions.NATION;
 import static com.teradata.tempto.process.CliProcess.trimLines;
-import static com.teradata.tempto.process.JavaProcessLauncher.defaultJavaProcessLauncher;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Arrays.asList;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class PrestoCliTests
-        extends ProductTest
+        extends PrestoCliLauncher
         implements RequirementsProvider
 {
-    protected static final long TIMEOUT = 300 * 1000; // 30 secs per test
-    protected static final String EXIT_COMMAND = "exit";
-
-    protected final List<String> nationTableInteractiveLines;
-    protected final List<String> nationTableBatchLines;
-
-    @Inject
-    @Named("databases.presto.host")
-    protected String serverHost;
-
-    @Inject
-    @Named("databases.presto.server_address")
-    private String serverAddress;
-
     @Inject(optional = true)
     @Named("databases.presto.cli_kerberos_authentication")
     private boolean kerberosAuthentication;
@@ -99,23 +79,15 @@ public class PrestoCliTests
     @Named("databases.presto.jdbc_user")
     private String jdbcUser;
 
-    protected PrestoCliProcess presto;
-
     public PrestoCliTests()
             throws IOException
-    {
-        nationTableInteractiveLines = readLines(getResource("com/facebook/presto/tests/cli/interactive_query.results"), UTF_8);
-        nationTableBatchLines = readLines(getResource("com/facebook/presto/tests/cli/batch_query.results"), UTF_8);
-    }
+    {}
 
     @AfterTestWithContext
     public void stopPresto()
             throws InterruptedException
     {
-        if (presto != null) {
-            presto.getProcessInput().println(EXIT_COMMAND);
-            presto.waitForWithTimeoutAndKill();
-        }
+        super.stopPresto();
     }
 
     @Override
@@ -148,7 +120,6 @@ public class PrestoCliTests
             throws IOException, InterruptedException
     {
         launchPrestoCliWithServerArgument("--execute", "select * from hive.default.nation;");
-
         assertThat(trimLines(presto.readRemainingOutputLines())).containsAll(nationTableBatchLines);
     }
 
@@ -238,17 +209,5 @@ public class PrestoCliTests
             prestoClientOptions.add(arguments);
             launchPrestoCli(prestoClientOptions.build());
         }
-    }
-
-    protected void launchPrestoCli(String... arguments)
-            throws IOException, InterruptedException
-    {
-        launchPrestoCli(asList(arguments));
-    }
-
-    protected void launchPrestoCli(List<String> arguments)
-            throws IOException, InterruptedException
-    {
-        presto = new PrestoCliProcess(defaultJavaProcessLauncher().launch(Presto.class, arguments));
     }
 }

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoCliTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoCliTests.java
@@ -30,6 +30,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
+import static com.facebook.presto.tests.TestGroups.ACTIVE_DIRECTORY;
 import static com.facebook.presto.tests.TestGroups.CLI;
 import static com.facebook.presto.tests.TestGroups.PREPARED_STATEMENTS;
 import static com.facebook.presto.tests.TestGroups.PROFILE_SPECIFIC_TESTS;
@@ -56,6 +57,10 @@ public class PrestoCliTests
 
     private final List<String> nationTableInteractiveLines;
     private final List<String> nationTableBatchLines;
+
+    @Inject
+    @Named("databases.presto.host")
+    private String serverHost;
 
     @Inject
     @Named("databases.presto.server_address")
@@ -228,7 +233,7 @@ public class PrestoCliTests
     public void shouldPassQueryForLdapUserInMultipleGroups()
             throws IOException, InterruptedException
     {
-        ldapUserName = "FinanceHRUserInAsia";
+        ldapUserName = "UserInMultipleGroups";
         launchPrestoCliWithServerArgument("--catalog", "hive", "--schema", "default", "--execute", "select * from nation;");
         assertThat(trimLines(presto.readRemainingOutputLines())).containsAll(nationTableBatchLines);
     }
@@ -237,27 +242,120 @@ public class PrestoCliTests
     public void shouldFailQueryForLdapUserInChildGroup()
             throws IOException, InterruptedException
     {
-        ldapUserName = "FinanceSubSubGroupUserInAsia";
+        ldapUserName = "ChildGroupUser";
         launchPrestoCliWithServerArgument("--catalog", "hive", "--schema", "default", "--execute", "select * from nation;");
-        assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("Authentication failed: User " + ldapUserName + " not a member of the group")));
+        assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("User " + ldapUserName + " not a member of the group")));
     }
 
     @Test(groups = {CLI, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
     public void shouldFailQueryForLdapUserInParentGroup()
             throws IOException, InterruptedException
     {
-        ldapUserName = "FinanceUserInAsia";
+        ldapUserName = "GrandParentGroupUser";
         launchPrestoCliWithServerArgument("--catalog", "hive", "--schema", "default", "--execute", "select * from nation;");
-        assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("Authentication failed: User " + ldapUserName + " not a member of the group")));
+        assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("User " + ldapUserName + " not a member of the group")));
     }
 
     @Test(groups = {CLI, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
     public void shouldFailQueryForOrphanLdapUser()
             throws IOException, InterruptedException
     {
-        ldapUserName = "OrphanUserInAsia";
+        ldapUserName = "OrphanUser";
         launchPrestoCliWithServerArgument("--catalog", "hive", "--schema", "default", "--execute", "select * from nation;");
-        assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("Authentication failed: User " + ldapUserName + " not a member of the group")));
+        assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("User " + ldapUserName + " not a member of the group")));
+    }
+
+    @Test(groups = {CLI, ACTIVE_DIRECTORY, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
+    public void shouldFailQueryForWrongLdapPassword()
+            throws IOException, InterruptedException
+    {
+        ldapUserPassword = "wrong_password";
+        launchPrestoCliWithServerArgument("--execute", "select * from hive.default.nation;");
+        assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("Invalid credentials")));
+    }
+
+    @Test(groups = {CLI, ACTIVE_DIRECTORY, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
+    public void shouldFailQueryForWrongLdapUser()
+            throws IOException, InterruptedException
+    {
+        ldapUserName = "invalid_user";
+        launchPrestoCliWithServerArgument("--execute", "select * from hive.default.nation;");
+        assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("Invalid credentials")));
+    }
+
+    @Test(groups = {CLI, ACTIVE_DIRECTORY, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
+    public void shouldFailForComputerContextType()
+            throws IOException, InterruptedException
+    {
+        ldapUserPassword = "ad-test";
+        launchPrestoCliWithServerArgument("--execute", "select * from hive.default.nation;");
+        assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("Invalid credentials")));
+    }
+
+    @Test(groups = {CLI, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
+    public void shouldFailQueryForEmptyUser()
+            throws IOException, InterruptedException
+    {
+        ldapUserName = "";
+        launchPrestoCliWithServerArgument("--execute", "select * from hive.default.nation;");
+        assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("Invalid credentials")));
+    }
+
+    @Test(groups = {CLI, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
+    public void shouldFailQueryForLdapWithoutPassword()
+            throws IOException, InterruptedException
+    {
+        launchPrestoCli("--server", ldapServerAddress,
+                "--truststore-path", ldapTruststorePath,
+                "--truststore-password", ldapTruststorePassword,
+                "--user", ldapUserName,
+                "--execute", "select * from hive.default.nation;");
+        assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("statusMessage=Unauthorized")));
+    }
+
+    @Test(groups = {CLI, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
+    public void shouldFailQueryForLdapWithoutHttps()
+            throws IOException, InterruptedException
+    {
+        ldapServerAddress = format("http://%s:8443", serverHost);
+        launchPrestoCliWithServerArgument("--execute", "select * from hive.default.nation;");
+        assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("Authentication using username/password requires HTTPS to be enabled")));
+        skipAfterTestWithContext();
+    }
+
+    private void skipAfterTestWithContext()
+    {
+        presto.close();
+        presto = null;
+    }
+
+    @Test(groups = {CLI, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
+    public void shouldFailForIncorrectTrustStore()
+            throws IOException, InterruptedException
+    {
+        ldapTruststorePassword = "wrong_password";
+        launchPrestoCliWithServerArgument("--execute", "select * from hive.default.nation;");
+        assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("Keystore was tampered with, or password was incorrect")));
+        skipAfterTestWithContext();
+    }
+
+    @Test(groups = {CLI, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
+    public void shouldPassForCredentialsWithSpecialCharacters()
+            throws IOException, InterruptedException
+    {
+        ldapUserName = "User WithSpecialPwd";
+        ldapUserPassword = "LDAP:Pass ~!@#$%^&*()_+{}|:\"<>?/.,';\\][=-`";
+        launchPrestoCliWithServerArgument("--catalog", "hive", "--schema", "default", "--execute", "select * from nation;");
+        assertThat(trimLines(presto.readRemainingOutputLines())).containsAll(nationTableBatchLines);
+    }
+
+    @Test(groups = {CLI, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
+    public void shouldFailForUserWithColon()
+            throws IOException, InterruptedException
+    {
+        ldapUserName = "UserWith:Colon";
+        launchPrestoCliWithServerArgument("--execute", "select * from hive.default.nation;");
+        assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("Illegal character ':' found in user name")));
     }
 
     private void launchPrestoCliWithServerArgument(String... arguments)

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoCliTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoCliTests.java
@@ -32,6 +32,7 @@ import java.util.List;
 
 import static com.facebook.presto.tests.TestGroups.CLI;
 import static com.facebook.presto.tests.TestGroups.PREPARED_STATEMENTS;
+import static com.facebook.presto.tests.TestGroups.PROFILE_SPECIFIC_TESTS;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Strings.repeat;
 import static com.google.common.io.Resources.getResource;
@@ -44,6 +45,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertTrue;
 
 public class PrestoCliTests
         extends ProductTest
@@ -220,6 +222,42 @@ public class PrestoCliTests
                 "--execute",
                 format("prepare my_select2 from select * from hive.default.nation where n_name != '%s'; deallocate prepare my_select2;", repeat("a", 65536)));
         assertThat(trimLines(presto.readRemainingErrorLines())).containsExactly("PREPARE", "DEALLOCATE");
+    }
+
+    @Test(groups = {CLI, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
+    public void shouldPassQueryForLdapUserInMultipleGroups()
+            throws IOException, InterruptedException
+    {
+        ldapUserName = "FinanceHRUserInAsia";
+        launchPrestoCliWithServerArgument("--catalog", "hive", "--schema", "default", "--execute", "select * from nation;");
+        assertThat(trimLines(presto.readRemainingOutputLines())).containsAll(nationTableBatchLines);
+    }
+
+    @Test(groups = {CLI, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
+    public void shouldFailQueryForLdapUserInChildGroup()
+            throws IOException, InterruptedException
+    {
+        ldapUserName = "FinanceSubSubGroupUserInAsia";
+        launchPrestoCliWithServerArgument("--catalog", "hive", "--schema", "default", "--execute", "select * from nation;");
+        assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("Authentication failed: User " + ldapUserName + " not a member of the group")));
+    }
+
+    @Test(groups = {CLI, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
+    public void shouldFailQueryForLdapUserInParentGroup()
+            throws IOException, InterruptedException
+    {
+        ldapUserName = "FinanceUserInAsia";
+        launchPrestoCliWithServerArgument("--catalog", "hive", "--schema", "default", "--execute", "select * from nation;");
+        assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("Authentication failed: User " + ldapUserName + " not a member of the group")));
+    }
+
+    @Test(groups = {CLI, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
+    public void shouldFailQueryForOrphanLdapUser()
+            throws IOException, InterruptedException
+    {
+        ldapUserName = "OrphanUserInAsia";
+        launchPrestoCliWithServerArgument("--catalog", "hive", "--schema", "default", "--execute", "select * from nation;");
+        assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("Authentication failed: User " + ldapUserName + " not a member of the group")));
     }
 
     private void launchPrestoCliWithServerArgument(String... arguments)

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoLdapCliTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoLdapCliTests.java
@@ -1,0 +1,262 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests.cli;
+
+import com.facebook.presto.tests.ImmutableTpchTablesRequirements;
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.Files;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import com.teradata.tempto.AfterTestWithContext;
+import com.teradata.tempto.Requirement;
+import com.teradata.tempto.RequirementsProvider;
+import com.teradata.tempto.Requires;
+import com.teradata.tempto.configuration.Configuration;
+import com.teradata.tempto.fulfillment.ldap.LdapObjectRequirement;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+import static com.facebook.presto.tests.ImmutableLdapObjectDefinitions.AMERICA_ORG;
+import static com.facebook.presto.tests.ImmutableLdapObjectDefinitions.ASIA_ORG;
+import static com.facebook.presto.tests.ImmutableLdapObjectDefinitions.CHILD_GROUP;
+import static com.facebook.presto.tests.ImmutableLdapObjectDefinitions.CHILD_GROUP_USER;
+import static com.facebook.presto.tests.ImmutableLdapObjectDefinitions.DEFAULT_GROUP;
+import static com.facebook.presto.tests.ImmutableLdapObjectDefinitions.DEFAULT_GROUP_USER;
+import static com.facebook.presto.tests.ImmutableLdapObjectDefinitions.ORPHAN_USER;
+import static com.facebook.presto.tests.ImmutableLdapObjectDefinitions.PARENT_GROUP;
+import static com.facebook.presto.tests.ImmutableLdapObjectDefinitions.PARENT_GROUP_USER;
+import static com.facebook.presto.tests.TestGroups.ACTIVE_DIRECTORY;
+import static com.facebook.presto.tests.TestGroups.LDAP;
+import static com.facebook.presto.tests.TestGroups.PROFILE_SPECIFIC_TESTS;
+import static com.teradata.tempto.process.CliProcess.trimLines;
+import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertTrue;
+
+public class PrestoLdapCliTests
+    extends PrestoCliTests
+    implements RequirementsProvider
+{
+    @Inject(optional = true)
+    @Named("databases.presto.cli_ldap_truststore_path")
+    private String ldapTruststorePath;
+
+    @Inject(optional = true)
+    @Named("databases.presto.cli_ldap_truststore_password")
+    private String ldapTruststorePassword;
+
+    @Inject(optional = true)
+    @Named("databases.presto.cli_ldap_user_name")
+    private String ldapUserName;
+
+    @Inject(optional = true)
+    @Named("databases.presto.cli_ldap_server_address")
+    private String ldapServerAddress;
+
+    @Inject(optional = true)
+    @Named("databases.presto.cli_ldap_user_password")
+    private String ldapUserPassword;
+
+    public PrestoLdapCliTests()
+            throws IOException
+    {}
+
+    @Override
+    public Requirement getRequirements(Configuration configuration)
+    {
+        return new LdapObjectRequirement(
+                Arrays.asList(
+                        AMERICA_ORG, ASIA_ORG,
+                        DEFAULT_GROUP, PARENT_GROUP, CHILD_GROUP,
+                        DEFAULT_GROUP_USER, PARENT_GROUP_USER, CHILD_GROUP_USER, ORPHAN_USER
+                ));
+    }
+
+    @AfterTestWithContext
+    public void stopPresto()
+            throws InterruptedException
+    {
+        super.stopPresto();
+    }
+
+    @Requires(ImmutableTpchTablesRequirements.ImmutableNationTable.class)
+    @Test(groups = {LDAP, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
+    public void shouldRunQueryWithLdap()
+            throws IOException, InterruptedException
+    {
+        launchPrestoCliWithServerArgument();
+        presto.waitForPrompt();
+        presto.getProcessInput().println("select * from hive.default.nation;");
+        assertThat(trimLines(presto.readLinesUntilPrompt())).containsAll(nationTableInteractiveLines);
+    }
+
+    @Requires(ImmutableTpchTablesRequirements.ImmutableNationTable.class)
+    @Test(groups = {LDAP, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
+    public void shouldRunBatchQueryWithLdap()
+            throws IOException, InterruptedException
+    {
+        launchPrestoCliWithServerArgument("--execute", "select * from hive.default.nation;");
+        assertThat(trimLines(presto.readRemainingOutputLines())).containsAll(nationTableBatchLines);
+    }
+
+    @Requires(ImmutableTpchTablesRequirements.ImmutableNationTable.class)
+    @Test(groups = {LDAP, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
+    public void shouldRunQueryFromFileWithLdap()
+            throws IOException, InterruptedException
+    {
+        File temporayFile = File.createTempFile("test-sql", null);
+        temporayFile.deleteOnExit();
+        Files.write("select * from hive.default.nation;\n", temporayFile, UTF_8);
+
+        launchPrestoCliWithServerArgument("--file", temporayFile.getAbsolutePath());
+        assertThat(trimLines(presto.readRemainingOutputLines())).containsAll(nationTableBatchLines);
+    }
+
+    @Test(groups = {ACTIVE_DIRECTORY, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
+    public void shouldPassQueryForLdapUserInMultipleGroups()
+            throws IOException, InterruptedException
+    {
+        ldapUserName = "UserInMultipleGroups";
+
+        launchPrestoCliWithServerArgument("--catalog", "hive", "--schema", "default", "--execute", "select * from nation;");
+        assertThat(trimLines(presto.readRemainingOutputLines())).containsAll(nationTableBatchLines);
+    }
+
+    @Test(groups = {LDAP, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
+    public void shouldFailQueryForLdapUserInChildGroup()
+            throws IOException, InterruptedException
+    {
+        ldapUserName = CHILD_GROUP_USER.getAttributes().get("cn");
+        launchPrestoCliWithServerArgument("--catalog", "hive", "--schema", "default", "--execute", "select * from nation;");
+        assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("Authentication failed: User " + ldapUserName + " not a member of the group")));
+    }
+
+    @Test(groups = {LDAP, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
+    public void shouldFailQueryForLdapUserInParentGroup()
+            throws IOException, InterruptedException
+    {
+        ldapUserName = PARENT_GROUP_USER.getAttributes().get("cn");
+        launchPrestoCliWithServerArgument("--catalog", "hive", "--schema", "default", "--execute", "select * from nation;");
+        assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("Authentication failed: User " + ldapUserName + " not a member of the group")));
+    }
+
+    @Test(groups = {LDAP, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
+    public void shouldFailQueryForOrphanLdapUser()
+            throws IOException, InterruptedException
+    {
+        ldapUserName = ORPHAN_USER.getAttributes().get("cn");
+        launchPrestoCliWithServerArgument("--catalog", "hive", "--schema", "default", "--execute", "select * from nation;");
+        assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("Authentication failed: User " + ldapUserName + " not a member of the group")));
+    }
+
+    @Test(groups = {LDAP, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
+    public void shouldFailQueryForWrongLdapPassword()
+            throws IOException, InterruptedException
+    {
+        ldapUserPassword = "wrong_password";
+        launchPrestoCliWithServerArgument("--execute", "select * from hive.default.nation;");
+        assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("Invalid credentials")));
+    }
+
+    @Test(groups = {LDAP, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
+    public void shouldFailQueryForWrongLdapUser()
+            throws IOException, InterruptedException
+    {
+        ldapUserName = "invalid_user";
+        launchPrestoCliWithServerArgument("--execute", "select * from hive.default.nation;");
+        assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("Invalid credentials")));
+    }
+
+    @Test(groups = {LDAP, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
+    public void shouldFailQueryForEmptyUser()
+            throws IOException, InterruptedException
+    {
+            ldapUserName = "";
+            launchPrestoCliWithServerArgument("--execute", "select * from hive.default.nation;");
+            assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("Invalid credentials")));
+    }
+
+    @Test(groups = {LDAP, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
+    public void shouldFailQueryForLdapWithoutPassword()
+            throws IOException, InterruptedException
+    {
+        launchPrestoCli("--server", ldapServerAddress,
+                "--truststore-path", ldapTruststorePath,
+                "--truststore-password", ldapTruststorePassword,
+                "--user", ldapUserName,
+                "--execute", "select * from hive.default.nation;");
+        assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("statusMessage=Unauthorized")));
+    }
+
+    @Test(groups = {LDAP, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
+    public void shouldFailQueryForLdapWithoutHttps()
+            throws IOException, InterruptedException
+    {
+        ldapServerAddress = format("http://%s:8443", serverHost);
+        launchPrestoCliWithServerArgument("--execute", "select * from hive.default.nation;");
+        assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("Authentication using username/password requires HTTPS to be enabled")));
+        skipAfterTestWithContext();
+    }
+
+    @Test(groups = {LDAP, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
+    public void shouldFailForIncorrectTrustStore()
+            throws IOException, InterruptedException
+    {
+        ldapTruststorePassword = "wrong_password";
+        launchPrestoCliWithServerArgument("--execute", "select * from hive.default.nation;");
+        assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("Keystore was tampered with, or password was incorrect")));
+        skipAfterTestWithContext();
+    }
+
+    private void skipAfterTestWithContext()
+    {
+        presto.close();
+        presto = null;
+    }
+
+    @Override
+    protected void launchPrestoCliWithServerArgument(String... arguments)
+            throws IOException, InterruptedException
+    {
+            requireNonNull(ldapTruststorePath, "databases.presto.cli_ldap_truststore_path is null");
+            requireNonNull(ldapTruststorePassword, "databases.presto.cli_ldap_truststore_password is null");
+            requireNonNull(ldapUserName, "databases.presto.cli_ldap_user_name is null");
+            requireNonNull(ldapServerAddress, "databases.presto.cli_ldap_server_address is null");
+            requireNonNull(ldapUserPassword, "databases.presto.cli_ldap_user_password is null");
+
+            ImmutableList.Builder<String> prestoClientOptions = ImmutableList.builder();
+            prestoClientOptions.add(
+                    "--server", ldapServerAddress,
+                    "--truststore-path", ldapTruststorePath,
+                    "--truststore-password", ldapTruststorePassword,
+                    "--user", ldapUserName,
+                    "--password");
+
+            prestoClientOptions.add(arguments);
+            launchPrestoCli(prestoClientOptions.build());
+            setLdapPassword();
+    }
+
+    private void setLdapPassword()
+    {
+        presto.waitForLdapPasswordPrompt();
+        presto.getProcessInput().println(ldapUserPassword);
+        presto.nextOutputToken();
+    }
+}

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoLdapCliTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoLdapCliTests.java
@@ -50,8 +50,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertTrue;
 
 public class PrestoLdapCliTests
-    extends PrestoCliTests
-    implements RequirementsProvider
+        extends PrestoCliLauncher
+        implements RequirementsProvider
 {
     @Inject(optional = true)
     @Named("databases.presto.cli_ldap_truststore_path")
@@ -187,9 +187,9 @@ public class PrestoLdapCliTests
     public void shouldFailQueryForEmptyUser()
             throws IOException, InterruptedException
     {
-            ldapUserName = "";
-            launchPrestoCliWithServerArgument("--execute", "select * from hive.default.nation;");
-            assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("Invalid credentials")));
+        ldapUserName = "";
+        launchPrestoCliWithServerArgument("--execute", "select * from hive.default.nation;");
+        assertTrue(trimLines(presto.readRemainingErrorLines()).stream().anyMatch(str -> str.contains("Invalid credentials")));
     }
 
     @Test(groups = {LDAP, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
@@ -230,27 +230,26 @@ public class PrestoLdapCliTests
         presto = null;
     }
 
-    @Override
     protected void launchPrestoCliWithServerArgument(String... arguments)
             throws IOException, InterruptedException
     {
-            requireNonNull(ldapTruststorePath, "databases.presto.cli_ldap_truststore_path is null");
-            requireNonNull(ldapTruststorePassword, "databases.presto.cli_ldap_truststore_password is null");
-            requireNonNull(ldapUserName, "databases.presto.cli_ldap_user_name is null");
-            requireNonNull(ldapServerAddress, "databases.presto.cli_ldap_server_address is null");
-            requireNonNull(ldapUserPassword, "databases.presto.cli_ldap_user_password is null");
+        requireNonNull(ldapTruststorePath, "databases.presto.cli_ldap_truststore_path is null");
+        requireNonNull(ldapTruststorePassword, "databases.presto.cli_ldap_truststore_password is null");
+        requireNonNull(ldapUserName, "databases.presto.cli_ldap_user_name is null");
+        requireNonNull(ldapServerAddress, "databases.presto.cli_ldap_server_address is null");
+        requireNonNull(ldapUserPassword, "databases.presto.cli_ldap_user_password is null");
 
-            ImmutableList.Builder<String> prestoClientOptions = ImmutableList.builder();
-            prestoClientOptions.add(
-                    "--server", ldapServerAddress,
-                    "--truststore-path", ldapTruststorePath,
-                    "--truststore-password", ldapTruststorePassword,
-                    "--user", ldapUserName,
-                    "--password");
+        ImmutableList.Builder<String> prestoClientOptions = ImmutableList.builder();
+        prestoClientOptions.add(
+                "--server", ldapServerAddress,
+                "--truststore-path", ldapTruststorePath,
+                "--truststore-password", ldapTruststorePassword,
+                "--user", ldapUserName,
+                "--password");
 
-            prestoClientOptions.add(arguments);
-            launchPrestoCli(prestoClientOptions.build());
-            setLdapPassword();
+        prestoClientOptions.add(arguments);
+        launchPrestoCli(prestoClientOptions.build());
+        setLdapPassword();
     }
 
     private void setLdapPassword()

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/jdbc/JdbcTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/jdbc/JdbcTests.java
@@ -33,7 +33,6 @@ import java.sql.SQLException;
 import java.sql.Statement;
 
 import static com.facebook.presto.tests.TestGroups.JDBC;
-import static com.facebook.presto.tests.TestGroups.QUARANTINE;
 import static com.facebook.presto.tests.TestGroups.SIMBA_JDBC;
 import static com.facebook.presto.tests.TpchTableResults.PRESTO_NATION_RESULT;
 import static com.facebook.presto.tests.utils.JdbcDriverUtils.getSessionProperty;

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/jdbc/JdbcTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/jdbc/JdbcTests.java
@@ -33,6 +33,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 
 import static com.facebook.presto.tests.TestGroups.JDBC;
+import static com.facebook.presto.tests.TestGroups.QUARANTINE;
 import static com.facebook.presto.tests.TestGroups.SIMBA_JDBC;
 import static com.facebook.presto.tests.TpchTableResults.PRESTO_NATION_RESULT;
 import static com.facebook.presto.tests.utils.JdbcDriverUtils.getSessionProperty;

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/jdbc/LdapTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/jdbc/LdapTests.java
@@ -110,7 +110,8 @@ public class LdapTests
     {
         if (usingTeradataJdbcDriver(defaultQueryExecutor().getConnection())) {
             if (prestoSslPort == null) {
-                LOGGER.debug("prestoSslPort not specified in properties file.  Using default value.");
+                LOGGER.warn("databases.presto.ssl_port not specified in properties file.  Using default value: " +
+                        DEFAULT_SSL_PORT);
                 prestoSslPort = DEFAULT_SSL_PORT;
             }
             LOGGER.debug("Using Presto server SSL port: " + prestoSslPort);

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/jdbc/LdapTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/jdbc/LdapTests.java
@@ -25,6 +25,7 @@ import com.teradata.tempto.configuration.Configuration;
 import com.teradata.tempto.fulfillment.ldap.LdapObjectRequirement;
 import com.teradata.tempto.query.QueryResult;
 import org.slf4j.LoggerFactory;
+import org.testng.TestException;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -118,7 +119,7 @@ public class LdapTests
             usingTeradataDriver = true;
         }
         else {
-            LOGGER.warn("Tests in this class only apply to Teradata Jdbc Driver");
+            throw new TestException("Tests in this class only apply to Teradata Jdbc Driver");
         }
     }
 

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/jdbc/LdapTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/jdbc/LdapTests.java
@@ -1,0 +1,274 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests.jdbc;
+
+import com.facebook.presto.tests.ImmutableTpchTablesRequirements;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import com.teradata.tempto.BeforeTestWithContext;
+import com.teradata.tempto.ProductTest;
+import com.teradata.tempto.Requirement;
+import com.teradata.tempto.RequirementsProvider;
+import com.teradata.tempto.Requires;
+import com.teradata.tempto.configuration.Configuration;
+import com.teradata.tempto.fulfillment.ldap.LdapObjectRequirement;
+import com.teradata.tempto.query.QueryResult;
+import org.slf4j.LoggerFactory;
+import org.testng.TestException;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+
+import static com.facebook.presto.tests.ImmutableLdapObjectDefinitions.AMERICA_ORG;
+import static com.facebook.presto.tests.ImmutableLdapObjectDefinitions.ASIA_ORG;
+import static com.facebook.presto.tests.ImmutableLdapObjectDefinitions.CHILD_GROUP;
+import static com.facebook.presto.tests.ImmutableLdapObjectDefinitions.CHILD_GROUP_USER;
+import static com.facebook.presto.tests.ImmutableLdapObjectDefinitions.DEFAULT_GROUP;
+import static com.facebook.presto.tests.ImmutableLdapObjectDefinitions.DEFAULT_GROUP_USER;
+import static com.facebook.presto.tests.ImmutableLdapObjectDefinitions.ORPHAN_USER;
+import static com.facebook.presto.tests.ImmutableLdapObjectDefinitions.PARENT_GROUP;
+import static com.facebook.presto.tests.ImmutableLdapObjectDefinitions.PARENT_GROUP_USER;
+import static com.facebook.presto.tests.TestGroups.LDAP;
+import static com.facebook.presto.tests.TestGroups.PROFILE_SPECIFIC_TESTS;
+import static com.facebook.presto.tests.TestGroups.SIMBA_JDBC;
+import static com.facebook.presto.tests.TpchTableResults.PRESTO_NATION_RESULT;
+import static com.facebook.presto.tests.utils.JdbcDriverUtils.usingTeradataJdbcDriver;
+import static com.teradata.tempto.assertions.QueryAssert.assertThat;
+import static com.teradata.tempto.query.QueryExecutor.defaultQueryExecutor;
+import static org.testng.Assert.assertTrue;
+
+public class LdapTests
+        extends ProductTest
+        implements RequirementsProvider
+
+{
+    private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(JdbcTests.class);
+    private static final long TIMEOUT = 300 * 1000; // 30 secs per test
+
+    private static final String SELECT_QUERY = "select * from tpch.tiny.nation";
+    private static final String JDBC_URL_FORMAT = "jdbc:presto://%s:%s;AuthenticationType=LDAP Authentication;" +
+            "SSLTrustStorePath=%s;SSLTrustStorePwd=%s;AllowSelfSignedServerCert=1;AllowHostNameCNMismatch=1";
+
+    private static final String DEFAULT_SSL_PORT = "8443";
+
+    @Inject(optional = true)
+    @Named("databases.presto.cli_ldap_truststore_path")
+    private String ldapTruststorePath;
+
+    @Inject(optional = true)
+    @Named("databases.presto.cli_ldap_truststore_password")
+    private String ldapTruststorePassword;
+
+    @Inject(optional = true)
+    @Named("databases.presto.cli_ldap_user_name")
+    private String ldapUserName;
+
+    @Inject(optional = true)
+    @Named("databases.presto.cli_ldap_user_password")
+    private String ldapUserPassword;
+
+    @Inject(optional = true)
+    @Named("databases.presto.host")
+    private String prestoHost;
+
+    // TODO: Find out why this doesn't bring in the value from the config file.
+    @Inject(optional = true)
+    @Named("databases.presto.ssl_port")
+    private String prestoSslPort;
+
+    private boolean usingTeradataDriver = false;
+
+    private static final String INVALID_CREDENTIALS = "Invalid credentials";
+
+    @BeforeTestWithContext
+    public void setup()
+            throws SQLException
+    {
+        if (usingTeradataJdbcDriver(defaultQueryExecutor().getConnection())) {
+            if (prestoSslPort == null) {
+                prestoSslPort = DEFAULT_SSL_PORT;
+            }
+            LOGGER.debug("Using Presto server SSL port: " + prestoSslPort);
+            usingTeradataDriver = true;
+        }
+        else {
+            LOGGER.warn("Tests in this class only apply to Teradata Jdbc Driver");
+        }
+    }
+
+    @Override
+    public Requirement getRequirements(Configuration configuration)
+    {
+        return new LdapObjectRequirement(
+                Arrays.asList(
+                        AMERICA_ORG, ASIA_ORG,
+                        DEFAULT_GROUP, PARENT_GROUP, CHILD_GROUP,
+                        DEFAULT_GROUP_USER, PARENT_GROUP_USER, CHILD_GROUP_USER, ORPHAN_USER
+                ));
+    }
+
+    @Requires(ImmutableTpchTablesRequirements.ImmutableNationTable.class)
+    @Test(groups = {LDAP, SIMBA_JDBC, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
+    public void shouldRunQueryWithLdap()
+            throws InterruptedException, SQLException
+    {
+        if (usingTeradataDriver) {
+            assertThat(executeQuery(SELECT_QUERY, ldapUserName, ldapUserPassword)).matches(PRESTO_NATION_RESULT);
+        }
+    }
+
+    @Test(groups = {LDAP, SIMBA_JDBC, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
+    public void shouldFailQueryForLdapUserInChildGroup()
+            throws InterruptedException
+    {
+        if (usingTeradataDriver) {
+            String name = CHILD_GROUP_USER.getAttributes().get("cn");
+            expectQueryToFailForUserNotInGroup(name);
+        }
+    }
+
+    @Test(groups = {LDAP, SIMBA_JDBC, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
+    public void shouldFailQueryForLdapUserInParentGroup()
+            throws InterruptedException
+    {
+        if (usingTeradataDriver) {
+            String name = PARENT_GROUP_USER.getAttributes().get("cn");
+            expectQueryToFailForUserNotInGroup(name);
+        }
+    }
+
+    @Test(groups = {LDAP, SIMBA_JDBC, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
+    public void shouldFailQueryForOrphanLdapUser()
+            throws InterruptedException
+    {
+        if (usingTeradataDriver) {
+            String name = ORPHAN_USER.getAttributes().get("cn");
+            expectQueryToFailForUserNotInGroup(name);
+        }
+    }
+
+    @Test(groups = {LDAP, SIMBA_JDBC, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
+    public void shouldFailQueryForWrongLdapPassword()
+            throws IOException, InterruptedException
+    {
+        if (usingTeradataDriver) {
+            expectQueryToFail(ldapUserName, "wrong_password", INVALID_CREDENTIALS);
+        }
+    }
+
+    @Test(groups = {LDAP, SIMBA_JDBC, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
+    public void shouldFailQueryForWrongLdapUser()
+            throws IOException, InterruptedException
+    {
+        if (usingTeradataDriver) {
+            expectQueryToFail("invalid_user", ldapUserPassword, INVALID_CREDENTIALS);
+        }
+    }
+
+    @Test(groups = {LDAP, SIMBA_JDBC, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
+    public void shouldFailQueryForEmptyUser()
+            throws IOException, InterruptedException
+    {
+        if (usingTeradataDriver) {
+            expectQueryToFail("", ldapUserPassword, INVALID_CREDENTIALS);
+        }
+    }
+
+    @Test(groups = {LDAP, SIMBA_JDBC, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
+    public void shouldFailQueryForLdapWithoutPassword()
+            throws IOException, InterruptedException
+    {
+        if (usingTeradataDriver) {
+            expectQueryToFail(ldapUserName, "", INVALID_CREDENTIALS);
+        }
+    }
+
+    @Test(groups = {LDAP, SIMBA_JDBC, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
+    public void shouldFailQueryForLdapWithoutSsl()
+            throws IOException, InterruptedException
+    {
+        if (usingTeradataDriver) {
+            try {
+                DriverManager.getConnection(getLdapUrl() + ";SSL=0", ldapUserName, ldapUserPassword);
+                throw new TestException("Expected exception was not thrown.");
+            }
+            catch (SQLException exception) {
+                LOGGER.debug("shouldFailQueryForLdapWithoutSsl", exception);
+                assertTrue(exception.getMessage().contains("SSL value is not valid for given AuthenticationType"));
+            }
+        }
+    }
+
+    @Test(groups = {LDAP, SIMBA_JDBC, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
+    public void shouldFailForIncorrectTrustStore()
+            throws IOException, InterruptedException
+    {
+        if (usingTeradataDriver) {
+            try {
+                String url = String.format(JDBC_URL_FORMAT, prestoHost, prestoSslPort, ldapTruststorePath, "wrong_password");
+                DriverManager.getConnection(url, ldapUserName, ldapUserPassword);
+                throw new TestException("Expected exception was not thrown.");
+            }
+            catch (SQLException exception) {
+                LOGGER.debug("shouldFailForIncorrectTrustStore", exception);
+                assertTrue(exception.getMessage().contains("Keystore was tampered with, or password was incorrect"));
+            }
+        }
+    }
+
+    private void expectQueryToFailForUserNotInGroup(String user)
+    {
+        expectQueryToFail(user, ldapUserPassword,
+                String.format("Authentication failed: User %s not a member of the group", user));
+    }
+
+    private void expectQueryToFail(String user, String password, String message)
+    {
+        try {
+            executeQuery(SELECT_QUERY, user, password);
+            throw new TestException("Expected exception was not thrown.");
+        }
+        catch (SQLException exception) {
+            LOGGER.debug("expectQueryToFail", exception);
+            assertTrue(exception.getMessage().contains(message));
+        }
+    }
+
+    private QueryResult executeQuery(String query, String name, String password)
+        throws SQLException
+    {
+        try (Connection connection = getConnection(name, password)) {
+            Statement statement = connection.createStatement();
+            ResultSet rs = statement.executeQuery(query);
+            return QueryResult.forResultSet(rs);
+        }
+    }
+
+    private Connection getConnection(String name, String password)
+            throws SQLException
+    {
+        return DriverManager.getConnection(getLdapUrl(), name, password);
+    }
+
+    private String getLdapUrl()
+    {
+        return String.format(JDBC_URL_FORMAT, prestoHost, prestoSslPort, ldapTruststorePath, ldapTruststorePassword);
+    }
+}

--- a/presto-product-tests/src/main/resources/tempto-configuration.yaml
+++ b/presto-product-tests/src/main/resources/tempto-configuration.yaml
@@ -60,3 +60,8 @@ tests:
   assert:
     float_tolerance: 0.000001
 
+ldap:
+   admin:
+       dn: cn=admin,dc=presto,dc=testldap,dc=com
+       password: admin
+   url: ldap://ldapserver


### PR DESCRIPTION
This is a port of the tests in PrestoLdapCliTests.

Only the last two commits (9eeba7e, e4af7c7) are relevant to this review.  The others are required to make it possible to run the tests on Sprint-38.
