### PR TITLE
Refactor ldap filter

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/security/LdapFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/LdapFilter.java
@@ -57,6 +57,7 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Throwables.propagateIfInstanceOf;
+import static com.google.common.io.ByteStreams.skipFully;
 import static com.google.common.net.HttpHeaders.AUTHORIZATION;
 import static io.airlift.http.client.HttpStatus.BAD_REQUEST;
 import static io.airlift.http.client.HttpStatus.INTERNAL_SERVER_ERROR;
@@ -146,17 +147,28 @@ public class LdapFilter
         }
         catch (AuthenticationException e) {
             log.debug(e, "LDAP authentication failed");
-            processAuthenticationException(e, response);
+            processAuthenticationException(e, request, response);
         }
     }
 
-    private static void processAuthenticationException(AuthenticationException e, HttpServletResponse response)
+    private static void processAuthenticationException(AuthenticationException e, HttpServletRequest request, HttpServletResponse response)
             throws IOException
     {
         if (e.getStatus() == UNAUTHORIZED) {
+            // Due to the Jetty bug explained here: https://github.com/eclipse/jetty.project/issues/938
+            skipRequestContent(request);
             response.setHeader(HttpHeaders.WWW_AUTHENTICATE, "Basic realm=\"presto\"");
         }
         response.sendError(e.getStatus().code(), e.getMessage());
+    }
+
+    private static void skipRequestContent(HttpServletRequest request)
+            throws IOException
+    {
+        long contentLength = request.getContentLengthLong();
+        if (contentLength > 0) {
+            skipFully(request.getInputStream(), contentLength);
+        }
     }
 
     private static Credentials getCredentials(String header)

--- a/presto-main/src/main/java/com/facebook/presto/server/security/LdapFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/LdapFilter.java
@@ -68,6 +68,7 @@ public class LdapFilter
     private static final Logger log = Logger.get(LdapFilter.class);
     private static final String AUTHENTICATION_TYPE = "Basic";
     private static final String LDAP_CONTEXT_FACTORY = "com.sun.jndi.ldap.LdapCtxFactory";
+
     private final LdapServerConfig serverConfig;
     private final GenericLdapBinder genericLdapBinder;
     private final long ldapCacheTtl;
@@ -104,8 +105,8 @@ public class LdapFilter
 
         HttpServletRequest request = (HttpServletRequest) servletRequest;
         HttpServletResponse response = (HttpServletResponse) servletResponse;
-        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
 
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
         if (header == null) {
             // request for user/password for LDAP authentication
             sendChallenge(response, SC_UNAUTHORIZED, null);
@@ -146,9 +147,11 @@ public class LdapFilter
             environment.put(SECURITY_PRINCIPAL, principal);
             environment.put(SECURITY_CREDENTIALS, password);
 
-            CacheLoader<Hashtable<String, String>, DirContext> loader = new CacheLoader<Hashtable<String, String>, DirContext>() {
+            CacheLoader<Hashtable<String, String>, DirContext> loader = new CacheLoader<Hashtable<String, String>, DirContext>()
+            {
                 @Override
-                public DirContext load(Hashtable<String, String> environment) throws NamingException
+                public DirContext load(Hashtable<String, String> environment)
+                        throws NamingException
                 {
                     return authenticate(environment);
                 }
@@ -189,9 +192,6 @@ public class LdapFilter
             log.debug("Authentication failed for user %s. Invalid credentials: %s", user, e.getMessage());
             throw new RuntimeException("Invalid credentials: " + e.getMessage());
         }
-        catch (NamingException e) {
-            throw Throwables.propagate(e);
-        }
         finally {
             try {
                 if (context != null) {
@@ -205,33 +205,34 @@ public class LdapFilter
 
     private void checkForGroupMembership(String searchFilterPattern, String user, DirContext context)
     {
-            checkState(serverConfig.getUserBaseDistinguishedName() != null, "Base distinguished name (DN) for user %s is null", user);
+        checkState(serverConfig.getUserBaseDistinguishedName() != null, "Base distinguished name (DN) for user %s is null", user);
 
-            try {
-                String searchFilter = searchFilterPattern.replaceAll("\\$\\{USER\\}", user);
-                GroupAuthorizationFilter groupFilter = new GroupAuthorizationFilter(serverConfig.getUserBaseDistinguishedName(), searchFilter);
+        try {
+            String searchFilter = searchFilterPattern.replaceAll("\\$\\{USER\\}", user);
+            GroupAuthorizationFilter groupFilter = new GroupAuthorizationFilter(serverConfig.getUserBaseDistinguishedName(), searchFilter);
 
-                CacheLoader<GroupAuthorizationFilter, Boolean> loader = new CacheLoader<GroupAuthorizationFilter, Boolean>()
+            CacheLoader<GroupAuthorizationFilter, Boolean> loader = new CacheLoader<GroupAuthorizationFilter, Boolean>()
+            {
+                @Override
+                public Boolean load(@NotNull GroupAuthorizationFilter groupFilter)
+                        throws NamingException
                 {
-                    @Override
-                    public Boolean load(@NotNull GroupAuthorizationFilter groupFilter) throws NamingException
-                    {
-                        return groupFilter.authorize(context);
-                    }
-                };
-                LoadingCache groupFilterCache = CacheBuilder.newBuilder().expireAfterWrite(ldapCacheTtl, MILLISECONDS).build(loader);
-
-                String groupNameIfPresent = firstNonNull(serverConfig.getLdapServerType().equals(GENERIC) ? null : serverConfig.getGroupDistinguishedName(), "");
-                if (Boolean.FALSE.equals(groupFilterCache.get(groupFilter))) {
-                    String errorMessage = format("User %s not a member of the group %s", user, groupNameIfPresent);
-                    log.debug("Authorization failed for user. " + errorMessage);
-                    throw new RuntimeException("Unauthorized user: " + errorMessage);
+                    return groupFilter.authorize(context);
                 }
-                log.debug("Authorization succeeded for user %s in group %s", user, groupNameIfPresent);
+            };
+            LoadingCache groupFilterCache = CacheBuilder.newBuilder().expireAfterWrite(ldapCacheTtl, MILLISECONDS).build(loader);
+
+            String groupNameIfPresent = firstNonNull(serverConfig.getLdapServerType().equals(GENERIC) ? null : serverConfig.getGroupDistinguishedName(), "");
+            if (Boolean.FALSE.equals(groupFilterCache.get(groupFilter))) {
+                String errorMessage = format("User %s not a member of the group %s", user, groupNameIfPresent);
+                log.debug("Authorization failed for user. " + errorMessage);
+                throw new RuntimeException("Unauthorized user: " + errorMessage);
             }
-            catch (ExecutionException e) {
-                throw Throwables.propagate(e);
-            }
+            log.debug("Authorization succeeded for user %s in group %s", user, groupNameIfPresent);
+        }
+        catch (ExecutionException e) {
+            throw Throwables.propagate(e);
+        }
     }
 
     private Hashtable<String, String> getBasicEnvironment()
@@ -343,12 +344,13 @@ public class LdapFilter
         public String toString()
         {
             return toStringHelper(this)
-            .add("userBaseDistinguishedName", userBaseDistinguishedName)
-            .add("searchFilter", searchFilter)
-            .toString();
+                    .add("userBaseDistinguishedName", userBaseDistinguishedName)
+                    .add("searchFilter", searchFilter)
+                    .toString();
         }
 
-        public boolean authorize(DirContext context) throws NamingException
+        public boolean authorize(DirContext context)
+                throws NamingException
         {
             SearchControls searchControls = new SearchControls();
             searchControls.setSearchScope(SearchControls.SUBTREE_SCOPE);

--- a/presto-main/src/main/java/com/facebook/presto/server/security/LdapServerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/LdapServerConfig.java
@@ -29,7 +29,7 @@ public class LdapServerConfig
     private String userBaseDistinguishedName;
     private String groupDistinguishedName;
     private String userObjectClass;
-    private Duration ldapCacheTtl = new Duration(1, TimeUnit.MINUTES);
+    private Duration ldapCacheTtl = new Duration(1, TimeUnit.HOURS);
 
     public enum ServerType{
         ACTIVE_DIRECTORY,

--- a/presto-main/src/test/java/com/facebook/presto/server/security/TestActiveDirectoryConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/security/TestActiveDirectoryConfig.java
@@ -37,7 +37,7 @@ public class TestActiveDirectoryConfig
                 .setUserBaseDistinguishedName(null)
                 .setGroupDistinguishedName(null)
                 .setUserObjectClass(null)
-                .setLdapCacheTtl(new Duration(1, TimeUnit.MINUTES)));
+                .setLdapCacheTtl(new Duration(1, TimeUnit.HOURS)));
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/server/security/TestLdapServerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/security/TestLdapServerConfig.java
@@ -41,7 +41,7 @@ public class TestLdapServerConfig
                 .setUserBaseDistinguishedName(null)
                 .setGroupDistinguishedName(null)
                 .setUserObjectClass(null)
-                .setLdapCacheTtl(new Duration(1, TimeUnit.MINUTES)));
+                .setLdapCacheTtl(new Duration(1, TimeUnit.HOURS)));
     }
 
     @Test


### PR DESCRIPTION
Cache authentication per credentials. In is important to cache authentication,
as we are going to use LDAP authentication for internal communication. Using LDAP
authentication without any caching will lead to severe performance degradation.
