### PR TITLE
Package product-test scripts

### DIFF
--- a/presto-product-tests/README.md
+++ b/presto-product-tests/README.md
@@ -265,6 +265,20 @@ presto-product-tests/bin/run_on_docker.sh multinode -x quarantine,big_query,prof
 
 All of the variables are optional and fall back to local sources / build artifacts if unspecified.
 
+### Running outside the source tree
+
+To run the tests outside the source tree, perhaps on a Continuous Integration server, you'll need
+to collect the following build artifacts:
+
+* presto-cli/target/presto-cli-executable.jar
+* presto-jdbc/target/presto-jdbc.jar
+* presto-product-tests/target/presto-product-tests-executable.jar
+* presto-product-tests/target/presto-product-tests-scripts.zip
+* presto-server/target/presto-server.tar.gz
+
+Unpack the zip and tar.gz archives in a convenient location, set environment variables, and execute
+`presto-product-tests/bin/run_on_docker.sh` as described above.
+
 ### Interrupting a test run
 
 To interrupt a product test run, send a single `Ctrl-C` signal. The scripts

--- a/presto-product-tests/pom.xml
+++ b/presto-product-tests/pom.xml
@@ -158,6 +158,22 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <descriptor>src/assembly/scripts.xml</descriptor>
+                        <finalName>presto-product-tests-${project.version}</finalName>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/presto-product-tests/src/assembly/scripts.xml
+++ b/presto-product-tests/src/assembly/scripts.xml
@@ -1,0 +1,30 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+<id>scripts</id>
+<formats>
+    <format>zip</format>
+</formats>
+
+<fileSets>
+   <fileSet>
+        <directory>./</directory>
+        <includes>
+            <include>README.md</include>
+        </includes>
+    </fileSet>
+    <fileSet>
+        <directory>bin</directory>
+    </fileSet>
+    <fileSet>
+        <directory>conf/docker</directory>
+    </fileSet>
+    <fileSet>
+        <directory>conf/presto</directory>
+    </fileSet>
+    <fileSet>
+        <directory>conf/tempto</directory>
+    </fileSet>
+</fileSets>
+</assembly>
+


### PR DESCRIPTION
Execute `mvn package` to create
presto-product-tests/target/*-scripts.zip

Unpack this archive somewhere else, set environment
variables as explained in README.md, and now you
can run presto-product-tests outside the source tree.