### PR TITLE
Fix handling of role names for grant/revoke

### DIFF
--- a/presto-docs/src/main/sphinx/sql/grant.rst
+++ b/presto-docs/src/main/sphinx/sql/grant.rst
@@ -20,7 +20,7 @@ Grants the specified privileges to the specified grantee.
 
 Specifying ``ALL PRIVILEGES`` grants :doc:`delete`, :doc:`insert` and :doc:`select` privileges.
 
-Specifying ``PUBLIC`` grants privileges to all grantees.
+Specifying ``PUBLIC`` grants privileges to the ``PUBLIC`` role and hence to all users.
 
 The optional ``WITH GRANT OPTION`` clause allows the grantee to grant these same privileges to others.
 

--- a/presto-docs/src/main/sphinx/sql/revoke.rst
+++ b/presto-docs/src/main/sphinx/sql/revoke.rst
@@ -20,7 +20,7 @@ Revokes the specified privileges from the specified grantee.
 
 Specifying ``ALL PRIVILEGES`` revokes :doc:`delete`, :doc:`insert` and :doc:`select` privileges.
 
-Specifying ``PUBLIC`` revokes privileges from all grantees.
+Specifying ``PUBLIC`` revokes privileges from the ``PUBLIC`` role. Users will retain privileges assigned to them directly or via other roles.
 
 The optional ``GRANT OPTION FOR`` clause also revokes the privileges to grant the specified privileges.
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/ThriftHiveMetastore.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/ThriftHiveMetastore.java
@@ -679,25 +679,9 @@ public class ThriftHiveMetastore
                     .stopOnIllegalExceptions()
                     .run("grantTablePrivileges", stats.getGrantTablePrivileges().wrap(() -> {
                         try (HiveMetastoreClient metastoreClient = clientProvider.createMetastoreClient()) {
-                            PrincipalType principalType;
-
-                            if (metastoreClient.getRoleNames().contains(grantee)) {
-                                principalType = ROLE;
-                            }
-                            else {
-                                principalType = USER;
-                            }
-
-                            ImmutableList.Builder<HiveObjectPrivilege> privilegeBagBuilder = ImmutableList.builder();
-                            for (PrivilegeGrantInfo privilegeGrantInfo : privilegesToGrant) {
-                                privilegeBagBuilder.add(
-                                        new HiveObjectPrivilege(new HiveObjectRef(HiveObjectType.TABLE, databaseName, tableName, null, null),
-                                                grantee,
-                                                principalType,
-                                                privilegeGrantInfo));
-                            }
-                            // TODO: Check whether the user/role exists in the hive metastore.
-                            metastoreClient.grantPrivileges(new PrivilegeBag(privilegeBagBuilder.build()));
+                            metastoreClient.grantPrivileges(
+                                    buildPrivilegeBag(metastoreClient, databaseName, tableName, grantee, privilegesToGrant)
+                            );
                         }
                         return null;
                     }));
@@ -732,26 +716,9 @@ public class ThriftHiveMetastore
                     .stopOnIllegalExceptions()
                     .run("revokeTablePrivileges", stats.getRevokeTablePrivileges().wrap(() -> {
                         try (HiveMetastoreClient metastoreClient = clientProvider.createMetastoreClient()) {
-                            PrincipalType principalType;
-
-                            if (metastoreClient.getRoleNames().contains(grantee)) {
-                                principalType = ROLE;
-                            }
-                            else {
-                                principalType = USER;
-                            }
-
-                            ImmutableList.Builder<HiveObjectPrivilege> privilegeBagBuilder = ImmutableList.builder();
-                            for (PrivilegeGrantInfo privilegeGrantInfo : privilegesToRevoke) {
-                                privilegeBagBuilder.add(
-                                        new HiveObjectPrivilege(
-                                                new HiveObjectRef(HiveObjectType.TABLE, databaseName, tableName, null, null),
-                                                grantee,
-                                                principalType,
-                                                privilegeGrantInfo));
-                            }
-                            // TODO: Check whether the user/role exists in the hive metastore.
-                            metastoreClient.revokePrivileges(new PrivilegeBag(privilegeBagBuilder.build()));
+                            metastoreClient.revokePrivileges(
+                                    buildPrivilegeBag(metastoreClient, databaseName, tableName, grantee, privilegesToRevoke)
+                            );
                         }
                         return null;
                     }));
@@ -764,6 +731,41 @@ public class ThriftHiveMetastore
                 Thread.currentThread().interrupt();
             }
             throw Throwables.propagate(e);
+        }
+    }
+
+    private PrivilegeBag buildPrivilegeBag(HiveMetastoreClient metastoreClient,
+                                                     String databaseName,
+                                                     String tableName,
+                                                     String grantee,
+                                                     Set<PrivilegeGrantInfo> privilegeGrantInfos)
+    {
+        PrincipalType principalType;
+        String principalName;
+
+        try {
+            if (metastoreClient.getRoleNames().contains(grantee.toLowerCase())) {
+                principalType = ROLE;
+                principalName = grantee.toLowerCase(); // Hive metastore API requires role names to be in lowercase.
+            }
+            else {
+                principalType = USER;
+                principalName = grantee;
+            }
+
+            ImmutableList.Builder<HiveObjectPrivilege> privilegeBagBuilder = ImmutableList.builder();
+            for (PrivilegeGrantInfo privilegeGrantInfo : privilegeGrantInfos) {
+                privilegeBagBuilder.add(
+                        new HiveObjectPrivilege(
+                                new HiveObjectRef(HiveObjectType.TABLE, databaseName, tableName, null, null),
+                                principalName,
+                                principalType,
+                                privilegeGrantInfo));
+            }
+            return new PrivilegeBag(privilegeBagBuilder.build());
+        }
+        catch (TException e) {
+            throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
     }
 


### PR DESCRIPTION
Hive metastore API requires role names to be in lowercase. So the role names need to be converted before they are passed to the metastore API method. 

Added product test for ``PUBLIC`` role. Also corrected ``GRANT/REVOKE`` documentation for ``PUBLIC`` role.

@cawallin @brian-rickman please review.