### PR TITLE
 Add product tests to verify owner privileges

### DIFF
--- a/presto-product-tests/conf/docker/common/compose-commons.sh
+++ b/presto-product-tests/conf/docker/common/compose-commons.sh
@@ -23,7 +23,7 @@ function export_canonical_path() {
 
 source ${BASH_SOURCE%/*}/../../../bin/locations.sh
 
-export DOCKER_IMAGES_VERSION=${DOCKER_IMAGES_VERSION:-10}
+export DOCKER_IMAGES_VERSION=${DOCKER_IMAGES_VERSION:-12}
 export HADOOP_MASTER_IMAGE=${HADOOP_MASTER_IMAGE:-"teradatalabs/cdh5-hive:${DOCKER_IMAGES_VERSION}"}
 
 # The following variables are defined to enable running product tests with arbitrary/downloaded jars

--- a/presto-product-tests/conf/tempto/tempto-configuration-for-docker-kerberos.yaml
+++ b/presto-product-tests/conf/tempto/tempto-configuration-for-docker-kerberos.yaml
@@ -9,10 +9,14 @@ databases:
   hive:
     host: hadoop-master
     jdbc_url: jdbc:hive2://${databases.hive.host}:10000/default;principal=hive/hadoop-master@LABS.TERADATA.COM;auth=kerberos;kerberosAuthType=fromSubject;
-    jdbc_user: hive/hadoop-master@LABS.TERADATA.COM
+    jdbc_user: hdfs # Note: databases.hive.jdbc_user is not being used in kerberized environment as of now
     jdbc_password: na
-    kerberos_principal: hive/hadoop-master@LABS.TERADATA.COM
-    kerberos_keytab: /etc/hive/conf/hive.keytab
+
+    # The primary part in kerberos_principal should be "hdfs" in order to pass the Hive authorization.
+    # The reason being this user, which is used by Tempto to run CREATE TABLE queries in Hive, should match
+    # the user that owns the "/product-test" directory in HDFS (i.e. the "hdfs" user).
+    kerberos_principal: hdfs/hadoop-master@LABS.TERADATA.COM
+    kerberos_keytab: /etc/hadoop/conf/hdfs.keytab
 
   presto:
     host: presto-master
@@ -20,7 +24,12 @@ databases:
     server_address: https://${databases.presto.host}:${databases.presto.port}
     # Use the HTTP interface in JDBC, as Kerberos authentication is not yet supported in there.
     jdbc_url: jdbc:presto://${databases.presto.host}:8080/hive/${databases.hive.schema}
-    jdbc_user: hive
+
+    # jdbc_user in here should satisfy two requirements in order to pass SQL standard access control checks in Presto:
+    #   1) It should belong to the "admin" role in hive
+    #   2) It should have the required privileges (such as SELECT) on Hive tables (such as hive.default.nation)
+    jdbc_user: hdfs
+
     cli_kerberos_authentication: true
     https_keystore_path: /etc/presto/conf/keystore.jks
     https_keystore_password: password

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestGrantRevoke.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestGrantRevoke.java
@@ -15,9 +15,11 @@
 package com.facebook.presto.tests.hive;
 
 import com.google.common.collect.ImmutableList;
+import com.teradata.tempto.AfterTestWithContext;
 import com.teradata.tempto.BeforeTestWithContext;
 import com.teradata.tempto.ProductTest;
 import com.teradata.tempto.query.QueryExecutor;
+import io.airlift.log.Logger;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
@@ -64,6 +66,18 @@ public class TestGrantRevoke
         aliceExecutor.executeQuery(format("CREATE TABLE %s(month bigint, day bigint)", tableName));
 
         assertAccessDeniedOnAllOperationsOnTable(bobExecutor, tableName);
+    }
+
+    @AfterTestWithContext
+    public void cleanup()
+    {
+        try {
+            aliceExecutor.executeQuery(format("DROP TABLE IF EXISTS %s", tableName));
+            aliceExecutor.executeQuery(format("DROP VIEW IF EXISTS %s", viewName));
+        }
+        catch (Exception e) {
+            Logger.get(getClass()).warn(e, "failed to drop table/view");
+        }
     }
 
     @Test(groups = {HIVE_CONNECTOR, AUTHORIZATION, PROFILE_SPECIFIC_TESTS})

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestGrantRevoke.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestGrantRevoke.java
@@ -14,6 +14,7 @@
 
 package com.facebook.presto.tests.hive;
 
+import com.google.common.collect.ImmutableList;
 import com.teradata.tempto.BeforeTestWithContext;
 import com.teradata.tempto.ProductTest;
 import com.teradata.tempto.query.QueryExecutor;
@@ -25,14 +26,19 @@ import static com.facebook.presto.tests.TestGroups.AUTHORIZATION;
 import static com.facebook.presto.tests.TestGroups.HIVE_CONNECTOR;
 import static com.facebook.presto.tests.TestGroups.PROFILE_SPECIFIC_TESTS;
 import static com.facebook.presto.tests.utils.QueryExecutors.connectToPresto;
+import static com.teradata.tempto.assertions.QueryAssert.Row;
 import static com.teradata.tempto.assertions.QueryAssert.Row.row;
 import static com.teradata.tempto.assertions.QueryAssert.assertThat;
+import static com.teradata.tempto.context.ContextDsl.executeWith;
+import static com.teradata.tempto.context.ThreadLocalTestContextHolder.testContext;
+import static com.teradata.tempto.sql.SqlContexts.createViewAs;
 import static java.lang.String.format;
 
 public class TestGrantRevoke
     extends ProductTest
 {
     private String tableName;
+    private String viewName;
     private QueryExecutor aliceExecutor;
     private QueryExecutor bobExecutor;
 
@@ -50,6 +56,7 @@ public class TestGrantRevoke
     public void setup()
     {
         tableName = "alice_owned_table";
+        viewName = "alice_view";
         aliceExecutor = connectToPresto("alice@presto");
         bobExecutor = connectToPresto("bob@presto");
 
@@ -119,6 +126,36 @@ public class TestGrantRevoke
         assertThat(() -> bobExecutor.executeQuery(format("SELECT * FROM %s", tableName))).
                 failsWithMessage(format("Access Denied: Cannot select from table default.%s", tableName));
         assertThat(aliceExecutor.executeQuery(format("SELECT * FROM %s", tableName))).hasNoRows();
+    }
+
+    @Test(groups = {AUTHORIZATION, HIVE_CONNECTOR, PROFILE_SPECIFIC_TESTS})
+    public void testTableOwnerPrivileges()
+    {
+        onHive().executeQuery("set role admin;");
+        assertThat(onHive().executeQuery(format("SHOW GRANT USER alice ON TABLE %s", tableName)).
+                project(7, 8)). // Project only two relevant columns of SHOW GRANT: Privilege and Grant Option
+                containsOnly(ownerGrants());
+    }
+
+    @Test(groups = {AUTHORIZATION, HIVE_CONNECTOR, PROFILE_SPECIFIC_TESTS})
+    public void testViewOwnerPrivileges()
+    {
+        onHive().executeQuery("set role admin;");
+        executeWith(createViewAs(viewName, format("SELECT * FROM %s", tableName), aliceExecutor), view -> {
+            assertThat(onHive().executeQuery(format("SHOW GRANT USER alice ON %s", viewName)).
+                    project(7, 8)). // Project only two relevant columns of SHOW GRANT: Privilege and Grant Option
+                    containsOnly(ownerGrants());
+        });
+    }
+
+    private ImmutableList<Row> ownerGrants()
+    {
+        return ImmutableList.of(row("SELECT", Boolean.TRUE), row("INSERT", Boolean.TRUE), row("UPDATE", Boolean.TRUE), row("DELETE", Boolean.TRUE));
+    }
+
+    public static QueryExecutor onHive()
+    {
+        return testContext().getDependency(QueryExecutor.class, "hive");
     }
 
     private static void assertAccessDeniedOnAllOperationsOnTable(QueryExecutor queryExecutor, String tableName)


### PR DESCRIPTION
Add product tests to verify that the owner of a table/view has the `SELECT`, `INSERT`, `UPDATE` and `DELETE` privileges.

These tests are for the commits that fixed a bug: 
https://github.com/prestodb/presto/commit/29319c52954f9b874de625c124e18209e573f44b
https://github.com/prestodb/presto/commit/fc36eff0dc985f06ac030b75b7746ad6ffdd84ae

I chose to use `SHOW GRANTS` for verifying the privileges, since there is no way to perform an `UPDATE` operation, if we go via the path of verifying the privileges by checking whether the owner can perform those operations.