### PR TITLE
Remove LDAP tests from standard product-tests run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,11 +56,6 @@ script:
   - |
     if [[ -v PRODUCT_TESTS ]]; then
       presto-product-tests/bin/run_on_docker.sh \
-              singlenode-ldap -g ldap_cli
-    fi
-  - |
-    if [[ -v PRODUCT_TESTS ]]; then
-      presto-product-tests/bin/run_on_docker.sh \
                 multinode-tls -g smoke,cli,group-by,join,tls
     fi
   - |


### PR DESCRIPTION
The LDAP tests require additional resources, so they
are being moved to presto-checks.