### PR TITLE
Do not use TableScanNode.tableLayout in CostCalculator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/CoefficientBasedCostCalculator.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/CoefficientBasedCostCalculator.java
@@ -189,10 +189,7 @@ public class CoefficientBasedCostCalculator
         {
             boolean fullyEnforced = false;
             Optional<TableLayoutHandle> layoutHandle = Optional.empty();
-            if (node.getLayout().isPresent()) {
-                layoutHandle = Optional.of(node.getLayout().get());
-            }
-            else {
+            {
                 List<TableLayoutResult> layoutCandidates = getLayouts(node, predicate);
                 if (!layoutCandidates.isEmpty()) {
                     TableLayout layout = layoutCandidates.get(0).getLayout();


### PR DESCRIPTION
When cost is computed in CoefficientBasedCostCalculator ignore the
possibly set TableScanNode.tableLayout field. Instead always compute
table layout based on predicates.

It results in printing cost which is actuly used by cost based
optimizers, which are run in phase when TableScanNode.tableLayout
is not set yet (it is set later by AddExchanges/PickLayout optimizer).