### PR TITLE
Document note about authorization without authentication

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive-security.rst
+++ b/presto-docs/src/main/sphinx/connector/hive-security.rst
@@ -12,7 +12,7 @@ Authorization
 
 You can enable authorization checks for the :doc:`/connector/hive` by setting
 the ``hive.security`` property in the Hive catalog properties file. This
-property must be one of the following values:
+property must have one of the following values:
 
 ================================================== ============================================================
 Property Value                                     Description
@@ -38,6 +38,8 @@ Property Value                                     Description
                                                    To alter these privileges, use the :doc:`/sql/grant` and
                                                    :doc:`/sql/revoke` commands.
 ================================================== ============================================================
+
+Ensure that authentication has been enabled when enabling authorization checks.
 
 Authentication
 ==============

--- a/presto-docs/src/main/sphinx/sql/grant.rst
+++ b/presto-docs/src/main/sphinx/sql/grant.rst
@@ -26,6 +26,11 @@ The optional ``WITH GRANT OPTION`` clause allows the grantee to grant these same
 
 For ``GRANT`` statement to succeed, the user executing it should possess the specified privileges as well as the ``GRANT OPTION`` for those privileges.
 
+.. note::
+
+    Ensure that authentication has been enabled before running any of the authorization
+    commands such as ``GRANT``, ``REVOKE`` or ``SHOW GRANTS``.
+
 Examples
 --------
 

--- a/presto-docs/src/main/sphinx/sql/revoke.rst
+++ b/presto-docs/src/main/sphinx/sql/revoke.rst
@@ -26,6 +26,11 @@ The optional ``GRANT OPTION FOR`` clause also revokes the privileges to grant th
 
 For ``REVOKE`` statement to succeed, the user executing it should possess the specified privileges as well as the ``GRANT OPTION`` for those privileges.
 
+.. note::
+
+    Ensure that authentication has been enabled before running any of the authorization
+    commands such as ``GRANT``, ``REVOKE`` or ``SHOW GRANTS``.
+
 Examples
 --------
 

--- a/presto-docs/src/main/sphinx/sql/show-grants.rst
+++ b/presto-docs/src/main/sphinx/sql/show-grants.rst
@@ -18,6 +18,11 @@ Specifying ``ALL`` lists the grants for the current user on all the tables in al
 
 The command requires the current catalog to be set.
 
+.. note::
+
+    Ensure that authentication has been enabled before running any of the authorization
+    commands such as ``GRANT``, ``REVOKE`` or ``SHOW GRANTS``.
+
 Examples
 --------
 


### PR DESCRIPTION
Running authorization commands without authentication is a bad practice. Warn users about it.