### PR TITLE
Support running tests with alternative JDBC drivers

### DIFF
--- a/presto-product-tests/README.md
+++ b/presto-product-tests/README.md
@@ -243,13 +243,15 @@ For running Java based tests from IntelliJ see the section on
 
 ### Running with custom / downloaded artifacts
 
-To run with custom versions of presto / presto-cli / product tests, just set the appropriate
-environment variables:
+To run with custom versions of presto / presto-cli / product tests / JDBC driver / Tempto config yaml, 
+just set the appropriate environment variables:
 
 ```
 export PRESTO_SERVER_DIR=/tmp/presto-server-dir      #unpacked presto-server.tar.gz
 export PRESTO_CLI_JAR=/tmp/artifacts/presto-cli-executable.jar
 export PRODUCT_TESTS_JAR=/tmp/artifacts/presto-product-tests-executable.jar
+export PRESTO_JDBC_DRIVER_JAR=/tmp/simba/PrestoJDBC_1.0.9.1017/PrestoJDBC42.jar
+export TEMPTO_CONFIG_YAML=${PRODUCT_TESTS_ROOT}/conf/tempto/tempto-configuration-for-docker-simba.yaml
 presto-product-tests/bin/run_on_docker.sh multinode -x quarantine,big_query,profile_specific_tests
 ```
 

--- a/presto-product-tests/bin/run_on_docker.sh
+++ b/presto-product-tests/bin/run_on_docker.sh
@@ -53,7 +53,8 @@ function run_product_tests() {
   mkdir -p "${REPORT_DIR}"
   run_in_application_runner_container \
     java "-Djava.util.logging.config.file=/docker/volumes/conf/tempto/logging.properties" \
-    -jar "/docker/volumes/presto-product-tests/presto-product-tests-executable.jar" \
+    -classpath "/docker/volumes/jdbc/driver.jar:/docker/volumes/presto-product-tests/presto-product-tests-executable.jar" \
+    com.facebook.presto.tests.TemptoProductTestRunner \
     --report-dir "/docker/volumes/test-reports" \
     --config-local "/docker/volumes/tempto/tempto-configuration-local.yaml" \
     "$@" \

--- a/presto-product-tests/conf/docker/common/compose-commons.sh
+++ b/presto-product-tests/conf/docker/common/compose-commons.sh
@@ -40,3 +40,9 @@ if [[ -z ${PRODUCT_TESTS_JAR} ]]; then
     PRODUCT_TESTS_JAR="${PRODUCT_TESTS_ROOT}/target/presto-product-tests-${PRESTO_VERSION}-executable.jar"
 fi
 export PRODUCT_TESTS_JAR=$(canonical_path ${PRODUCT_TESTS_JAR})
+
+if [[ -z ${PRESTO_JDBC_DRIVER_JAR} ]]; then
+    source "${PRODUCT_TESTS_ROOT}/target/classes/presto.env"
+    PRESTO_JDBC_DRIVER_JAR="${PROJECT_ROOT}/presto-jdbc/target/presto-jdbc-${PRESTO_VERSION}.jar"
+fi
+export PRESTO_JDBC_DRIVER_JAR=$(canonical_path ${PRESTO_JDBC_DRIVER_JAR})

--- a/presto-product-tests/conf/docker/common/kerberos.yml
+++ b/presto-product-tests/conf/docker/common/kerberos.yml
@@ -12,5 +12,3 @@ services:
 
   application-runner:
     image: 'teradatalabs/cdh5-hive-kerberized:${DOCKER_IMAGES_VERSION}'
-    volumes:
-      - ../../../conf/tempto/tempto-configuration-for-docker-kerberos.yaml:/docker/volumes/tempto/tempto-configuration-local.yaml

--- a/presto-product-tests/conf/docker/common/standard.yml
+++ b/presto-product-tests/conf/docker/common/standard.yml
@@ -39,5 +39,6 @@ services:
     volumes:
       - ${PRESTO_CLI_JAR}:/docker/volumes/presto-cli/presto-cli-executable.jar
       - ${PRODUCT_TESTS_JAR}:/docker/volumes/presto-product-tests/presto-product-tests-executable.jar
-      - ../../../conf/tempto/tempto-configuration-for-docker-default.yaml:/docker/volumes/tempto/tempto-configuration-local.yaml
+      - ${TEMPTO_CONFIG_YAML}:/docker/volumes/tempto/tempto-configuration-local.yaml
+      - ${PRESTO_JDBC_DRIVER_JAR}:/docker/volumes/jdbc/driver.jar
       - ../../../target/test-reports:/docker/volumes/test-reports

--- a/presto-product-tests/conf/docker/multinode/compose.sh
+++ b/presto-product-tests/conf/docker/multinode/compose.sh
@@ -2,6 +2,9 @@
 
 source ${BASH_SOURCE%/*}/../common/compose-commons.sh
 
+TEMPTO_CONFIG_YAML_DEFAULT="${PRODUCT_TESTS_ROOT}/conf/tempto/tempto-configuration-for-docker-default.yaml"
+export TEMPTO_CONFIG_YAML=$(canonical_path ${TEMPTO_CONFIG_YAML:-${TEMPTO_CONFIG_YAML_DEFAULT}})
+
 docker-compose \
 -f ${BASH_SOURCE%/*}/../common/standard.yml \
 -f ${BASH_SOURCE%/*}/../common/jdbc_db.yml \

--- a/presto-product-tests/conf/docker/singlenode-hdfs-impersonation/compose.sh
+++ b/presto-product-tests/conf/docker/singlenode-hdfs-impersonation/compose.sh
@@ -2,6 +2,9 @@
 
 source ${BASH_SOURCE%/*}/../common/compose-commons.sh
 
+TEMPTO_CONFIG_YAML_DEFAULT="${PRODUCT_TESTS_ROOT}/conf/tempto/tempto-configuration-for-docker-default.yaml"
+export TEMPTO_CONFIG_YAML=$(canonical_path ${TEMPTO_CONFIG_YAML:-${TEMPTO_CONFIG_YAML_DEFAULT}})
+
 docker-compose \
 -f ${BASH_SOURCE%/*}/../common/standard.yml \
 -f ${BASH_SOURCE%/*}/../common/jdbc_db.yml \

--- a/presto-product-tests/conf/docker/singlenode-kerberos-hdfs-impersonation/compose.sh
+++ b/presto-product-tests/conf/docker/singlenode-kerberos-hdfs-impersonation/compose.sh
@@ -2,6 +2,9 @@
 
 source ${BASH_SOURCE%/*}/../common/compose-commons.sh
 
+TEMPTO_CONFIG_YAML_DEFAULT="${PRODUCT_TESTS_ROOT}/conf/tempto/tempto-configuration-for-docker-kerberos.yaml"
+export TEMPTO_CONFIG_YAML=$(canonical_path ${TEMPTO_CONFIG_YAML:-${TEMPTO_CONFIG_YAML_DEFAULT}})
+
 docker-compose \
 -f ${BASH_SOURCE%/*}/../common/standard.yml \
 -f ${BASH_SOURCE%/*}/../common/kerberos.yml \

--- a/presto-product-tests/conf/docker/singlenode-kerberos-hdfs-no-impersonation/compose.sh
+++ b/presto-product-tests/conf/docker/singlenode-kerberos-hdfs-no-impersonation/compose.sh
@@ -2,6 +2,9 @@
 
 source ${BASH_SOURCE%/*}/../common/compose-commons.sh
 
+TEMPTO_CONFIG_YAML_DEFAULT="${PRODUCT_TESTS_ROOT}/conf/tempto/tempto-configuration-for-docker-kerberos.yaml"
+export TEMPTO_CONFIG_YAML=$(canonical_path ${TEMPTO_CONFIG_YAML:-${TEMPTO_CONFIG_YAML_DEFAULT}})
+
 docker-compose \
 -f ${BASH_SOURCE%/*}/../common/standard.yml \
 -f ${BASH_SOURCE%/*}/../common/kerberos.yml \

--- a/presto-product-tests/conf/docker/singlenode-ldap/compose.sh
+++ b/presto-product-tests/conf/docker/singlenode-ldap/compose.sh
@@ -2,6 +2,9 @@
 
 source ${BASH_SOURCE%/*}/../common/compose-commons.sh
 
+TEMPTO_CONFIG_YAML_DEFAULT="${PRODUCT_TESTS_ROOT}/conf/tempto/tempto-configuration-for-docker-ldap.yaml"
+export TEMPTO_CONFIG_YAML=$(canonical_path ${TEMPTO_CONFIG_YAML:-${TEMPTO_CONFIG_YAML_DEFAULT}})
+
 docker-compose \
 -f ${BASH_SOURCE%/*}/../common/standard.yml \
 -f ${BASH_SOURCE%/*}/../common/jdbc_db.yml \

--- a/presto-product-tests/conf/docker/singlenode-ldap/docker-compose.yml
+++ b/presto-product-tests/conf/docker/singlenode-ldap/docker-compose.yml
@@ -9,8 +9,6 @@ services:
 
   application-runner:
     image: 'teradatalabs/centos6-java8-oracle-ldap:5'
-    volumes:
-      - ../../../conf/tempto/tempto-configuration-for-docker-ldap.yaml:/docker/volumes/tempto/tempto-configuration-local.yaml
 
   ldapserver:
     image: 'teradatalabs/centos6-java8-oracle-openldap:5'

--- a/presto-product-tests/conf/docker/singlenode/compose.sh
+++ b/presto-product-tests/conf/docker/singlenode/compose.sh
@@ -2,6 +2,9 @@
 
 source ${BASH_SOURCE%/*}/../common/compose-commons.sh
 
+TEMPTO_CONFIG_YAML_DEFAULT="${PRODUCT_TESTS_ROOT}/conf/tempto/tempto-configuration-for-docker-default.yaml"
+export TEMPTO_CONFIG_YAML=$(canonical_path ${TEMPTO_CONFIG_YAML:-${TEMPTO_CONFIG_YAML_DEFAULT}})
+
 docker-compose \
 -f ${BASH_SOURCE%/*}/../common/standard.yml \
 -f ${BASH_SOURCE%/*}/../common/jdbc_db.yml \


### PR DESCRIPTION
With these changes, run_on_docker.sh can be used to run product-tests with the open source JDBC driver (default) or with the Teradata/Simba JDBC driver.  To use a different JDBC driver, edit locations.sh.

I have verified that these changes do not cause any test failures when the open source JDBC driver is used.  

Several tests fail when run with the Simba JDBC driver due to differences in the way the two JDBC drivers report column datatypes.  I will fix that in a later PR.

We will need to modify the configuration of our Kerberos Docker image before it can be used with the Simba JDBC driver.  That also will be done in a separate PR.

@ebd2 @anusudarsan @arhimondr @sanjay990 
