### PR TITLE
Fix Simba specfic tests

### DIFF
--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/jdbc/PreparedStatements.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/jdbc/PreparedStatements.java
@@ -67,6 +67,8 @@ public class PreparedStatements
     private static final Logger LOGGER = Logger.get(PreparedStatements.class);
     private static final String TABLE_NAME = "textfile_all_types";
     private static final String TABLE_NAME_MUTABLE = "all_types_table_name";
+    private static final String insertSql = "INSERT INTO %s VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
+    private static final String selectStarSql = "SELECT * FROM %s";
 
     private Connection connection;
 
@@ -149,15 +151,53 @@ public class PreparedStatements
 
     @Test(groups = {JDBC, SIMBA_JDBC})
     @Requires(MutableAllTypesTable.class)
+    public void preparedInsertVarbinaryApi()
+            throws SQLException
+    {
+        if (usingTeradataJdbcDriver(connection)) {
+            String tableNameInDatabase = mutableTablesState().get(TABLE_NAME_MUTABLE).getNameInDatabase();
+            String insertSqlWithTable = String.format(insertSql, tableNameInDatabase);
+            String selectSqlWithTable = String.format(selectStarSql, tableNameInDatabase);
+
+            defaultQueryExecutor().executeQuery(insertSqlWithTable, QueryType.UPDATE,
+                    param(TINYINT, null),
+                    param(SMALLINT, null),
+                    param(INTEGER, null),
+                    param(BIGINT, null),
+                    param(FLOAT, null),
+                    param(DOUBLE, null),
+                    param(DECIMAL, null),
+                    param(DECIMAL, null),
+                    param(TIMESTAMP, null),
+                    param(DATE, null),
+                    param(VARCHAR, null),
+                    param(VARCHAR, null),
+                    param(CHAR, null),
+                    param(BOOLEAN, null),
+                    param(VARBINARY, "a290IGJpbmFybnk=".getBytes()));
+
+            QueryResult result = defaultQueryExecutor().executeQuery(selectSqlWithTable);
+            assertColumnTypes(result);
+            assertThat(result).containsOnly(
+                    row(null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+                            "a290IGJpbmFybnk=".getBytes()));
+        }
+        else {
+            LOGGER.warn("preparedInsertVarbinaryApi() only applies to TeradataJdbcDriver");
+        }
+    }
+
+    @Test(groups = {JDBC, SIMBA_JDBC})
+    @Requires(MutableAllTypesTable.class)
     public void preparedInsertApi()
             throws SQLException
     {
         if (usingTeradataJdbcDriver(connection)) {
             String tableNameInDatabase = mutableTablesState().get(TABLE_NAME_MUTABLE).getNameInDatabase();
-            String insertSql = "INSERT INTO " + tableNameInDatabase + " VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
-            String selectSql = "SELECT * FROM " + tableNameInDatabase;
+            String insertSqlWithTable = String.format(insertSql, tableNameInDatabase);
+            String selectSqlWithTable = String.format(selectStarSql, tableNameInDatabase);
 
-            defaultQueryExecutor().executeQuery(insertSql, QueryType.UPDATE,
+            defaultQueryExecutor().executeQuery(insertSqlWithTable, QueryType.UPDATE,
                     param(TINYINT, 127),
                     param(SMALLINT, 32767),
                     param(INTEGER, 2147483647),
@@ -172,9 +212,9 @@ public class PreparedStatements
                     param(VARCHAR, "ala ma kot"),
                     param(CHAR, "ala ma    "),
                     param(BOOLEAN, Boolean.TRUE),
-                    param(VARBINARY, "a290IGJpbmFybnk=".getBytes()));
+                    param(VARBINARY, null));
 
-            defaultQueryExecutor().executeQuery(insertSql, QueryType.UPDATE,
+            defaultQueryExecutor().executeQuery(insertSqlWithTable, QueryType.UPDATE,
                     param(TINYINT, 1),
                     param(SMALLINT, 2),
                     param(INTEGER, 3),
@@ -189,9 +229,9 @@ public class PreparedStatements
                     param(VARCHAR, "def"),
                     param(CHAR, "ghi       "),
                     param(BOOLEAN, Boolean.FALSE),
-                    param(VARBINARY, "jkl".getBytes()));
+                    param(VARBINARY, null));
 
-            defaultQueryExecutor().executeQuery(insertSql, QueryType.UPDATE,
+            defaultQueryExecutor().executeQuery(insertSqlWithTable, QueryType.UPDATE,
                     param(TINYINT, null),
                     param(SMALLINT, null),
                     param(INTEGER, null),
@@ -208,30 +248,30 @@ public class PreparedStatements
                     param(BOOLEAN, null),
                     param(VARBINARY, null));
 
-            QueryResult result = defaultQueryExecutor().executeQuery(selectSql);
+            QueryResult result = defaultQueryExecutor().executeQuery(selectSqlWithTable);
             assertColumnTypes(result);
             assertThat(result).containsOnly(
                     row(
                             127,
                             32767,
                             2147483647,
-                            new BigInteger("9223372036854775807"),
+                            Long.parseLong("9223372036854775807"),
                             Float.valueOf("123.345"),
-                            234.567,
+                            Double.valueOf("234.567"),
                             BigDecimal.valueOf(346),
                             BigDecimal.valueOf(345.678),
                             Timestamp.valueOf("2015-05-10 12:15:35"),
                             Date.valueOf("2015-05-10"),
                             "ala ma kota",
-                            "ala ma kota",
-                            "ala ma",
+                            "ala ma kot",
+                            "ala ma    ",
                             Boolean.TRUE,
-                            "a290IGJpbmFybnk=".getBytes()),
+                            null),
                     row(
                             1,
                             2,
                             3,
-                            4,
+                            4L,
                             Float.valueOf("5.6"),
                             7.8,
                             BigDecimal.valueOf(91),
@@ -240,9 +280,9 @@ public class PreparedStatements
                             Date.valueOf("2014-03-10"),
                             "abc",
                             "def",
-                            "ghi",
+                            "ghi       ",
                             Boolean.FALSE,
-                            "jkl".getBytes()),
+                            null),
                     row(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null));
         }
         else {
@@ -257,12 +297,12 @@ public class PreparedStatements
     {
         if (usingTeradataJdbcDriver(connection)) {
             String tableNameInDatabase = mutableTablesState().get(TABLE_NAME_MUTABLE).getNameInDatabase();
-            String prepareSql = "PREPARE ps1 from INSERT INTO " + tableNameInDatabase + " VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
-            String selectSql = "SELECT * FROM " + tableNameInDatabase;
+            String insertSqlWithTable = "PREPARE ps1 from " + String.format(insertSql, tableNameInDatabase);
+            String selectSqlWithTable = String.format(selectStarSql, tableNameInDatabase);
             String executeSql = "EXECUTE ps1 using ";
 
             Statement statement = connection.createStatement();
-            statement.execute(prepareSql);
+            statement.execute(insertSqlWithTable);
             statement.execute(executeSql +
                     "cast(127 as tinyint), " +
                     "cast(32767 as smallint), " +
@@ -276,8 +316,7 @@ public class PreparedStatements
                     "date '2015-05-10', " +
                     "'ala ma kota', " +
                     "'ala ma kot', " +
-                    "'ala ma    ', " +
-                    "cast('ala ma' as char(10), " +
+                    "cast('ala ma' as char(10)), " +
                     "true, " +
                     "varbinary 'a290IGJpbmFybnk='");
 
@@ -315,14 +354,14 @@ public class PreparedStatements
                     "null, " +
                     "null");
 
-            QueryResult result = defaultQueryExecutor().executeQuery(selectSql);
+            QueryResult result = defaultQueryExecutor().executeQuery(selectSqlWithTable);
             assertColumnTypes(result);
             assertThat(result).containsOnly(
                     row(
                             127,
                             32767,
                             2147483647,
-                            new BigInteger("9223372036854775807"),
+                            Long.parseLong("9223372036854775807"),
                             Float.valueOf("123.345"),
                             234.567,
                             BigDecimal.valueOf(346),
@@ -331,7 +370,6 @@ public class PreparedStatements
                             Date.valueOf("2015-05-10"),
                             "ala ma kota",
                             "ala ma kot",
-                            "ala ma    ",
                             "ala ma    ",
                             Boolean.TRUE,
                             "a290IGJpbmFybnk=".getBytes()),
@@ -355,6 +393,47 @@ public class PreparedStatements
         }
         else {
             LOGGER.warn("preparedInsertSql() only applies to TeradataJdbcDriver");
+        }
+    }
+
+    @Test(groups = {JDBC, SIMBA_JDBC})
+    @Requires(MutableAllTypesTable.class)
+    public void preparedInsertVarbinarySql()
+            throws SQLException
+    {
+        if (usingTeradataJdbcDriver(connection)) {
+            String tableNameInDatabase = mutableTablesState().get(TABLE_NAME_MUTABLE).getNameInDatabase();
+            String insertSqlWithTable = "PREPARE ps1 from " + String.format(insertSql, tableNameInDatabase);
+            String selectSqlWithTable = String.format(selectStarSql, tableNameInDatabase);
+            String executeSql = "EXECUTE ps1 using ";
+
+            Statement statement = connection.createStatement();
+            statement.execute(insertSqlWithTable);
+            statement.execute(executeSql +
+                    "null, " +
+                    "null, " +
+                    "null, " +
+                    "null, " +
+                    "null, " +
+                    "null, " +
+                    "null, " +
+                    "null, " +
+                    "null, " +
+                    "null, " +
+                    "null, " +
+                    "null, " +
+                    "null, " +
+                    "null, " +
+                    "varbinary 'a290IGJpbmFybnk='");
+
+            QueryResult result = defaultQueryExecutor().executeQuery(selectSqlWithTable);
+            assertColumnTypes(result);
+            assertThat(result).containsOnly(
+                    row(null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+                            "a290IGJpbmFybnk=".getBytes()));
+        }
+        else {
+            LOGGER.warn("preparedInsertVarbinarySql() only applies to TeradataJdbcDriver");
         }
     }
 

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/utils/JdbcDriverUtils.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/utils/JdbcDriverUtils.java
@@ -53,7 +53,7 @@ public class JdbcDriverUtils
         }
         else if (usingTeradataJdbcDriver(connection)) {
             try (Statement statement = connection.createStatement()) {
-                statement.execute(String.format("set session %s=%s", key, value));
+                statement.execute(String.format("set session %s='%s'", key, value));
             }
         }
         else {


### PR DESCRIPTION
Fix testSessionProperties().

Test insert of binary values via PreparedStatement in a separate method, because this is broken in the current version of the Simba JDBC driver.

Correct data types in expected results.