### PR TITLE
Add noSexism option to the TPC-DS connector

### DIFF
--- a/presto-tpcds/src/main/java/com/facebook/presto/tpcds/TpcdsConnectorFactory.java
+++ b/presto-tpcds/src/main/java/com/facebook/presto/tpcds/TpcdsConnectorFactory.java
@@ -29,6 +29,7 @@ import java.util.Map;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkState;
+import static java.lang.Boolean.parseBoolean;
 import static java.lang.Integer.parseInt;
 import static java.util.Objects.requireNonNull;
 
@@ -83,7 +84,7 @@ public class TpcdsConnectorFactory
             @Override
             public ConnectorSplitManager getSplitManager()
             {
-                return new TpcdsSplitManager(connectorId, nodeManager, splitsPerNode);
+                return new TpcdsSplitManager(connectorId, nodeManager, splitsPerNode, isWithNoSexism(config));
             }
 
             @Override
@@ -108,5 +109,10 @@ public class TpcdsConnectorFactory
         catch (NumberFormatException e) {
             throw new IllegalArgumentException("Invalid property tpcds.splits-per-node");
         }
+    }
+
+    private boolean isWithNoSexism(Map<String, String> properties)
+    {
+        return parseBoolean(firstNonNull(properties.get("tpcds.with-no-sexism"), String.valueOf(false)));
     }
 }

--- a/presto-tpcds/src/main/java/com/facebook/presto/tpcds/TpcdsRecordSetProvider.java
+++ b/presto-tpcds/src/main/java/com/facebook/presto/tpcds/TpcdsRecordSetProvider.java
@@ -40,7 +40,7 @@ public class TpcdsRecordSetProvider
         TpcdsSplit tpcdsSplit = checkType(split, TpcdsSplit.class, "split");
         String tableName = tpcdsSplit.getTableHandle().getTableName();
         Table table = getTable(tableName);
-        return getRecordSet(table, columns, tpcdsSplit.getTableHandle().getScaleFactor(), tpcdsSplit.getPartNumber(), tpcdsSplit.getTotalParts());
+        return getRecordSet(table, columns, tpcdsSplit.getTableHandle().getScaleFactor(), tpcdsSplit.getPartNumber(), tpcdsSplit.getTotalParts(), tpcdsSplit.isNoSexism());
     }
 
     private RecordSet getRecordSet(
@@ -48,7 +48,8 @@ public class TpcdsRecordSetProvider
             List<? extends  ColumnHandle> columns,
             int scaleFactor,
             int partNumber,
-            int totalParts)
+            int totalParts,
+            boolean noSexism)
     {
         ImmutableList.Builder<Column> builder = ImmutableList.builder();
         for (ColumnHandle column : columns) {
@@ -60,7 +61,8 @@ public class TpcdsRecordSetProvider
                 .withScale(scaleFactor)
                 .withParallelism(totalParts)
                 .withChunkNumber(partNumber + 1)
-                .withTable(table);
+                .withTable(table)
+                .withNoSexism(noSexism);
         Results results = constructResults(table, session);
         return new TpcdsRecordSet(results, builder.build());
     }

--- a/presto-tpcds/src/main/java/com/facebook/presto/tpcds/TpcdsSplit.java
+++ b/presto-tpcds/src/main/java/com/facebook/presto/tpcds/TpcdsSplit.java
@@ -33,12 +33,14 @@ public class TpcdsSplit
     private final int totalParts;
     private final int partNumber;
     private final List<HostAddress> addresses;
+    private final boolean noSexism;
 
     @JsonCreator
     public TpcdsSplit(@JsonProperty("tableHandle") TpcdsTableHandle tableHandle,
             @JsonProperty("partNumber") int partNumber,
             @JsonProperty("totalParts") int totalParts,
-            @JsonProperty("addresses") List<HostAddress> addresses)
+            @JsonProperty("addresses") List<HostAddress> addresses,
+            @JsonProperty("noSexism") boolean noSexism)
     {
         checkState(partNumber >= 0, "partNumber must be >= 0");
         checkState(totalParts >= 1, "totalParts must be >= 1");
@@ -48,6 +50,7 @@ public class TpcdsSplit
         this.partNumber = partNumber;
         this.totalParts = totalParts;
         this.addresses = ImmutableList.copyOf(addresses);
+        this.noSexism = noSexism;
     }
 
     @JsonProperty
@@ -116,5 +119,11 @@ public class TpcdsSplit
                 .add("partNumber", partNumber)
                 .add("totalParts", totalParts)
                 .toString();
+    }
+
+    @JsonProperty
+    public boolean isNoSexism()
+    {
+        return noSexism;
     }
 }

--- a/presto-tpcds/src/main/java/com/facebook/presto/tpcds/TpcdsSplitManager.java
+++ b/presto-tpcds/src/main/java/com/facebook/presto/tpcds/TpcdsSplitManager.java
@@ -37,8 +37,9 @@ public class TpcdsSplitManager
     private final String connectorId;
     private final NodeManager nodeManager;
     private final int splitsPerNode;
+    private final boolean noSexism;
 
-    public TpcdsSplitManager(String connectorId, NodeManager nodeManager, int splitsPerNode)
+    public TpcdsSplitManager(String connectorId, NodeManager nodeManager, int splitsPerNode, boolean noSexism)
     {
         requireNonNull(connectorId);
         requireNonNull(nodeManager);
@@ -47,6 +48,7 @@ public class TpcdsSplitManager
         this.connectorId = connectorId;
         this.nodeManager = nodeManager;
         this.splitsPerNode = splitsPerNode;
+        this.noSexism = noSexism;
     }
 
     @Override
@@ -64,7 +66,7 @@ public class TpcdsSplitManager
         ImmutableList.Builder<ConnectorSplit> splits = ImmutableList.builder();
         for (Node node : nodes) {
             for (int i = 0; i < splitsPerNode; i++) {
-                splits.add(new TpcdsSplit(tableHandle, partNumber, totalParts, ImmutableList.of(node.getHostAndPort())));
+                splits.add(new TpcdsSplit(tableHandle, partNumber, totalParts, ImmutableList.of(node.getHostAndPort()), noSexism));
                 partNumber++;
             }
         }


### PR DESCRIPTION
When specified, columns representing names of managers can contain male
or female names (the behavior of the C generator is to only select male
managers).

Usage:
tpcds.with-no-sexism=true

@petroav 
