### PR TITLE
Add testing for partitioned BZ2 tables in Hive

### DIFF
--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/TestGroups.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/TestGroups.java
@@ -52,6 +52,7 @@ public final class TestGroups
     public static final String AUTHORIZATION = "authorization";
     public static final String POST_HIVE_1_0_1 = "post_hive_1_0_1";
     public static final String PREPARED_STATEMENTS = "prepared_statements";
+    public static final String BIG_QUERY = "big_query";
 
     private TestGroups() {}
 }

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/utils/QueryExecutors.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/utils/QueryExecutors.java
@@ -24,6 +24,11 @@ public class QueryExecutors
         return testContext().getDependency(QueryExecutor.class, "presto");
     }
 
+    public static QueryExecutor onHive()
+    {
+        return testContext().getDependency(QueryExecutor.class, "hive");
+    }
+
     public static QueryExecutor connectToPresto(String prestoConfig)
     {
         return testContext().getDependency(QueryExecutor.class, prestoConfig);


### PR DESCRIPTION
In the past, partitioned BZ2 tables in Hive failed. The error now is not reproducable.
