### PR TITLE
Add support for "show grant"

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -43,7 +43,7 @@ import com.facebook.presto.spi.ViewNotFoundException;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.predicate.NullableValue;
 import com.facebook.presto.spi.predicate.TupleDomain;
-import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.spi.security.PrivilegeInfo.Privilege;
 import com.facebook.presto.spi.type.TypeManager;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Verify;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -16,6 +16,7 @@ package com.facebook.presto.hive;
 import com.facebook.presto.hadoop.HadoopFileStatus;
 import com.facebook.presto.hive.metastore.Column;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.presto.hive.metastore.HivePrivilegeInfo;
 import com.facebook.presto.hive.metastore.Partition;
 import com.facebook.presto.hive.metastore.StorageFormat;
 import com.facebook.presto.hive.metastore.Table;
@@ -43,6 +44,9 @@ import com.facebook.presto.spi.ViewNotFoundException;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.predicate.NullableValue;
 import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.security.GrantInfo;
+import com.facebook.presto.spi.security.Identity;
+import com.facebook.presto.spi.security.PrivilegeInfo;
 import com.facebook.presto.spi.security.PrivilegeInfo.Privilege;
 import com.facebook.presto.spi.type.TypeManager;
 import com.google.common.annotations.VisibleForTesting;
@@ -1529,6 +1533,26 @@ public class HiveMetadata
                 .collect(toSet());
 
         metastore.revokeTablePrivileges(schemaName, tableName, grantee, privilegeGrantInfoSet);
+    }
+
+    @Override
+    public List<GrantInfo> listTablePrivileges(ConnectorSession session, SchemaTablePrefix schemaTablePrefix, String grantee)
+    {
+        ImmutableList.Builder<GrantInfo> grantInfoBuilder = ImmutableList.builder();
+        for (SchemaTableName tableName : listTables(session, schemaTablePrefix)) {
+            Set<PrivilegeInfo> privilegeInfoSet = metastore.getTablePrivileges(grantee, tableName.getSchemaName(), tableName.getTableName()).stream()
+                    .map(HivePrivilegeInfo::toPrivilegeInfo)
+                    .collect(toSet());
+
+            grantInfoBuilder.add(
+                    new GrantInfo(
+                            privilegeInfoSet,
+                            new Identity(grantee, Optional.empty()),
+                            tableName,
+                            Optional.empty(), // Can't access grantor
+                            Optional.empty())); // Can't access withHierarchy
+        }
+        return grantInfoBuilder.build();
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/NoAccessControl.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/NoAccessControl.java
@@ -18,7 +18,7 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.connector.ConnectorAccessControl;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.security.Identity;
-import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.spi.security.PrivilegeInfo.Privilege;
 import org.apache.hadoop.hive.metastore.api.Table;
 
 import javax.inject.Inject;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/SqlStandardAccessControl.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/SqlStandardAccessControl.java
@@ -19,7 +19,7 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.connector.ConnectorAccessControl;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.security.Identity;
-import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.spi.security.PrivilegeInfo.Privilege;
 import com.google.common.collect.ImmutableSet;
 
 import javax.inject.Inject;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/HivePrivilegeInfo.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/HivePrivilegeInfo.java
@@ -13,7 +13,7 @@
  */
 package com.facebook.presto.hive.metastore;
 
-import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.spi.security.PrivilegeInfo.Privilege;
 import com.google.common.collect.ImmutableSet;
 import org.apache.hadoop.hive.metastore.api.PrivilegeGrantInfo;
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/HivePrivilegeInfo.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/HivePrivilegeInfo.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive.metastore;
 
+import com.facebook.presto.spi.security.PrivilegeInfo;
 import com.facebook.presto.spi.security.PrivilegeInfo.Privilege;
 import com.google.common.collect.ImmutableSet;
 import org.apache.hadoop.hive.metastore.api.PrivilegeGrantInfo;
@@ -101,6 +102,23 @@ public class HivePrivilegeInfo
         return (getHivePrivilege().equals(hivePrivilegeInfo.getHivePrivilege()) &&
                 (isGrantOption() == hivePrivilegeInfo.isGrantOption() ||
                         (!isGrantOption() && hivePrivilegeInfo.isGrantOption())));
+    }
+
+    public PrivilegeInfo toPrivilegeInfo()
+    {
+        switch (getHivePrivilege()) {
+            case SELECT:
+                return new PrivilegeInfo(Privilege.SELECT, isGrantOption());
+            case INSERT:
+                return new PrivilegeInfo(Privilege.INSERT, isGrantOption());
+            case DELETE:
+                return new PrivilegeInfo(Privilege.DELETE, isGrantOption());
+            case UPDATE:
+                return new PrivilegeInfo(Privilege.UPDATE, isGrantOption());
+            case OWNERSHIP:
+                return new PrivilegeInfo(Privilege.OWNERSHIP, isGrantOption());
+        }
+        return null;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaMetadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaMetadata.java
@@ -38,6 +38,7 @@ import static com.facebook.presto.metadata.MetadataUtil.SchemaMetadataBuilder.sc
 import static com.facebook.presto.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
 import static com.facebook.presto.metadata.MetadataUtil.findColumnMetadata;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
 import static com.facebook.presto.util.Types.checkType;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -58,6 +59,7 @@ public class InformationSchemaMetadata
     public static final SchemaTableName TABLE_VIEWS = new SchemaTableName(INFORMATION_SCHEMA, "views");
     public static final SchemaTableName TABLE_SCHEMATA = new SchemaTableName(INFORMATION_SCHEMA, "schemata");
     public static final SchemaTableName TABLE_INTERNAL_PARTITIONS = new SchemaTableName(INFORMATION_SCHEMA, "__internal_partitions__");
+    public static final SchemaTableName TABLE_TABLE_PRIVILEGES = new SchemaTableName(INFORMATION_SCHEMA, "table_privileges");
 
     public static final Map<SchemaTableName, ConnectorTableMetadata> TABLES = schemaMetadataBuilder()
             .table(tableMetadataBuilder(TABLE_COLUMNS)
@@ -94,6 +96,16 @@ public class InformationSchemaMetadata
                     .column("partition_number", BIGINT)
                     .column("partition_key", createUnboundedVarcharType())
                     .column("partition_value", createUnboundedVarcharType())
+                    .build())
+            .table(tableMetadataBuilder(TABLE_TABLE_PRIVILEGES)
+                    .column("grantor", createUnboundedVarcharType())
+                    .column("grantee", createUnboundedVarcharType())
+                    .column("table_catalog", createUnboundedVarcharType())
+                    .column("table_schema", createUnboundedVarcharType())
+                    .column("table_name", createUnboundedVarcharType())
+                    .column("privilege_type", createUnboundedVarcharType())
+                    .column("is_grantable", BOOLEAN)
+                    .column("with_hierarchy", BOOLEAN)
                     .build())
             .build();
 

--- a/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaPageSourceProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaPageSourceProvider.java
@@ -40,6 +40,8 @@ import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.predicate.NullableValue;
 import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.security.GrantInfo;
+import com.facebook.presto.spi.security.PrivilegeInfo;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableList;
@@ -60,6 +62,7 @@ import static com.facebook.presto.connector.informationSchema.InformationSchemaM
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.TABLE_INTERNAL_PARTITIONS;
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.TABLE_SCHEMATA;
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.TABLE_TABLES;
+import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.TABLE_TABLE_PRIVILEGES;
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.TABLE_VIEWS;
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.informationSchemaTableColumns;
 import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
@@ -146,6 +149,9 @@ public class InformationSchemaPageSourceProvider
         if (table.equals(TABLE_INTERNAL_PARTITIONS)) {
             return buildPartitions(session, catalog, filters);
         }
+        if (table.equals(TABLE_TABLE_PRIVILEGES)) {
+            return buildTablePrivileges(session, catalog, filters);
+        }
 
         throw new IllegalArgumentException(format("table does not exist: %s", table));
     }
@@ -202,6 +208,34 @@ public class InformationSchemaPageSourceProvider
     private List<QualifiedObjectName> getTablesList(Session session, String catalogName, Map<String, NullableValue> filters)
     {
         return metadata.listTables(session, extractQualifiedTablePrefix(catalogName, filters));
+    }
+
+    private InternalTable buildTablePrivileges(Session session, String catalogName, Map<String, NullableValue> filters)
+    {
+        List<GrantInfo> grants = ImmutableList.copyOf(getTablePrivilegesList(session, catalogName, filters));
+
+        InternalTable.Builder table = InternalTable.builder(informationSchemaTableColumns(TABLE_TABLE_PRIVILEGES));
+        for (GrantInfo grant : grants) {
+            if (session.getIdentity().getUser().equals(grant.getIdentity().getUser())) {
+                for (PrivilegeInfo privilegeInfo : grant.getPrivilegeInfo()) {
+                    table.add(
+                            grant.getGrantor().orElse(null),
+                            grant.getIdentity().getUser(),
+                            catalogName,
+                            grant.getSchemaTableName().getSchemaName(),
+                            grant.getSchemaTableName().getTableName(),
+                            privilegeInfo.getPrivilege().name(),
+                            privilegeInfo.isGrantOption(),
+                            grant.getWithHierarchy().orElse(null));
+                }
+            }
+        }
+        return table.build();
+    }
+
+    private List<GrantInfo> getTablePrivilegesList(Session session, String catalogName, Map<String, NullableValue> filters)
+    {
+        return metadata.listTablePrivileges(session, extractQualifiedTablePrefix(catalogName, filters), extractGrantee(session, filters));
     }
 
     private List<QualifiedObjectName> getViewsList(Session session, String catalogName, Map<String, NullableValue> filters)
@@ -318,6 +352,15 @@ public class InformationSchemaPageSourceProvider
             return new QualifiedTablePrefix(catalogName, Optional.empty(), Optional.empty());
         }
         return new QualifiedTablePrefix(catalogName, schemaName, tableName);
+    }
+
+    private static String extractGrantee(Session session, Map<String, NullableValue> filters)
+    {
+        Optional<String> grantee = getFilterColumn(filters, "grantee");
+        if (!grantee.isPresent()) {
+            return session.getUser();
+        }
+        return grantee.get();
     }
 
     private static Optional<String> getFilterColumn(Map<String, NullableValue> filters, String columnName)

--- a/presto-main/src/main/java/com/facebook/presto/execution/GrantTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/GrantTask.java
@@ -18,7 +18,7 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.QualifiedObjectName;
 import com.facebook.presto.metadata.TableHandle;
 import com.facebook.presto.security.AccessControl;
-import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.spi.security.PrivilegeInfo.Privilege;
 import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.tree.Grant;
 import com.facebook.presto.transaction.TransactionManager;

--- a/presto-main/src/main/java/com/facebook/presto/execution/RevokeTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/RevokeTask.java
@@ -18,7 +18,7 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.QualifiedObjectName;
 import com.facebook.presto.metadata.TableHandle;
 import com.facebook.presto.security.AccessControl;
-import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.spi.security.PrivilegeInfo.Privilege;
 import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.tree.Revoke;
 import com.facebook.presto.transaction.TransactionManager;

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.block.BlockEncodingSerde;
 import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.security.GrantInfo;
 import com.facebook.presto.spi.security.PrivilegeInfo.Privilege;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
@@ -245,6 +246,11 @@ public interface Metadata
      * Revokes the specified privilege on the specified table from the specified user
      */
     void revokeTablePrivileges(Session session, QualifiedObjectName tableName, Set<Privilege> privileges, String grantee, boolean grantOption);
+
+    /**
+     * Gets the privileges for the specified table available to the given grantee
+     */
+    List<GrantInfo> listTablePrivileges(Session session, QualifiedTablePrefix prefix, String grantee);
 
     FunctionRegistry getFunctionRegistry();
 

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -19,7 +19,7 @@ import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.block.BlockEncodingSerde;
 import com.facebook.presto.spi.predicate.TupleDomain;
-import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.spi.security.PrivilegeInfo.Privilege;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.TypeSignature;

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -37,7 +37,7 @@ import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.function.OperatorType;
 import com.facebook.presto.spi.predicate.NullableValue;
 import com.facebook.presto.spi.predicate.TupleDomain;
-import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.spi.security.PrivilegeInfo.Privilege;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.TypeSignature;

--- a/presto-main/src/main/java/com/facebook/presto/security/AccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AccessControl.java
@@ -15,7 +15,7 @@ package com.facebook.presto.security;
 
 import com.facebook.presto.metadata.QualifiedObjectName;
 import com.facebook.presto.spi.security.Identity;
-import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.spi.security.PrivilegeInfo.Privilege;
 import com.facebook.presto.transaction.TransactionId;
 
 import java.security.Principal;

--- a/presto-main/src/main/java/com/facebook/presto/security/AccessControlManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AccessControlManager.java
@@ -19,7 +19,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.connector.ConnectorAccessControl;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.security.Identity;
-import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.spi.security.PrivilegeInfo.Privilege;
 import com.facebook.presto.spi.security.SystemAccessControl;
 import com.facebook.presto.spi.security.SystemAccessControlFactory;
 import com.facebook.presto.transaction.TransactionId;

--- a/presto-main/src/main/java/com/facebook/presto/security/AllowAllAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AllowAllAccessControl.java
@@ -15,7 +15,7 @@ package com.facebook.presto.security;
 
 import com.facebook.presto.metadata.QualifiedObjectName;
 import com.facebook.presto.spi.security.Identity;
-import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.spi.security.PrivilegeInfo.Privilege;
 import com.facebook.presto.transaction.TransactionId;
 
 import java.security.Principal;

--- a/presto-main/src/main/java/com/facebook/presto/security/DenyAllAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/DenyAllAccessControl.java
@@ -15,7 +15,7 @@ package com.facebook.presto.security;
 
 import com.facebook.presto.metadata.QualifiedObjectName;
 import com.facebook.presto.spi.security.Identity;
-import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.spi.security.PrivilegeInfo.Privilege;
 import com.facebook.presto.transaction.TransactionId;
 
 import java.security.Principal;

--- a/presto-main/src/main/java/com/facebook/presto/security/LegacyConnectorAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/LegacyConnectorAccessControl.java
@@ -17,7 +17,7 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.connector.ConnectorAccessControl;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.security.Identity;
-import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.spi.security.PrivilegeInfo.Privilege;
 
 import static java.util.Objects.requireNonNull;
 

--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -82,6 +82,7 @@ import com.facebook.presto.sql.tree.ShowCatalogs;
 import com.facebook.presto.sql.tree.ShowColumns;
 import com.facebook.presto.sql.tree.ShowCreate;
 import com.facebook.presto.sql.tree.ShowFunctions;
+import com.facebook.presto.sql.tree.ShowGrants;
 import com.facebook.presto.sql.tree.ShowPartitions;
 import com.facebook.presto.sql.tree.ShowSchemas;
 import com.facebook.presto.sql.tree.ShowSession;
@@ -219,6 +220,7 @@ public class CoordinatorModule
         executionBinder.addBinding(ShowCatalogs.class).to(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);
         executionBinder.addBinding(Use.class).to(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);
         executionBinder.addBinding(ShowSession.class).to(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);
+        executionBinder.addBinding(ShowGrants.class).to(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);
         executionBinder.addBinding(CreateTableAsSelect.class).to(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);
         executionBinder.addBinding(Insert.class).to(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);
         executionBinder.addBinding(Delete.class).to(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
@@ -56,6 +56,7 @@ import com.facebook.presto.sql.tree.ShowCatalogs;
 import com.facebook.presto.sql.tree.ShowColumns;
 import com.facebook.presto.sql.tree.ShowCreate;
 import com.facebook.presto.sql.tree.ShowFunctions;
+import com.facebook.presto.sql.tree.ShowGrants;
 import com.facebook.presto.sql.tree.ShowPartitions;
 import com.facebook.presto.sql.tree.ShowSchemas;
 import com.facebook.presto.sql.tree.ShowSession;
@@ -80,10 +81,12 @@ import static com.facebook.presto.connector.informationSchema.InformationSchemaM
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.TABLE_INTERNAL_PARTITIONS;
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.TABLE_SCHEMATA;
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.TABLE_TABLES;
+import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.TABLE_TABLE_PRIVILEGES;
 import static com.facebook.presto.metadata.FunctionKind.APPROXIMATE_AGGREGATE;
 import static com.facebook.presto.metadata.MetadataUtil.createQualifiedName;
 import static com.facebook.presto.metadata.MetadataUtil.createQualifiedObjectName;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_TABLE_PROPERTY;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyShowGrants;
 import static com.facebook.presto.sql.QueryUtil.aliased;
 import static com.facebook.presto.sql.QueryUtil.aliasedName;
 import static com.facebook.presto.sql.QueryUtil.aliasedNullToEmpty;
@@ -198,6 +201,44 @@ final class ShowQueriesRewrite
                     from(catalogName, TABLE_TABLES),
                     predicate,
                     ordering(ascending("table_name")));
+        }
+
+        @Override
+        protected Node visitShowGrants(ShowGrants showGrant, Void context)
+        {
+            String catalogName = session.getCatalog().orElse(null);
+            Expression predicate = equal(nameReference("grantee"), new StringLiteral(session.getUser()));
+
+            Optional<String> identity = showGrant.getIdentity();
+            if (identity.isPresent() && !identity.get().equals(session.getUser())) {
+                denyShowGrants(identity.get());
+            }
+
+            Optional<QualifiedName> tableName = showGrant.getTableName();
+            if (tableName.isPresent()) {
+                QualifiedObjectName qualifiedTableName = createQualifiedObjectName(session, showGrant, tableName.get());
+
+                catalogName = qualifiedTableName.getCatalogName();
+
+                Expression tablePredicate = equal(nameReference("table_name"), new StringLiteral(qualifiedTableName.getObjectName()));
+                predicate = logicalAnd(predicate, tablePredicate);
+            }
+
+            if (catalogName == null) {
+                throw new SemanticException(CATALOG_NOT_SPECIFIED, showGrant, "Catalog must be specified when session catalog is not set");
+            }
+
+            return simpleQuery(
+                    selectList(
+                            aliasedName("grantee", "Grantee"),
+                            aliasedName("table_catalog", "Catalog"),
+                            aliasedName("table_schema", "Schema"),
+                            aliasedName("table_name", "Table"),
+                            aliasedName("privilege_type", "Privilege"),
+                            aliasedName("is_grantable", "Grantable")),
+                    from(catalogName, TABLE_TABLE_PRIVILEGES),
+                    predicate,
+                    ordering(ascending("grantee"), ascending("table_name")));
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/transaction/LegacyConnectorMetadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/transaction/LegacyConnectorMetadata.java
@@ -32,7 +32,7 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.predicate.TupleDomain;
-import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.spi.security.PrivilegeInfo.Privilege;
 import io.airlift.slice.Slice;
 
 import java.util.Collection;

--- a/presto-main/src/main/java/com/facebook/presto/transaction/LegacyConnectorMetadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/transaction/LegacyConnectorMetadata.java
@@ -32,6 +32,7 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.security.GrantInfo;
 import com.facebook.presto.spi.security.PrivilegeInfo.Privilege;
 import io.airlift.slice.Slice;
 
@@ -44,6 +45,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.google.common.base.Preconditions.checkState;
+import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
 
 public class LegacyConnectorMetadata
@@ -270,6 +272,12 @@ public class LegacyConnectorMetadata
     public void revokeTablePrivileges(ConnectorSession session, SchemaTableName tableName, Set<Privilege> privileges, String grantee, boolean grantOption)
     {
         metadata.revokeTablePrivileges(session, tableName, privileges, grantee, grantOption);
+    }
+
+    @Override
+    public List<GrantInfo> listTablePrivileges(ConnectorSession session, SchemaTablePrefix prefix, String grantee)
+    {
+        return emptyList();
     }
 
     private void setRollback(Runnable action)

--- a/presto-main/src/test/java/com/facebook/presto/security/TestAccessControlManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/security/TestAccessControlManager.java
@@ -23,7 +23,7 @@ import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorSplitManager;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.security.Identity;
-import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.spi.security.PrivilegeInfo.Privilege;
 import com.facebook.presto.spi.security.SystemAccessControl;
 import com.facebook.presto.spi.security.SystemAccessControlFactory;
 import com.facebook.presto.spi.transaction.IsolationLevel;

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -55,6 +55,9 @@ statement
         (GRANT OPTION FOR)?
         (privilege (',' privilege)* | ALL PRIVILEGES)
         ON TABLE? qualifiedName FROM grantee=identifier                #revoke
+    | SHOW GRANTS
+        (USER identifier)?
+        ON (TABLE? qualifiedName | ALL)                                #showGrants
     | EXPLAIN ANALYZE?
         ('(' explainOption (',' explainOption)* ')')? statement        #explain
     | SHOW CREATE TABLE qualifiedName                                  #showCreateTable
@@ -426,7 +429,7 @@ nonReserved
     | START | TRANSACTION | COMMIT | ROLLBACK | WORK | ISOLATION | LEVEL
     | SERIALIZABLE | REPEATABLE | COMMITTED | UNCOMMITTED | READ | WRITE | ONLY
     | CALL
-    | GRANT | REVOKE | PRIVILEGES | PUBLIC | OPTION
+    | GRANT | REVOKE | PRIVILEGES | PUBLIC | OPTION | GRANTS | USER
     | SUBSTRING
     ;
 
@@ -537,6 +540,8 @@ REVOKE: 'REVOKE';
 PRIVILEGES: 'PRIVILEGES';
 PUBLIC: 'PUBLIC';
 OPTION: 'OPTION';
+GRANTS: 'GRANTS';
+USER: 'USER';
 EXPLAIN: 'EXPLAIN';
 ANALYZE: 'ANALYZE';
 FORMAT: 'FORMAT';

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -63,6 +63,7 @@ import com.facebook.presto.sql.tree.ShowCatalogs;
 import com.facebook.presto.sql.tree.ShowColumns;
 import com.facebook.presto.sql.tree.ShowCreate;
 import com.facebook.presto.sql.tree.ShowFunctions;
+import com.facebook.presto.sql.tree.ShowGrants;
 import com.facebook.presto.sql.tree.ShowPartitions;
 import com.facebook.presto.sql.tree.ShowSchemas;
 import com.facebook.presto.sql.tree.ShowSession;
@@ -974,6 +975,35 @@ public final class SqlFormatter
             builder.append(node.getTableName())
                     .append(" FROM ")
                     .append(node.getGrantee());
+
+            return null;
+        }
+
+        @Override
+        public Void visitShowGrants(ShowGrants node, Integer indent)
+        {
+            builder.append("SHOW GRANTS ");
+            if (node.getIdentityType().isPresent()) {
+                if (node.getIdentityType().get() == ShowGrants.IdentityType.USER) {
+                    builder.append("USER ")
+                            .append(node.getIdentity().get())
+                            .append(" ");
+                }
+                else {
+                    throw new UnsupportedOperationException("unhandled identity : " + node.getIdentityType());
+                }
+            }
+
+            builder.append("ON ");
+            if (node.getAll()) {
+                builder.append("ALL");
+            }
+            else {
+                if (node.getTable()) {
+                    builder.append("TABLE ");
+                }
+                builder.append(node.getTableName().get());
+            }
 
             return null;
         }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -107,6 +107,7 @@ import com.facebook.presto.sql.tree.ShowCatalogs;
 import com.facebook.presto.sql.tree.ShowColumns;
 import com.facebook.presto.sql.tree.ShowCreate;
 import com.facebook.presto.sql.tree.ShowFunctions;
+import com.facebook.presto.sql.tree.ShowGrants;
 import com.facebook.presto.sql.tree.ShowPartitions;
 import com.facebook.presto.sql.tree.ShowSchemas;
 import com.facebook.presto.sql.tree.ShowSession;
@@ -699,6 +700,31 @@ class AstBuilder
                 context.TABLE() != null,
                 getQualifiedName(context.qualifiedName()),
                 context.grantee.getText());
+    }
+
+    @Override
+    public Node visitShowGrants(SqlBaseParser.ShowGrantsContext context)
+    {
+        Optional<ShowGrants.IdentityType> identityType = Optional.empty();
+        Optional<String> identity = Optional.empty();
+        Optional<QualifiedName> tableName = Optional.empty();
+
+        if (context.USER() != null) {
+            identityType = Optional.of(ShowGrants.IdentityType.USER);
+            identity = Optional.of(context.identifier().getText());
+        }
+
+        if (context.ALL() == null) {
+            tableName = Optional.of(getQualifiedName(context.qualifiedName()));
+        }
+
+        return new ShowGrants(
+                getLocation(context),
+                identityType,
+                identity,
+                context.TABLE() != null,
+                tableName,
+                context.ALL() != null);
     }
 
     // ***************** boolean expressions ******************

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
@@ -547,6 +547,11 @@ public abstract class AstVisitor<R, C>
         return visitStatement(node, context);
     }
 
+    protected R visitShowGrants(ShowGrants node, C context)
+    {
+        return visitStatement(node, context);
+    }
+
     protected R visitTransactionMode(TransactionMode node, C context)
     {
         return visitNode(node, context);

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowGrants.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowGrants.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.tree;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class ShowGrants
+    extends Statement
+{
+    public enum IdentityType
+    {
+        USER, ROLE;
+    }
+
+    private final Optional<IdentityType> identityType;
+    private final Optional<String> identity;
+    private final boolean table;
+    private final Optional<QualifiedName> tableName;
+    private final boolean all;
+
+    public ShowGrants(Optional<IdentityType> identityType, Optional<String> identity, boolean table, Optional<QualifiedName> tableName, boolean all)
+    {
+        this(Optional.empty(), identityType, identity, table, tableName, all);
+    }
+
+    public ShowGrants(NodeLocation location, Optional<IdentityType> identityType, Optional<String> identity, boolean table, Optional<QualifiedName> tableName, boolean all)
+    {
+        this(Optional.of(location), identityType, identity, table, tableName, all);
+    }
+
+    public ShowGrants(Optional<NodeLocation> location, Optional<IdentityType> identityType, Optional<String> identity, boolean table, Optional<QualifiedName> tableName, boolean all)
+    {
+        super(location);
+        requireNonNull(identity, "identity is null");
+        requireNonNull(tableName, "tableName is null");
+
+        this.identityType = identityType;
+        this.table = table;
+        this.tableName = tableName;
+        this.identity = identity;
+        this.all = all;
+    }
+
+    public Optional<IdentityType> getIdentityType()
+    {
+        return identityType;
+    }
+
+    public Optional<String> getIdentity()
+    {
+        return identity;
+    }
+
+    public boolean getAll()
+    {
+        return all;
+    }
+
+    public boolean getTable()
+    {
+        return table;
+    }
+
+    public Optional<QualifiedName> getTableName()
+    {
+        return tableName;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitShowGrants(this, context);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(identityType, identity, table, tableName, all);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        ShowGrants o = (ShowGrants) obj;
+        return Objects.equals(identityType, o.identityType) &&
+                Objects.equals(identity, o.identity) &&
+                Objects.equals(table, o.table) &&
+                Objects.equals(tableName, o.tableName) &&
+                Objects.equals(all, o.all);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("identityType", identityType)
+                .add("identity", identity)
+                .add("table", table)
+                .add("tableName", tableName)
+                .add("all", all)
+                .toString();
+    }
+}

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -81,6 +81,7 @@ import com.facebook.presto.sql.tree.Rollup;
 import com.facebook.presto.sql.tree.Row;
 import com.facebook.presto.sql.tree.SetSession;
 import com.facebook.presto.sql.tree.ShowCatalogs;
+import com.facebook.presto.sql.tree.ShowGrants;
 import com.facebook.presto.sql.tree.ShowPartitions;
 import com.facebook.presto.sql.tree.ShowSchemas;
 import com.facebook.presto.sql.tree.ShowSession;
@@ -1223,6 +1224,18 @@ public class TestSqlParser
                 new Revoke(false, Optional.empty(), true, QualifiedName.of("t"), "u"));
         assertStatement("REVOKE taco ON TABLE t FROM u",
                 new Revoke(false, Optional.of(ImmutableList.of("taco")), true, QualifiedName.of("t"), "u"));
+    }
+
+    @Test
+    public void testShowGrants()
+        throws Exception
+    {
+        assertStatement("SHOW GRANTS USER u ON TABLE t",
+                new ShowGrants(Optional.of(ShowGrants.IdentityType.USER), Optional.of("u"), true, Optional.of(QualifiedName.of("t")), false));
+        assertStatement("SHOW GRANTS USER u ON t",
+                new ShowGrants(Optional.of(ShowGrants.IdentityType.USER), Optional.of("u"), false, Optional.of(QualifiedName.of("t")), false));
+        assertStatement("SHOW GRANTS ON ALL",
+                new ShowGrants(Optional.empty(), Optional.empty(), false, Optional.empty(), true));
     }
 
     @Test

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestStatementBuilder.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestStatementBuilder.java
@@ -213,6 +213,9 @@ public class TestStatementBuilder
         printStatement("revoke grant option for select on foo from alice");
         printStatement("revoke all privileges on foo from alice");
         printStatement("revoke insert, delete on foo from public"); //check support for public
+        printStatement("show grants user u on table t");
+        printStatement("show grants user u on t");
+        printStatement("show grants on all");
     }
 
     @Test

--- a/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/AllowAllAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/AllowAllAccessControl.java
@@ -17,7 +17,7 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.connector.ConnectorAccessControl;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.security.Identity;
-import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.spi.security.PrivilegeInfo.Privilege;
 
 public class AllowAllAccessControl
         implements ConnectorAccessControl

--- a/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/FileBasedAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/FileBasedAccessControl.java
@@ -19,7 +19,7 @@ import com.facebook.presto.spi.connector.ConnectorAccessControl;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.security.AccessDeniedException;
 import com.facebook.presto.spi.security.Identity;
-import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.spi.security.PrivilegeInfo.Privilege;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.json.JsonCodec;
 

--- a/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/ReadOnlyAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/ReadOnlyAccessControl.java
@@ -17,7 +17,7 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.connector.ConnectorAccessControl;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.security.Identity;
-import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.spi.security.PrivilegeInfo.Privilege;
 
 import static com.facebook.presto.spi.security.AccessDeniedException.denyAddColumn;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyCreateTable;

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestGrantRevoke.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestGrantRevoke.java
@@ -19,10 +19,13 @@ import com.teradata.tempto.ProductTest;
 import com.teradata.tempto.query.QueryExecutor;
 import org.testng.annotations.Test;
 
+import java.util.Arrays;
+
 import static com.facebook.presto.tests.TestGroups.AUTHORIZATION;
 import static com.facebook.presto.tests.TestGroups.HIVE_CONNECTOR;
 import static com.facebook.presto.tests.TestGroups.PROFILE_SPECIFIC_TESTS;
 import static com.facebook.presto.tests.utils.QueryExecutors.connectToPresto;
+import static com.teradata.tempto.assertions.QueryAssert.Row.row;
 import static com.teradata.tempto.assertions.QueryAssert.assertThat;
 import static java.lang.String.format;
 
@@ -68,6 +71,14 @@ public class TestGrantRevoke
         assertThat(() -> bobExecutor.executeQuery(format("DELETE FROM %s WHERE day=3", tableName))).
                 failsWithMessage(format("Access Denied: Cannot delete from table default.%s", tableName));
 
+        // test SHOW GRANTS
+        assertThat(bobExecutor.executeQuery(format("SHOW GRANTS ON %s", tableName)))
+                .contains(
+                        Arrays.asList(
+                                row("bob", "hive", "default", "alice_owned_table", "SELECT", Boolean.TRUE),
+                                row("bob", "hive", "default", "alice_owned_table", "INSERT", Boolean.FALSE)
+                        ));
+
         // test REVOKE
         aliceExecutor.executeQuery(format("REVOKE INSERT ON %s FROM bob", tableName));
         assertThat(() -> bobExecutor.executeQuery(format("INSERT INTO %s VALUES ('y', 5)", tableName))).
@@ -89,6 +100,8 @@ public class TestGrantRevoke
 
         aliceExecutor.executeQuery(format("REVOKE ALL PRIVILEGES ON %s FROM bob", tableName));
         assertAccessDeniedOnAllOperationsOnTable(bobExecutor, tableName);
+
+        assertThat(bobExecutor.executeQuery(format("SHOW GRANTS ON %s", tableName))).hasNoRows();
     }
 
     private static void assertAccessDeniedOnAllOperationsOnTable(QueryExecutor queryExecutor, String tableName)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorMetadata.java
@@ -13,7 +13,7 @@
  */
 package com.facebook.presto.spi;
 
-import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.spi.security.PrivilegeInfo.Privilege;
 import io.airlift.slice.Slice;
 
 import java.util.Collection;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -28,7 +28,7 @@ import com.facebook.presto.spi.ConnectorViewDefinition;
 import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
-import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.spi.security.PrivilegeInfo.Privilege;
 import io.airlift.slice.Slice;
 
 import java.util.Collection;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorAccessControl.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorAccessControl.java
@@ -15,7 +15,7 @@ package com.facebook.presto.spi.connector;
 
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.security.Identity;
-import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.spi.security.PrivilegeInfo.Privilege;
 
 import static com.facebook.presto.spi.security.AccessDeniedException.denyAddColumn;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyCreateTable;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -31,6 +31,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
 import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.security.GrantInfo;
 import com.facebook.presto.spi.security.PrivilegeInfo.Privilege;
 import io.airlift.slice.Slice;
 
@@ -344,5 +345,13 @@ public interface ConnectorMetadata
     default void revokeTablePrivileges(ConnectorSession session, SchemaTableName tableName, Set<Privilege> privileges, String grantee, boolean grantOption)
     {
         throw new PrestoException(NOT_SUPPORTED, "This connector does not support revokes");
+    }
+
+    /**
+     * List table privileges granted to the specified grantee for the tables that have the specified prefix
+     */
+    default List<GrantInfo> listTablePrivileges(ConnectorSession session, SchemaTablePrefix prefix, String grantee)
+    {
+        return emptyList();
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -31,7 +31,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
 import com.facebook.presto.spi.predicate.TupleDomain;
-import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.spi.security.PrivilegeInfo.Privilege;
 import io.airlift.slice.Slice;
 
 import java.util.Collection;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -30,7 +30,7 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
 import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
-import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.spi.security.PrivilegeInfo.Privilege;
 import io.airlift.slice.Slice;
 
 import java.util.Collection;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -30,6 +30,7 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
 import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
+import com.facebook.presto.spi.security.GrantInfo;
 import com.facebook.presto.spi.security.PrivilegeInfo.Privilege;
 import io.airlift.slice.Slice;
 
@@ -319,6 +320,14 @@ public class ClassLoaderSafeConnectorMetadata
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             delegate.revokeTablePrivileges(session, tableName, privileges, grantee, grantOption);
+        }
+    }
+
+    @Override
+    public List<GrantInfo> listTablePrivileges(ConnectorSession session, SchemaTablePrefix prefix, String grantee)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.listTablePrivileges(session, prefix, grantee);
         }
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/AccessDeniedException.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/AccessDeniedException.java
@@ -178,6 +178,16 @@ public class AccessDeniedException
         throw new AccessDeniedException(format("Cannot revoke privilege %s on table %s%s", privilege, tableName, formatExtraInfo(extraInfo)));
     }
 
+    public static void denyShowGrants(String user)
+    {
+        denyShowGrants(user, null);
+    }
+
+    public static void denyShowGrants(String user, String extraInfo)
+    {
+        throw new AccessDeniedException(format("Cannot show grants for user %s%s", user, formatExtraInfo(extraInfo)));
+    }
+
     public static void denySetSystemSessionProperty(String propertyName)
     {
         denySetSystemSessionProperty(propertyName, null);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/ConnectorAccessControl.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/ConnectorAccessControl.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.spi.security;
 
 import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.security.PrivilegeInfo.Privilege;
 
 @Deprecated
 public interface ConnectorAccessControl

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/GrantInfo.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/GrantInfo.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.security;
+
+import com.facebook.presto.spi.SchemaTableName;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+public class GrantInfo
+{
+    private final Set<PrivilegeInfo> privilegeInfo;
+    private final Identity identity;
+    private final SchemaTableName schemaTableName;
+    private final Optional<Identity> grantor;
+    private final Optional<Boolean> withHierarchy;
+
+    public GrantInfo(Set<PrivilegeInfo> privilegeInfo, Identity identity, SchemaTableName schemaTableName, Optional<Identity> grantor, Optional<Boolean> withHierarchy)
+    {
+        this.privilegeInfo = privilegeInfo;
+        this.identity = identity;
+        this.schemaTableName = schemaTableName;
+        this.grantor = grantor;
+        this.withHierarchy = withHierarchy;
+    }
+
+    public Set<PrivilegeInfo> getPrivilegeInfo()
+    {
+        return privilegeInfo;
+    }
+
+    public Identity getIdentity()
+    {
+        return identity;
+    }
+
+    public SchemaTableName getSchemaTableName()
+    {
+        return schemaTableName;
+    }
+
+    public Optional<Identity> getGrantor()
+    {
+        return grantor;
+    }
+
+    public Optional<Boolean> getWithHierarchy()
+    {
+        return withHierarchy;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(privilegeInfo, identity, schemaTableName, grantor, withHierarchy);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        GrantInfo grantInfo = (GrantInfo) o;
+        return Objects.equals(privilegeInfo, grantInfo.getPrivilegeInfo()) &&
+                Objects.equals(identity, grantInfo.getIdentity()) &&
+                Objects.equals(schemaTableName, grantInfo.getSchemaTableName()) &&
+                Objects.equals(grantor, grantInfo.getGrantor()) &&
+                Objects.equals(withHierarchy, grantInfo.getWithHierarchy());
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/Privilege.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/Privilege.java
@@ -15,5 +15,5 @@ package com.facebook.presto.spi.security;
 
 public enum Privilege
 {
-    SELECT, DELETE, INSERT
+    SELECT, DELETE, INSERT, UPDATE, OWNERSHIP;
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/PrivilegeInfo.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/PrivilegeInfo.java
@@ -13,7 +13,28 @@
  */
 package com.facebook.presto.spi.security;
 
-public enum Privilege
+public class PrivilegeInfo
 {
-    SELECT, DELETE, INSERT, UPDATE, OWNERSHIP;
+    public enum Privilege {
+        SELECT, DELETE, INSERT, UPDATE, OWNERSHIP;
+    }
+
+    private final Privilege privilege;
+    private final boolean grantOption;
+
+    public PrivilegeInfo(Privilege privilege, boolean grantOption)
+    {
+        this.privilege = privilege;
+        this.grantOption = grantOption;
+    }
+
+    public Privilege getPrivilege()
+    {
+        return privilege;
+    }
+
+    public boolean isGrantOption()
+    {
+        return grantOption;
+    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/SystemAccessControl.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/SystemAccessControl.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.spi.security;
 
 import com.facebook.presto.spi.CatalogSchemaTableName;
+import com.facebook.presto.spi.security.PrivilegeInfo.Privilege;
 
 import java.security.Principal;
 


### PR DESCRIPTION
This PR adds syntax support for "show grant" and its implementation for Hive connector. This command is not specified in SQL standard, so there there is no gold standard for the syntax. I have borrowed the syntax from Hive. Here is the syntax that the current version supports:
`SHOW GRANT
        (USER identifier)?
        ON (TABLE? qualifiedName | ALL)`

It supports showing grants for users but lacks the support to show grants for roles (which I am planning to add later).
- When user name is speciified, `SHOW GRANT USER identifier ...` will show grants for the specified user, provided the specified user is the same as the current user. Attempts to show grants for any other user than the current user will be denied.
- When user is not specified, `SHOW GRANT ...` will show grants for the current user. 

The implementation follows the definition of `TABLE_PRIVILEGES` table specified in SQL standard:

``` sql
CREATE VIEW TABLE_PRIVILEGES AS
SELECT GRANTOR, GRANTEE, TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME,
PRIVILEGE_TYPE, IS_GRANTABLE, WITH_HIERARCHY
FROM DEFINITION_SCHEMA.TABLE_PRIVILEGES
WHERE ( GRANTEE IN
( ’PUBLIC’, CURRENT_USER )
OR
GRANTOR = CURRENT_USER )
AND
TABLE_CATALOG
= ( SELECT CATALOG_NAME
FROM INFORMATION_SCHEMA_CATALOG_NAME );
```

except that:
1) We don't consider the case of grantor = current_user
2) grantee in `PUBLIC` is not taken into consideration

I will handle these cases soon.

PS: I will add product tests and documentation in a separate PR once this gets in.
