### PR TITLE
Fix simba jdbc test

### DIFF
--- a/presto-product-tests/pom.xml
+++ b/presto-product-tests/pom.xml
@@ -109,6 +109,11 @@
             <artifactId>mysql-connector-java</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveCoercion.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveCoercion.java
@@ -52,7 +52,7 @@ import static java.sql.JDBCType.DOUBLE;
 import static java.sql.JDBCType.INTEGER;
 import static java.sql.JDBCType.LONGNVARCHAR;
 import static java.sql.JDBCType.SMALLINT;
-import static java.sql.JDBCType.VARBINARY;
+import static java.sql.JDBCType.VARCHAR;
 
 public class TestHiveCoercion
         extends ProductTest
@@ -292,7 +292,7 @@ public class TestHiveCoercion
                     INTEGER,
                     BIGINT,
                     BIGINT,
-                    VARBINARY,
+                    VARCHAR,
                     INTEGER,
                     DOUBLE,
                     BIGINT

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/jdbc/JdbcTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/jdbc/JdbcTests.java
@@ -245,9 +245,9 @@ public class JdbcTests
     public void testSessionProperties()
             throws SQLException
     {
-        final String propertyName = "join_distribution_type";
-        final String defaultValue = "repartitioned";
-        final String testValue = "replicated";
+        final String propertyName = "task_concurrency";
+        final String defaultValue = "16";
+        final String testValue = "32";
         assertThat(getSessionProperty(connection, propertyName)).isEqualTo(defaultValue);
         setSessionProperty(connection, propertyName, testValue);
         assertThat(getSessionProperty(connection, propertyName)).isEqualTo(testValue);

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/jdbc/JdbcTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/jdbc/JdbcTests.java
@@ -111,11 +111,16 @@ public class JdbcTests
     public void shouldExecuteQueryWithSelectedCatalogAndSchema()
             throws SQLException
     {
-        connection.setCatalog("hive");
-        connection.setSchema("default");
-        try (Statement statement = connection.createStatement()) {
-            QueryResult result = queryResult(statement, "select * from nation");
-            assertThat(result).matches(PRESTO_NATION_RESULT);
+        if (usingTeradataJdbc4Driver(connection)) {
+            LOGGER.warn("connection.setSchema() is not supported in JDBC 4");
+        }
+        else {
+            connection.setCatalog("hive");
+            connection.setSchema("default");
+            try (Statement statement = connection.createStatement()) {
+                QueryResult result = queryResult(statement, "select * from nation");
+                assertThat(result).matches(PRESTO_NATION_RESULT);
+            }
         }
     }
 

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/jdbc/JdbcTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/jdbc/JdbcTests.java
@@ -52,8 +52,6 @@ import static com.teradata.tempto.fulfillment.table.hive.tpch.TpchTableDefinitio
 import static com.teradata.tempto.internal.convention.SqlResultDescriptor.sqlResultDescriptorForResource;
 import static com.teradata.tempto.query.QueryExecutor.defaultQueryExecutor;
 import static com.teradata.tempto.query.QueryExecutor.query;
-import static java.lang.Boolean.FALSE;
-import static java.lang.Boolean.TRUE;
 import static java.util.Locale.CHINESE;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -247,13 +245,14 @@ public class JdbcTests
     public void testSessionProperties()
             throws SQLException
     {
-        final String distributedJoin = "distributed_join";
-
-        assertThat(getSessionProperty(connection, distributedJoin)).isEqualTo(TRUE.toString());
-        setSessionProperty(connection, distributedJoin, FALSE.toString());
-        assertThat(getSessionProperty(connection, distributedJoin)).isEqualTo(FALSE.toString());
-        resetSessionProperty(connection, distributedJoin);
-        assertThat(getSessionProperty(connection, distributedJoin)).isEqualTo(TRUE.toString());
+        final String propertyName = "join_distribution_type";
+        final String defaultValue = "repartitioned";
+        final String testValue = "replicated";
+        assertThat(getSessionProperty(connection, propertyName)).isEqualTo(defaultValue);
+        setSessionProperty(connection, propertyName, testValue);
+        assertThat(getSessionProperty(connection, propertyName)).isEqualTo(testValue);
+        resetSessionProperty(connection, propertyName);
+        assertThat(getSessionProperty(connection, propertyName)).isEqualTo(defaultValue);
     }
 
     private QueryResult queryResult(Statement statement, String query)

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/utils/JdbcDriverUtils.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/utils/JdbcDriverUtils.java
@@ -53,7 +53,7 @@ public class JdbcDriverUtils
         }
         else if (usingTeradataJdbcDriver(connection)) {
             try (Statement statement = connection.createStatement()) {
-                statement.execute(String.format("set session %s=%s", key, value));
+                statement.execute(String.format("set session %s='%s'", key, value));
             }
         }
         else {

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/utils/JdbcDriverUtils.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/utils/JdbcDriverUtils.java
@@ -14,6 +14,8 @@
 package com.facebook.presto.tests.utils;
 
 import com.facebook.presto.jdbc.PrestoConnection;
+import io.airlift.log.Logger;
+import org.apache.commons.lang3.StringUtils;
 
 import java.math.BigDecimal;
 import java.sql.Connection;
@@ -23,6 +25,8 @@ import java.sql.Statement;
 
 public class JdbcDriverUtils
 {
+    private static final Logger LOGGER = Logger.get(JdbcDriverUtils.class);
+
     public static String getSessionProperty(Connection connection, String key) throws SQLException
     {
         return getSessionProperty(connection, key, "Value");
@@ -57,13 +61,23 @@ public class JdbcDriverUtils
             return false;
         }
 
-        // Not particularly efficient, but for occasional use in
-        // setting session properties for tests, this should be OK.
+        if (StringUtils.isNumeric(value)) {
+            return false;
+        }
+
+        if (StringUtils.isAlphanumericSpace(value)) {
+            return true;
+        }
+
+        // Not particularly efficient, but it should be rare that we get here.
+        // For occasional use in setting session properties for tests, this should be OK.
         try {
             new BigDecimal(value);
             return false;
         }
-        catch (NumberFormatException e) { }
+        catch (NumberFormatException e) {
+            LOGGER.info("'%s' is not a number", value, e);
+        }
 
         return true;
     }

--- a/presto-product-tests/src/main/resources/com/facebook/presto/tests/jdbc/get_nation_columns_simba.result
+++ b/presto-product-tests/src/main/resources/com/facebook/presto/tests/jdbc/get_nation_columns_simba.result
@@ -1,5 +1,5 @@
 -- delimiter: |; ignoreOrder: false; ignoreExcessRows: false;
 hive|default|nation|n_nationkey|-5|bigint|19|8|0|10|1|null|null|null|null|null|1|YES|null|null|null|null|null|null|
-hive|default|nation|n_name|12|varchar|2048|2048|null|10|1|null|null|null|null|2048|2|YES|null|null|null|null|null|null|
+hive|default|nation|n_name|12|varchar(25)|25|25|null|10|1|null|null|null|null|2048|2|YES|null|null|null|null|null|null|
 hive|default|nation|n_regionkey|-5|bigint|19|8|0|10|1|null|null|null|null|null|3|YES|null|null|null|null|null|null|
-hive|default|nation|n_comment|12|varchar|2048|2048|null|10|1|null|null|null|null|2048|4|YES|null|null|null|null|null|null|
+hive|default|nation|n_comment|12|varchar(152)|152|152|null|10|1|null|null|null|null|2048|4|YES|null|null|null|null|null|null|

--- a/presto-product-tests/src/main/resources/com/facebook/presto/tests/jdbc/get_nation_columns_simba4.result
+++ b/presto-product-tests/src/main/resources/com/facebook/presto/tests/jdbc/get_nation_columns_simba4.result
@@ -1,5 +1,5 @@
 -- delimiter: |; ignoreOrder: false; ignoreExcessRows: false;
 hive|default|nation|n_nationkey|-5|bigint|19|8|0|10|1|null|null|null|null|null|1|YES|null|null|null|null|null|
-hive|default|nation|n_name|12|varchar|2048|2048|null|10|1|null|null|null|null|2048|2|YES|null|null|null|null|null|
+hive|default|nation|n_name|12|varchar(25)|25|25|null|10|1|null|null|null|null|2048|2|YES|null|null|null|null|null|
 hive|default|nation|n_regionkey|-5|bigint|19|8|0|10|1|null|null|null|null|null|3|YES|null|null|null|null|null|
-hive|default|nation|n_comment|12|varchar|2048|2048|null|10|1|null|null|null|null|2048|4|YES|null|null|null|null|null|
+hive|default|nation|n_comment|12|varchar(152)|152|152|null|10|1|null|null|null|null|2048|4|YES|null|null|null|null|null|


### PR DESCRIPTION
This PR is for 2977315 only.  The other commits have already been merged to sprint-48.

The new change is to exclude shouldExecuteQueryWithSelectedCatalogAndSchema()
when running with Simba's JDBC 4 driver.  This is necessary because the relevant JDBC method is not available in JDBC4, but is available in JDBC4.1 and JDBC4.2.