### PR TITLE
Handle extraneous privileges for grant and revoke

### DIFF
--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestGrantRevoke.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestGrantRevoke.java
@@ -14,6 +14,7 @@
 
 package com.facebook.presto.tests.hive;
 
+import com.teradata.tempto.BeforeTestWithContext;
 import com.teradata.tempto.ProductTest;
 import com.teradata.tempto.query.QueryExecutor;
 import org.testng.annotations.Test;
@@ -28,6 +29,10 @@ import static java.lang.String.format;
 public class TestGrantRevoke
     extends ProductTest
 {
+    private String tableName;
+    private QueryExecutor aliceExecutor;
+    private QueryExecutor bobExecutor;
+
     /*
      * Pre-requisites for the tests in this class:
      *
@@ -37,55 +42,48 @@ public class TestGrantRevoke
      * "bob@presto" that has "jdbc_user: bob"
      * (all other values of the connection are same as that of the default "presto" connection).
     */
+
+    @BeforeTestWithContext
+    public void setup()
+    {
+        tableName = "alice_owned_table";
+        aliceExecutor = connectToPresto("alice@presto");
+        bobExecutor = connectToPresto("bob@presto");
+
+        aliceExecutor.executeQuery(format("DROP TABLE IF EXISTS %s", tableName));
+        aliceExecutor.executeQuery(format("CREATE TABLE %s(month bigint, day bigint)", tableName));
+
+        assertAccessDeniedOnAllOperationsOnTable(bobExecutor, tableName);
+    }
+
     @Test(groups = {HIVE_CONNECTOR, AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
     public void testGrantRevoke()
     {
-        String tableName = "alice_owned_table";
-        QueryExecutor queryExecutorForAlice = connectToPresto("alice@presto");
-        QueryExecutor queryExecutorForBob = connectToPresto("bob@presto");
-
-        queryExecutorForAlice.executeQuery(format("DROP TABLE IF EXISTS %s", tableName));
-        queryExecutorForAlice.executeQuery(format("CREATE TABLE %s(month bigint, day bigint)", tableName));
-
-        assertThat(() -> queryExecutorForBob.executeQuery(format("SELECT * FROM %s", tableName))).
-                failsWithMessage(format("Access Denied: Cannot select from table default.%s", tableName));
-        assertThat(() -> queryExecutorForBob.executeQuery(format("INSERT INTO %s VALUES (3, 22)", tableName))).
-                failsWithMessage(format("Access Denied: Cannot insert into table default.%s", tableName));
-
-        //test GRANT
-        queryExecutorForAlice.executeQuery(format("GRANT INSERT, SELECT ON %s TO bob", tableName));
-        assertThat(queryExecutorForBob.executeQuery(format("INSERT INTO %s VALUES (3, 22)", tableName))).hasRowsCount(1);
-        assertThat(queryExecutorForBob.executeQuery(format("SELECT * FROM %s", tableName))).hasRowsCount(1);
-        assertThat(() -> queryExecutorForBob.executeQuery(format("DELETE FROM %s WHERE day=3", tableName))).
+        // test GRANT
+        aliceExecutor.executeQuery(format("GRANT INSERT, SELECT ON %s TO bob", tableName));
+        assertThat(bobExecutor.executeQuery(format("INSERT INTO %s VALUES (3, 22)", tableName))).hasRowsCount(1);
+        assertThat(bobExecutor.executeQuery(format("SELECT * FROM %s", tableName))).hasRowsCount(1);
+        assertThat(() -> bobExecutor.executeQuery(format("DELETE FROM %s WHERE day=3", tableName))).
                 failsWithMessage(format("Access Denied: Cannot delete from table default.%s", tableName));
 
-        //test REVOKE
-        queryExecutorForAlice.executeQuery(format("REVOKE INSERT ON %s FROM bob", tableName));
-        assertThat(() -> queryExecutorForBob.executeQuery(format("INSERT INTO %s VALUES ('y', 5)", tableName))).
+        // test REVOKE
+        aliceExecutor.executeQuery(format("REVOKE INSERT ON %s FROM bob", tableName));
+        assertThat(() -> bobExecutor.executeQuery(format("INSERT INTO %s VALUES ('y', 5)", tableName))).
                 failsWithMessage(format("Access Denied: Cannot insert into table default.%s", tableName));
-        assertThat(queryExecutorForBob.executeQuery(format("SELECT * FROM %s", tableName))).hasRowsCount(1);
+        assertThat(bobExecutor.executeQuery(format("SELECT * FROM %s", tableName))).hasRowsCount(1);
     }
 
     @Test(groups = {HIVE_CONNECTOR, AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
     public void testGrantRevokeAll()
     {
-        String tableName = "alice_owned_table";
-        QueryExecutor queryExecutorForAlice = connectToPresto("alice@presto");
-        QueryExecutor queryExecutorForBob = connectToPresto("bob@presto");
+        aliceExecutor.executeQuery(format("GRANT ALL PRIVILEGES ON %s TO bob", tableName));
+        assertThat(bobExecutor.executeQuery(format("INSERT INTO %s VALUES (4, 13)", tableName))).hasRowsCount(1);
+        assertThat(bobExecutor.executeQuery(format("SELECT * FROM %s", tableName))).hasRowsCount(1);
+        bobExecutor.executeQuery(format("DELETE FROM %s", tableName));
+        assertThat(bobExecutor.executeQuery(format("SELECT * FROM %s", tableName))).hasNoRows();
 
-        queryExecutorForAlice.executeQuery(format("DROP TABLE IF EXISTS %s", tableName));
-        queryExecutorForAlice.executeQuery(format("CREATE TABLE %s(month bigint, day bigint)", tableName));
-
-        assertAccessDeniedOnAllOperationsOnTable(queryExecutorForBob, tableName);
-
-        queryExecutorForAlice.executeQuery(format("GRANT ALL PRIVILEGES ON %s TO bob", tableName));
-        assertThat(queryExecutorForBob.executeQuery(format("INSERT INTO %s VALUES (4, 13)", tableName))).hasRowsCount(1);
-        assertThat(queryExecutorForBob.executeQuery(format("SELECT * FROM %s", tableName))).hasRowsCount(1);
-        queryExecutorForBob.executeQuery(format("DELETE FROM %s", tableName));
-        assertThat(queryExecutorForBob.executeQuery(format("SELECT * FROM %s", tableName))).hasNoRows();
-
-        queryExecutorForAlice.executeQuery(format("REVOKE ALL PRIVILEGES ON %s FROM bob", tableName));
-        assertAccessDeniedOnAllOperationsOnTable(queryExecutorForBob, tableName);
+        aliceExecutor.executeQuery(format("REVOKE ALL PRIVILEGES ON %s FROM bob", tableName));
+        assertAccessDeniedOnAllOperationsOnTable(bobExecutor, tableName);
     }
 
     private static void assertAccessDeniedOnAllOperationsOnTable(QueryExecutor queryExecutor, String tableName)

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestGrantRevoke.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestGrantRevoke.java
@@ -60,6 +60,8 @@ public class TestGrantRevoke
     public void testGrantRevoke()
     {
         // test GRANT
+        aliceExecutor.executeQuery(format("GRANT SELECT ON %s TO bob", tableName));
+        assertThat(bobExecutor.executeQuery(format("SELECT * FROM %s", tableName))).hasNoRows();
         aliceExecutor.executeQuery(format("GRANT INSERT, SELECT ON %s TO bob", tableName));
         assertThat(bobExecutor.executeQuery(format("INSERT INTO %s VALUES (3, 22)", tableName))).hasRowsCount(1);
         assertThat(bobExecutor.executeQuery(format("SELECT * FROM %s", tableName))).hasRowsCount(1);
@@ -71,6 +73,9 @@ public class TestGrantRevoke
         assertThat(() -> bobExecutor.executeQuery(format("INSERT INTO %s VALUES ('y', 5)", tableName))).
                 failsWithMessage(format("Access Denied: Cannot insert into table default.%s", tableName));
         assertThat(bobExecutor.executeQuery(format("SELECT * FROM %s", tableName))).hasRowsCount(1);
+        aliceExecutor.executeQuery(format("REVOKE INSERT, SELECT ON %s FROM bob", tableName));
+        assertThat(() -> bobExecutor.executeQuery(format("SELECT * FROM %s", tableName))).
+                failsWithMessage(format("Access Denied: Cannot select from table default.%s", tableName));
     }
 
     @Test(groups = {HIVE_CONNECTOR, AUTHORIZATION, PROFILE_SPECIFIC_TESTS})


### PR DESCRIPTION
At present, the grant and revoke code fails when trying to grant a privilege that the user already possesses or revoking a privilege that a user doesn't possess. This PR adds commits for:
1. Cleaning up the product test for grant and revoke
2. Ignore extraneous privileges in grant and revoke statements. 

Testing:
Modified the existing product test for grant/revoke.
