### PR TITLE
Add beginQuery and endQuery SPI notifications

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/AddColumnTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/AddColumnTask.java
@@ -54,7 +54,7 @@ public class AddColumnTask
     public CompletableFuture<?> execute(AddColumn statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
     {
         Session session = stateMachine.getSession();
-        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getName());
+        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getQualifiedName());
         Optional<TableHandle> tableHandle = metadata.getTableHandle(session, tableName);
         if (!tableHandle.isPresent()) {
             throw new SemanticException(MISSING_TABLE, statement, "Table '%s' does not exist", tableName);

--- a/presto-main/src/main/java/com/facebook/presto/execution/CallTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/CallTask.java
@@ -71,7 +71,7 @@ public class CallTask
         }
 
         Session session = stateMachine.getSession();
-        QualifiedObjectName procedureName = createQualifiedObjectName(session, call, call.getName());
+        QualifiedObjectName procedureName = createQualifiedObjectName(session, call, call.getQualifiedName());
         Procedure procedure = metadata.getProcedureRegistry().resolve(procedureName);
 
         // map declared argument names to positions

--- a/presto-main/src/main/java/com/facebook/presto/execution/CreateTableTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/CreateTableTask.java
@@ -54,7 +54,7 @@ public class CreateTableTask
     @Override
     public String explain(CreateTable statement, List<Expression> parameters)
     {
-        return "CREATE TABLE " + statement.getName();
+        return "CREATE TABLE " + statement.getQualifiedName();
     }
 
     @Override
@@ -63,7 +63,7 @@ public class CreateTableTask
         checkArgument(!statement.getElements().isEmpty(), "no columns for table");
 
         Session session = stateMachine.getSession();
-        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getName());
+        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getQualifiedName());
         Optional<TableHandle> tableHandle = metadata.getTableHandle(session, tableName);
         if (tableHandle.isPresent()) {
             if (!statement.isNotExists()) {

--- a/presto-main/src/main/java/com/facebook/presto/execution/CreateViewTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/CreateViewTask.java
@@ -71,14 +71,14 @@ public class CreateViewTask
     @Override
     public String explain(CreateView statement, List<Expression> parameters)
     {
-        return "CREATE VIEW " + statement.getName();
+        return "CREATE VIEW " + statement.getQualifiedName();
     }
 
     @Override
     public CompletableFuture<?> execute(CreateView statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
     {
         Session session = stateMachine.getSession();
-        QualifiedObjectName name = createQualifiedObjectName(session, statement, statement.getName());
+        QualifiedObjectName name = createQualifiedObjectName(session, statement, statement.getQualifiedName());
 
         accessControl.checkCanCreateView(session.getRequiredTransactionId(), session.getIdentity(), name);
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
@@ -70,9 +70,13 @@ public class DataDefinitionExecution<T extends Statement>
         this.parameters = parameters;
 
         stateMachine.addStateChangeListener(state -> {
-            if (state == QueryState.RUNNING) { // DDLs don't have STARTING phase
-                if (statement instanceof CatalogRelatedStatement) {
-                    notifyBeginQuery((CatalogRelatedStatement) statement);
+            if (statement instanceof CatalogRelatedStatement) {
+                CatalogRelatedStatement catalogRelatedStatement = (CatalogRelatedStatement) statement;
+                if (state == QueryState.RUNNING) { // DDLs don't have STARTING phase
+                    notifyBeginQuery(catalogRelatedStatement);
+                }
+                if (state.isDone()) {
+                    notifyEndQuery();
                 }
             }
         });
@@ -83,6 +87,11 @@ public class DataDefinitionExecution<T extends Statement>
         Session session = stateMachine.getSession();
         QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getQualifiedName());
         metadata.beginQuery(session, tableName.getCatalogName());
+    }
+
+    private void notifyEndQuery()
+    {
+        metadata.endQuery(stateMachine.getSession());
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/DropTableTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DropTableTask.java
@@ -44,7 +44,7 @@ public class DropTableTask
     public CompletableFuture<?> execute(DropTable statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
     {
         Session session = stateMachine.getSession();
-        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getTableName());
+        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getQualifiedName());
 
         Optional<TableHandle> tableHandle = metadata.getTableHandle(session, tableName);
         if (!tableHandle.isPresent()) {

--- a/presto-main/src/main/java/com/facebook/presto/execution/DropViewTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DropViewTask.java
@@ -44,7 +44,7 @@ public class DropViewTask
     public CompletableFuture<?> execute(DropView statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
     {
         Session session = stateMachine.getSession();
-        QualifiedObjectName name = createQualifiedObjectName(session, statement, statement.getName());
+        QualifiedObjectName name = createQualifiedObjectName(session, statement, statement.getQualifiedName());
 
         Optional<ViewDefinition> view = metadata.getView(session, name);
         if (!view.isPresent()) {

--- a/presto-main/src/main/java/com/facebook/presto/execution/GrantTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/GrantTask.java
@@ -49,7 +49,7 @@ public class GrantTask
     public CompletableFuture<?> execute(Grant statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
     {
         Session session = stateMachine.getSession();
-        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getTableName());
+        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getQualifiedName());
         Optional<TableHandle> tableHandle = metadata.getTableHandle(session, tableName);
         if (!tableHandle.isPresent()) {
             throw new SemanticException(MISSING_TABLE, statement, "Table '%s' does not exist", tableName);

--- a/presto-main/src/main/java/com/facebook/presto/execution/RenameColumnTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/RenameColumnTask.java
@@ -49,7 +49,7 @@ public class RenameColumnTask
     public CompletableFuture<?> execute(RenameColumn statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
     {
         Session session = stateMachine.getSession();
-        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getTable());
+        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getQualifiedName());
         Optional<TableHandle> tableHandle = metadata.getTableHandle(session, tableName);
 
         String source = statement.getSource().toLowerCase(ENGLISH);

--- a/presto-main/src/main/java/com/facebook/presto/execution/RevokeTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/RevokeTask.java
@@ -49,7 +49,7 @@ public class RevokeTask
     public CompletableFuture<?> execute(Revoke statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
     {
         Session session = stateMachine.getSession();
-        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getTableName());
+        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getQualifiedName());
         Optional<TableHandle> tableHandle = metadata.getTableHandle(session, tableName);
         if (!tableHandle.isPresent()) {
             throw new SemanticException(MISSING_TABLE, statement, "Table '%s' does not exist", tableName);

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -171,6 +171,9 @@ public final class SqlQueryExecution
                     checkState(tableHandles != null, "Analysis must happen before query is starting");
                     metadata.beginQuery(getSession(), tableHandles);
                 }
+                if (state.isDone()) {
+                    metadata.endQuery(getSession());
+                }
             });
 
             this.remoteTaskFactory = new MemoryTrackingRemoteTaskFactory(requireNonNull(remoteTaskFactory, "remoteTaskFactory is null"), stateMachine);

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -23,6 +23,7 @@ import com.facebook.presto.execution.scheduler.NodeScheduler;
 import com.facebook.presto.execution.scheduler.SqlQueryScheduler;
 import com.facebook.presto.memory.VersionedMemoryPoolId;
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.TableHandle;
 import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.QueryId;
@@ -50,6 +51,7 @@ import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.Statement;
 import com.facebook.presto.transaction.TransactionManager;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
 import io.airlift.concurrent.SetThreadName;
 import io.airlift.units.Duration;
 
@@ -57,6 +59,7 @@ import javax.annotation.concurrent.ThreadSafe;
 import javax.inject.Inject;
 
 import java.net.URI;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -67,6 +70,7 @@ import static com.facebook.presto.OutputBuffers.BROADCAST_PARTITION_ID;
 import static com.facebook.presto.OutputBuffers.createInitialEmptyOutputBuffers;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -97,6 +101,8 @@ public final class SqlQueryExecution
     private final NodeTaskMap nodeTaskMap;
     private final ExecutionPolicy executionPolicy;
     private final List<Expression> parameters;
+
+    private Collection<TableHandle> tableHandles = null;
 
     public SqlQueryExecution(QueryId queryId,
             String query,
@@ -157,6 +163,13 @@ public final class SqlQueryExecution
                 SqlQueryScheduler scheduler = queryScheduler.get();
                 if (scheduler != null) {
                     scheduler.abort();
+                }
+            });
+
+            stateMachine.addStateChangeListener(state -> {
+                if (state == QueryState.STARTING) {
+                    checkState(tableHandles != null, "Analysis must happen before query is starting");
+                    metadata.beginQuery(getSession(), tableHandles);
                 }
             });
 
@@ -283,6 +296,8 @@ public final class SqlQueryExecution
         Analyzer analyzer = new Analyzer(stateMachine.getSession(), metadata, sqlParser, accessControl, Optional.of(queryExplainer), experimentalSyntaxEnabled, parameters);
         Analysis analysis = analyzer.analyze(statement);
 
+        tableHandles = extractTableHandles(analysis);
+
         stateMachine.setUpdateType(analysis.getUpdateType());
 
         // plan query
@@ -306,6 +321,18 @@ public final class SqlQueryExecution
 
         boolean explainAnalyze = analysis.getStatement() instanceof Explain && ((Explain) analysis.getStatement()).isAnalyze();
         return new PlanRoot(subplan, !explainAnalyze);
+    }
+
+    private static List<TableHandle> extractTableHandles(Analysis analysis)
+    {
+        ImmutableList.Builder<TableHandle> builder = ImmutableList.builder();
+        builder.addAll(analysis.getTableHandles());
+
+        if (analysis.getInsert().isPresent()) {
+            builder.add(analysis.getInsert().get().getTarget());
+        }
+
+        return builder.build();
     }
 
     private void planDistribution(PlanRoot plan)

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -171,6 +171,11 @@ public interface Metadata
     void beginQuery(Session session, String catalogName);
 
     /**
+     * Ends query. This is the very last notification when query is done.
+     */
+    void endQuery(Session session);
+
+    /**
      * Begin insert query
      */
     InsertTableHandle beginInsert(Session session, TableHandle tableHandle);

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -161,6 +161,11 @@ public interface Metadata
     Optional<NewTableLayout> getInsertLayout(Session session, TableHandle target);
 
     /**
+     * Begin the execution of the SELECT/UPDATE/INSERT/DELETE query
+     */
+    void beginQuery(Session session, Collection<TableHandle> tableHandles);
+
+    /**
      * Begin insert query
      */
     InsertTableHandle beginInsert(Session session, TableHandle tableHandle);

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -161,9 +161,14 @@ public interface Metadata
     Optional<NewTableLayout> getInsertLayout(Session session, TableHandle target);
 
     /**
-     * Begin the execution of the SELECT/UPDATE/INSERT/DELETE query
+     * Begin the execution of the query
      */
     void beginQuery(Session session, Collection<TableHandle> tableHandles);
+
+    /**
+     * Notify catalogName of execution of a query
+     */
+    void beginQuery(Session session, String catalogName);
 
     /**
      * Begin insert query

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -550,6 +550,15 @@ public class MetadataManager
     }
 
     @Override
+    public void beginQuery(Session session, String catalogName)
+    {
+        ConnectorEntry entry = connectorsByCatalog.get(catalogName);
+        ConnectorSession connectorSession = session.toConnectorSession(entry.getCatalog());
+        ConnectorMetadata metadata = entry.getMetadata(session);
+        metadata.beginQuery(connectorSession);
+    }
+
+    @Override
     public OutputTableHandle beginCreateTable(Session session, String catalogName, TableMetadata tableMetadata, Optional<NewTableLayout> layout)
     {
         ConnectorEntry entry = connectorsByCatalog.get(catalogName);

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -29,6 +29,7 @@ import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.ConnectorViewDefinition;
 import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
 import com.facebook.presto.spi.block.BlockEncodingSerde;
@@ -48,6 +49,7 @@ import com.facebook.presto.transaction.TransactionManager;
 import com.facebook.presto.type.TypeDeserializer;
 import com.facebook.presto.type.TypeRegistry;
 import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
@@ -111,6 +113,7 @@ public class MetadataManager
     private final ConcurrentMap<String, ConnectorEntry> systemTablesByCatalog = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, ConnectorEntry> connectorsByCatalog = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, ConnectorEntry> connectorsById = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Collection<ConnectorMetadata>> catalogsByQueryId = new ConcurrentHashMap<>();
     private final FunctionRegistry functions;
     private final ProcedureRegistry procedures;
     private final TypeManager typeManager;
@@ -538,6 +541,31 @@ public class MetadataManager
             ConnectorSession connectorSession = session.toConnectorSession(entry.getCatalog());
             ConnectorMetadata metadata = entry.getMetadata(session);
             metadata.beginQuery(connectorSession);
+            registerCatalogForQueryId(session.getQueryId(), metadata);
+        }
+    }
+
+    private void registerCatalogForQueryId(QueryId queryId, ConnectorMetadata metadata)
+    {
+        catalogsByQueryId.putIfAbsent(queryId.getId(), new ArrayList<>());
+        catalogsByQueryId.get(queryId.getId()).add(metadata);
+    }
+
+    @Override
+    public void endQuery(Session session)
+    {
+        try {
+            Collection<ConnectorMetadata> catalogs = catalogsByQueryId.get(session.getQueryId().getId());
+            if (catalogs == null) {
+                return;
+            }
+
+            for (ConnectorMetadata metadata : catalogs) {
+                metadata.endQuery(session.toConnectorSession());
+            }
+        }
+        finally {
+            catalogsByQueryId.remove(session.getQueryId().getId());
         }
     }
 
@@ -556,6 +584,7 @@ public class MetadataManager
         ConnectorSession connectorSession = session.toConnectorSession(entry.getCatalog());
         ConnectorMetadata metadata = entry.getMetadata(session);
         metadata.beginQuery(connectorSession);
+        registerCatalogForQueryId(session.getQueryId(), metadata);
     }
 
     @Override
@@ -906,5 +935,11 @@ public class MetadataManager
         ObjectMapperProvider provider = new ObjectMapperProvider();
         provider.setJsonDeserializers(ImmutableMap.<Class<?>, JsonDeserializer<?>>of(Type.class, new TypeDeserializer(new TypeRegistry())));
         return new JsonCodecFactory(provider).jsonCodec(ViewDefinition.class);
+    }
+
+    @VisibleForTesting
+    public Map<String, Collection<ConnectorMetadata>> getCatalogsByQueryId()
+    {
+        return ImmutableMap.copyOf(catalogsByQueryId);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
@@ -42,6 +42,7 @@ import com.google.common.collect.ListMultimap;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import java.util.Collection;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
@@ -382,6 +383,11 @@ public class Analysis
     public TableHandle getTableHandle(Table table)
     {
         return tables.get(table);
+    }
+
+    public Collection<TableHandle> getTableHandles()
+    {
+        return tables.values();
     }
 
     public void registerTable(Table table, TableHandle handle)

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -344,7 +344,7 @@ class StatementAnalyzer
     {
         analysis.setUpdateType("CREATE VIEW");
 
-        QualifiedObjectName viewName = createQualifiedObjectName(session, node, node.getName());
+        QualifiedObjectName viewName = createQualifiedObjectName(session, node, node.getQualifiedName());
 
         // analyze the query that creates the view
         StatementAnalyzer analyzer = new StatementAnalyzer(

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -503,7 +503,7 @@ public final class SqlFormatter
                 builder.append("OR REPLACE ");
             }
             builder.append("VIEW ")
-                    .append(node.getName())
+                    .append(node.getQualifiedName())
                     .append(" AS\n");
 
             process(node.getQuery(), indent);
@@ -518,7 +518,7 @@ public final class SqlFormatter
             if (node.isExists()) {
                 builder.append("IF EXISTS ");
             }
-            builder.append(node.getName());
+            builder.append(node.getQualifiedName());
 
             return null;
         }
@@ -714,7 +714,7 @@ public final class SqlFormatter
             if (node.isNotExists()) {
                 builder.append("IF NOT EXISTS ");
             }
-            String tableName = formatName(node.getName());
+            String tableName = formatName(node.getQualifiedName());
             builder.append(tableName).append(" (\n");
 
             String columnList = node.getElements().stream()
@@ -758,7 +758,7 @@ public final class SqlFormatter
             if (node.isExists()) {
                 builder.append("IF EXISTS ");
             }
-            builder.append(node.getTableName());
+            builder.append(node.getQualifiedName());
 
             return null;
         }
@@ -778,7 +778,7 @@ public final class SqlFormatter
         protected Void visitRenameColumn(RenameColumn node, Integer context)
         {
             builder.append("ALTER TABLE ")
-                    .append(node.getTable())
+                    .append(node.getQualifiedName())
                     .append(" RENAME COLUMN ")
                     .append(node.getSource())
                     .append(" TO ")
@@ -791,7 +791,7 @@ public final class SqlFormatter
         protected Void visitAddColumn(AddColumn node, Integer indent)
         {
             builder.append("ALTER TABLE ")
-                    .append(node.getName())
+                    .append(node.getQualifiedName())
                     .append(" ADD COLUMN ")
                     .append(node.getColumn().getName())
                     .append(" ")
@@ -854,7 +854,7 @@ public final class SqlFormatter
         protected Void visitCall(Call node, Integer indent)
         {
             builder.append("CALL ")
-                    .append(node.getName())
+                    .append(node.getQualifiedName())
                     .append("(");
 
             Iterator<CallArgument> arguments = node.getArguments().iterator();
@@ -947,7 +947,7 @@ public final class SqlFormatter
             if (node.isTable()) {
                 builder.append("TABLE ");
             }
-            builder.append(node.getTableName())
+            builder.append(node.getQualifiedName())
                     .append(" TO ")
                     .append(node.getGrantee());
             if (node.isWithGrantOption()) {
@@ -978,7 +978,7 @@ public final class SqlFormatter
             if (node.isTable()) {
                 builder.append("TABLE ");
             }
-            builder.append(node.getTableName())
+            builder.append(node.getQualifiedName())
                     .append(" FROM ")
                     .append(node.getGrantee());
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AddColumn.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AddColumn.java
@@ -20,7 +20,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 public class AddColumn
-        extends Statement
+        extends CatalogRelatedStatement
 {
     private final QualifiedName name;
     private final TableElement column;
@@ -42,7 +42,8 @@ public class AddColumn
         this.column = requireNonNull(column, "column is null");
     }
 
-    public QualifiedName getName()
+    @Override
+    public QualifiedName getQualifiedName()
     {
         return name;
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Call.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Call.java
@@ -23,7 +23,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 public final class Call
-        extends Statement
+        extends CatalogRelatedStatement
 {
     private final QualifiedName name;
     private final List<CallArgument> arguments;
@@ -45,7 +45,7 @@ public final class Call
         this.arguments = ImmutableList.copyOf(requireNonNull(arguments, "arguments is null"));
     }
 
-    public QualifiedName getName()
+    public QualifiedName getQualifiedName()
     {
         return name;
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/CatalogRelatedStatement.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/CatalogRelatedStatement.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.tree;
+
+import java.util.Optional;
+
+public abstract class CatalogRelatedStatement
+    extends Statement
+{
+    protected CatalogRelatedStatement(Optional<NodeLocation> location)
+    {
+        super(location);
+    }
+
+    public abstract QualifiedName getQualifiedName();
+}

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateTable.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateTable.java
@@ -25,7 +25,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 public class CreateTable
-        extends Statement
+        extends CatalogRelatedStatement
 {
     private final QualifiedName name;
     private final List<TableElement> elements;
@@ -51,7 +51,8 @@ public class CreateTable
         this.properties = ImmutableMap.copyOf(requireNonNull(properties, "properties is null"));
     }
 
-    public QualifiedName getName()
+    @Override
+    public QualifiedName getQualifiedName()
     {
         return name;
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateView.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateView.java
@@ -20,7 +20,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 public class CreateView
-        extends Statement
+        extends CatalogRelatedStatement
 {
     private final QualifiedName name;
     private final Query query;
@@ -44,7 +44,8 @@ public class CreateView
         this.replace = replace;
     }
 
-    public QualifiedName getName()
+    @Override
+    public QualifiedName getQualifiedName()
     {
         return name;
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DropTable.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DropTable.java
@@ -19,7 +19,7 @@ import java.util.Optional;
 import static com.google.common.base.MoreObjects.toStringHelper;
 
 public class DropTable
-        extends Statement
+        extends CatalogRelatedStatement
 {
     private final QualifiedName tableName;
     private final boolean exists;
@@ -41,7 +41,8 @@ public class DropTable
         this.exists = exists;
     }
 
-    public QualifiedName getTableName()
+    @Override
+    public QualifiedName getQualifiedName()
     {
         return tableName;
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DropView.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DropView.java
@@ -19,7 +19,7 @@ import java.util.Optional;
 import static com.google.common.base.MoreObjects.toStringHelper;
 
 public class DropView
-        extends Statement
+        extends CatalogRelatedStatement
 {
     private final QualifiedName name;
     private final boolean exists;
@@ -41,7 +41,8 @@ public class DropView
         this.exists = exists;
     }
 
-    public QualifiedName getName()
+    @Override
+    public QualifiedName getQualifiedName()
     {
         return name;
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Grant.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Grant.java
@@ -23,7 +23,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 public class Grant
-        extends Statement
+        extends CatalogRelatedStatement
 {
     private final Optional<List<String>> privileges; // missing means ALL PRIVILEGES
     private final boolean table;
@@ -61,7 +61,8 @@ public class Grant
         return table;
     }
 
-    public QualifiedName getTableName()
+    @Override
+    public QualifiedName getQualifiedName()
     {
         return tableName;
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/RenameColumn.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/RenameColumn.java
@@ -20,7 +20,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 public class RenameColumn
-        extends Statement
+        extends CatalogRelatedStatement
 {
     private final QualifiedName table;
     private final String source;
@@ -44,7 +44,8 @@ public class RenameColumn
         this.target = requireNonNull(target, "target is null");
     }
 
-    public QualifiedName getTable()
+    @Override
+    public QualifiedName getQualifiedName()
     {
         return table;
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/RenameTable.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/RenameTable.java
@@ -20,7 +20,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 public final class RenameTable
-        extends Statement
+        extends CatalogRelatedStatement
 {
     private final QualifiedName source;
     private final QualifiedName target;
@@ -40,6 +40,12 @@ public final class RenameTable
         super(location);
         this.source = requireNonNull(source, "source name is null");
         this.target = requireNonNull(target, "target name is null");
+    }
+
+    @Override
+    public QualifiedName getQualifiedName()
+    {
+        return getSource();
     }
 
     public QualifiedName getSource()

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Revoke.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Revoke.java
@@ -23,7 +23,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 public class Revoke
-        extends Statement
+        extends CatalogRelatedStatement
 {
     private final boolean grantOptionFor;
     private final Optional<List<String>> privileges; // missing means ALL PRIVILEGES
@@ -66,7 +66,8 @@ public class Revoke
         return table;
     }
 
-    public QualifiedName getTableName()
+    @Override
+    public QualifiedName getQualifiedName()
     {
         return tableName;
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -238,6 +238,12 @@ public interface ConnectorMetadata
     }
 
     /**
+     * Notification of starting SELECT/UPDATE/INSERT/DELETE query
+     */
+    default void beginQuery(ConnectorSession session)
+    {}
+
+    /**
      * Begin insert query
      */
     default ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -244,6 +244,12 @@ public interface ConnectorMetadata
     {}
 
     /**
+     * Notification of ending a query
+     */
+    default void endQuery(ConnectorSession session)
+    {}
+
+    /**
      * Begin insert query
      */
     default ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -238,7 +238,7 @@ public interface ConnectorMetadata
     }
 
     /**
-     * Notification of starting SELECT/UPDATE/INSERT/DELETE query
+     * Notification of starting a query
      */
     default void beginQuery(ConnectorSession session)
     {}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -227,6 +227,14 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
+    public void beginQuery(ConnectorSession session)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            delegate.beginQuery(session);
+        }
+    }
+
+    @Override
     public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -235,6 +235,14 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
+    public void endQuery(ConnectorSession session)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            delegate.endQuery(session);
+        }
+    }
+
+    @Override
     public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestMetadataManager.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestMetadataManager.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.testing.QueryRunner;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.tests.tpch.TpchQueryRunner.createQueryRunner;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * This is integration / unit test suite.
+ * The reason for having it here is to ensure that we won't leak memory in MetadataManager
+ * while registering catalog -> query Id mapping.
+ * This mapping has to be manually cleaned when query finishes execution (Metadata#endQuery method).
+ */
+public class TestMetadataManager
+{
+    private final QueryRunner queryRunner;
+    private final MetadataManager metadataManager;
+
+    TestMetadataManager()
+            throws Exception
+    {
+        queryRunner = createQueryRunner();
+        metadataManager = (MetadataManager) queryRunner.getMetadata();
+    }
+
+    @Test
+    public void testMetadataIsClearedAfterQueryFinished()
+    {
+        @Language("SQL") String sql = "SELECT * FROM nation";
+        queryRunner.execute(sql);
+
+        assertEquals(metadataManager.getCatalogsByQueryId().size(), 0);
+    }
+
+    @Test
+    public void testMetadataIsClearedAfterQueryFailed()
+    {
+        @Language("SQL") String sql = "SELECT nationkey/0 FROM nation"; // will raise division by zero exception
+        try {
+            queryRunner.execute(sql);
+        }
+        catch (Throwable t) {
+            assertEquals(t.getMessage(), "/ by zero");
+        }
+
+        assertEquals(metadataManager.getCatalogsByQueryId().size(), 0);
+    }
+}


### PR DESCRIPTION
`beginQuery(Session)` is called when any type of query (SELECT, INSERT, UPDATE, DELETE or DDLs) is starting it's execution.
`endQuery(Session)` is called in the very end of query execution after any other notification.
If multiple connectors are involved in execution of a query (e.g. JOIN between connectors) each of them is notified once. If multiple sources (tables) from the same connector are participating in one query, it's notified only once.
E.g.:

``` sql
SELECT n.name, l.tax, nh.comment
  FROM tpch.tiny.nation n
     JOIN tpch.sf1.lineitem l    ON (n.nationkey = l.orderkey)
     JOIN hive.default.nation nh ON (n.nationkey = nh.nationkey);
```

will trigger two notifications:
one for TPCH catalog and another for Hive catalog.
But if below was queried instead (mind the _tpch_2__ is different than _tpch_ catalog, using the same connector though):

``` sql
SELECT n.name, l.tax, nh.comment
  FROM tpch.tiny.nation n
    JOIN tpch2.sf1.lineitem l   ON (n.nationkey = l.orderkey)
    JOIN hive.default.nation nh ON (n.nationkey = nh.nationkey);
```

it would trigger three notifications for those catalogs:
- `tpch`
- `tpch2`
- `hive`

The purpose of this patch is to let connector know about each query it's participating in.
That's to let catalog follow (e.g. allocate necessary resources [and deallocate them in `endQuery` notification]) execution of queries in more generic way than using `beginX` and `endX` pairs of notifications (e.g. `beginInsert` and `finishInsert`).

Please keep in mind that `beginQuery` does not mean the query will be executed correctly.
Especially for DDLs, e.g.:
`create table x` will trigger `beginQuery` while it may fail right after with `table already exists` error. Though, `endQuery` will be triggered when it's failed.

---

This is a continuation of work started at https://github.com/prestodb/presto/pull/5122.
