### PR TITLE
Add MergeAdjacentWindows rule to iterative optimizer

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeAdjacentWindows.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeAdjacentWindows.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.DependencyExtractor;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.WindowNode;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Optional;
+
+public class MergeAdjacentWindows
+    implements Rule
+{
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator)
+    {
+        if (!(node instanceof WindowNode)) {
+            return Optional.empty();
+        }
+
+        WindowNode parent = (WindowNode) node;
+
+        PlanNode source = lookup.resolve(parent.getSource());
+        if (!(source instanceof WindowNode)) {
+            return Optional.empty();
+        }
+
+        WindowNode child = (WindowNode) source;
+
+        if (!child.getSpecification().equals(parent.getSpecification()) || dependsOn(parent, child)) {
+            return Optional.empty();
+        }
+
+        ImmutableMap.Builder<Symbol, WindowNode.Function> functionsBuilder = ImmutableMap.builder();
+        functionsBuilder.putAll(parent.getWindowFunctions());
+        functionsBuilder.putAll(child.getWindowFunctions());
+
+        return Optional.of(new WindowNode(
+                parent.getId(),
+                child.getSource(),
+                parent.getSpecification(),
+                functionsBuilder.build(),
+                parent.getHashSymbol(),
+                parent.getPrePartitionedInputs(),
+                parent.getPreSortedOrderPrefix()));
+    }
+
+    private static boolean dependsOn(WindowNode parent, WindowNode child)
+    {
+        return parent.getPartitionBy().stream().anyMatch(symbol -> child.getCreatedSymbols().contains(symbol))
+                || parent.getOrderBy().stream().anyMatch(symbol -> child.getCreatedSymbols().contains(symbol))
+                || parent.getWindowFunctions().values().stream()
+                .map(WindowNode.Function::getFunctionCall)
+                .flatMap(functionCall -> functionCall.getArguments().stream())
+                .map(argument -> DependencyExtractor.extractUnique(argument))
+                .flatMap(symbols -> symbols.stream())
+                .anyMatch(symbol -> child.getCreatedSymbols().contains(symbol));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MergeWindows.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MergeWindows.java
@@ -62,6 +62,8 @@ import static com.google.common.base.Preconditions.checkState;
  *             `--WindowNode(Specification: A, Functions: [avg(something)])
  *                `--...
  */
+
+@Deprecated
 public class MergeWindows
         implements PlanOptimizer
 {

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/TestMergeAdjacentWindows.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/TestMergeAdjacentWindows.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule.test;
+
+import com.facebook.presto.metadata.FunctionKind;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.sql.planner.assertions.ExpectedValueProvider;
+import com.facebook.presto.sql.planner.iterative.rule.MergeAdjacentWindows;
+import com.facebook.presto.sql.planner.plan.Assignments;
+import com.facebook.presto.sql.planner.plan.WindowNode;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.QualifiedName;
+import com.facebook.presto.sql.tree.SymbolReference;
+import com.facebook.presto.sql.tree.Window;
+import com.facebook.presto.sql.tree.WindowFrame;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.functionCall;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.specification;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.window;
+import static com.facebook.presto.sql.tree.FrameBound.Type.CURRENT_ROW;
+import static com.facebook.presto.sql.tree.FrameBound.Type.UNBOUNDED_PRECEDING;
+
+public class TestMergeAdjacentWindows
+{
+    private final RuleTester tester = new RuleTester();
+
+    private WindowNode.Frame frame;
+    private Signature signature;
+
+    public TestMergeAdjacentWindows()
+    {
+        frame = new WindowNode.Frame(WindowFrame.Type.RANGE, UNBOUNDED_PRECEDING,
+                Optional.empty(), CURRENT_ROW, Optional.empty());
+        signature = new Signature(
+                "avg",
+                FunctionKind.WINDOW,
+                ImmutableList.of(),
+                ImmutableList.of(),
+                DOUBLE.getTypeSignature(),
+                ImmutableList.of(DOUBLE.getTypeSignature()),
+                false);
+    }
+
+    @Test
+    public void testPlanWithoutWindowNode()
+            throws Exception
+    {
+        tester.assertThat(new MergeAdjacentWindows())
+                .on(p -> p.values(p.symbol("a", BIGINT)))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testPlanWithSingleWindowNode()
+            throws Exception
+    {
+        tester.assertThat(new MergeAdjacentWindows())
+                .on(p ->
+                        p.window(
+                                newWindowNodeSpecification(p, "a"),
+                                ImmutableMap.of(p.symbol("avg_1", BIGINT), newWindowNodeFunction("avg", "a")),
+                                p.values(p.symbol("a", BIGINT))))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDistinctAdjacentWindowSpecifications()
+    {
+        tester.assertThat(new MergeAdjacentWindows())
+                .on(p ->
+                        p.window(
+                                newWindowNodeSpecification(p, "a"),
+                                ImmutableMap.of(p.symbol("avg_1", BIGINT), newWindowNodeFunction("avg", "a")),
+                                p.window(
+                                        newWindowNodeSpecification(p, "b"),
+                                        ImmutableMap.of(p.symbol("sum_1", BIGINT), newWindowNodeFunction("sum", "b")),
+                                        p.values(p.symbol("a", BIGINT), p.symbol("b", BIGINT))
+                                )
+                        ))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testNonWindowIntermediateNode()
+    {
+        tester.assertThat(new MergeAdjacentWindows())
+                .on(p ->
+                        p.window(
+                                newWindowNodeSpecification(p, "a"),
+                                ImmutableMap.of(p.symbol("lag_1", BIGINT), newWindowNodeFunction("lag", "a", "ONE")),
+                                p.project(
+                                        Assignments.copyOf(ImmutableMap.of(p.symbol("ONE", BIGINT), p.expression("CAST(1 AS bigint)"))),
+                                        p.window(
+                                                newWindowNodeSpecification(p, "a"),
+                                                ImmutableMap.of(p.symbol("avg_1", BIGINT), newWindowNodeFunction("avg", "a")),
+                                                p.values(p.symbol("a", BIGINT), p.symbol("b", BIGINT))
+                                        )
+                                )
+                        ))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDependentAdjacentWindowsIdenticalSpecifications()
+            throws Exception
+    {
+        Optional<Window> windowA = Optional.of(new Window(ImmutableList.of(new SymbolReference("a")), ImmutableList.of(), Optional.empty()));
+
+        tester.assertThat(new MergeAdjacentWindows())
+                .on(p ->
+                        p.window(
+                                newWindowNodeSpecification(p, "a"),
+                                ImmutableMap.of(p.symbol("avg_1", BIGINT), newWindowNodeFunction("avg", windowA, "avg_2")),
+                                p.window(
+                                        newWindowNodeSpecification(p, "a"),
+                                        ImmutableMap.of(p.symbol("avg_2", BIGINT), newWindowNodeFunction("avg", windowA, "a")),
+                                        p.values(p.symbol("a", BIGINT), p.symbol("b", BIGINT))
+                                )
+                        ))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDependentAdjacentWindowsDistinctSpecifications()
+            throws Exception
+    {
+        Optional<Window> windowA = Optional.of(new Window(ImmutableList.of(new SymbolReference("a")), ImmutableList.of(), Optional.empty()));
+
+        tester.assertThat(new MergeAdjacentWindows())
+                .on(p ->
+                        p.window(
+                                newWindowNodeSpecification(p, "a"),
+                                ImmutableMap.of(p.symbol("avg_1", BIGINT), newWindowNodeFunction("avg", windowA, "avg_2")),
+                                p.window(
+                                        newWindowNodeSpecification(p, "b"),
+                                        ImmutableMap.of(p.symbol("avg_2", BIGINT), newWindowNodeFunction("avg", windowA, "a")),
+                                        p.values(p.symbol("a", BIGINT), p.symbol("b", BIGINT))
+                                )
+                        ))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testIdenticalAdjacentWindowSpecifications()
+            throws Exception
+    {
+        String columnAAlias = "ALIAS_A";
+        String columnBAlias = "ALIAS_B";
+
+        ExpectedValueProvider<WindowNode.Specification> specificationA = specification(ImmutableList.of(columnAAlias), ImmutableList.of(), ImmutableMap.of());
+
+        Optional<Window> windowA = Optional.of(new Window(ImmutableList.of(new SymbolReference("a")), ImmutableList.of(), Optional.empty()));
+
+        tester.assertThat(new MergeAdjacentWindows())
+                .on(p ->
+                        p.window(
+                                newWindowNodeSpecification(p, "a"),
+                                ImmutableMap.of(p.symbol("avg_1", BIGINT), newWindowNodeFunction("avg", windowA, "a")),
+                                p.window(
+                                        newWindowNodeSpecification(p, "a"),
+                                        ImmutableMap.of(p.symbol("sum_1", BIGINT), newWindowNodeFunction("sum", windowA, "a")),
+                                        p.values(p.symbol("a", BIGINT), p.symbol("b", BIGINT))
+                                )
+                        ))
+                .matches(window(
+                        specificationA,
+                        ImmutableList.of(
+                                functionCall("avg", Optional.empty(), ImmutableList.of(columnAAlias)),
+                                functionCall("sum", Optional.empty(), ImmutableList.of(columnAAlias))),
+                        values(ImmutableMap.of(columnAAlias, 0, columnBAlias, 1))));
+    }
+
+    private static WindowNode.Specification newWindowNodeSpecification(PlanBuilder planBuilder, String symbolName)
+    {
+        return new WindowNode.Specification(ImmutableList.of(planBuilder.symbol(symbolName, BIGINT)), ImmutableList.of(), ImmutableMap.of());
+    }
+
+    private WindowNode.Function newWindowNodeFunction(String functionName, String... symbols)
+    {
+        return new WindowNode.Function(
+                new FunctionCall(
+                        QualifiedName.of(functionName),
+                        Arrays.stream(symbols).map(symbol -> new SymbolReference(symbol)).collect(Collectors.toList())),
+                signature,
+                frame);
+    }
+
+    private WindowNode.Function newWindowNodeFunction(String functionName, Optional<Window> window, String symbolName)
+    {
+        return new WindowNode.Function(
+                new FunctionCall(QualifiedName.of(functionName), window, false, ImmutableList.of(new SymbolReference(symbolName))),
+                signature,
+                frame);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestMergeWindows.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestMergeWindows.java
@@ -30,6 +30,7 @@ import org.intellij.lang.annotations.Language;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.any;
@@ -89,7 +90,12 @@ public class TestMergeWindows
 
     public TestMergeWindows()
     {
-        super();
+        this(ImmutableMap.of());
+    }
+
+    public TestMergeWindows(Map<String, String> sessionProperties)
+    {
+        super(sessionProperties);
 
         specificationA = specification(
                 ImmutableList.of(SUPPKEY_ALIAS),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestMergeWindowsIterativeOptimizer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestMergeWindowsIterativeOptimizer.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.google.common.collect.ImmutableMap;
+
+public class TestMergeWindowsIterativeOptimizer
+        extends TestMergeWindows
+{
+    public TestMergeWindowsIterativeOptimizer()
+    {
+        super(ImmutableMap.of("iterative_optimizer_enabled", "true"));
+    }
+}


### PR DESCRIPTION
This PR is based off the branch in https://github.com/Teradata/presto/pull/493. The code assumes that the rule about reordering windows has already been added in the iterative optimizer.

Previously, `MergeWindows` optimization would merge `WindowNode`s having identical `Specification` even if they were not adjacent (as long as all the nodes in the chain were `WindowNode`s). In the new framework, this will be achieved as a combination of two rules -- `MergeAdjacentWindows` and `SwapAdjacentWindowsByPartitionsOrder`. i.e. if there are three `WindowNode`s such as the following:
```
 *    WindowNode(Specification: A, Functions: [sum(something)])
 *      WindowNode(Specification: B, Functions: [sum(something)])
 *        WindowNode(Specification: A, Functions: [avg(something)])
```
First, the rule that reorders windows will reorder this as:
```
 *    WindowNode(Specification: A, Functions: [sum(something)])
 *      WindowNode(Specification: A, Functions: [avg(something)])
 *         WindowNode(Specification: B, Functions: [sum(something)])
```

Then the merge windows will merge it into a single window:
```
 *    WindowNode(Specification: A, Functions: [sum(something), avg(something)])
 *       WindowNode(Specification: B, Functions: [sum(something)])
```

I have implemented in this way in the spirit of keeping the rules simpler. We may have to re-think over whether this is the best approach.