### PR TITLE
Remove dead application-runner containers

### DIFF
--- a/presto-product-tests/bin/run_on_docker.sh
+++ b/presto-product-tests/bin/run_on_docker.sh
@@ -83,6 +83,9 @@ function stop_application_runner_containers() {
     docker stop ${CONTAINER_NAME}
     echo "Container stopped: ${CONTAINER_NAME}"
   done
+  echo "Removing dead application-runner containers"
+  docker ps -aq --no-trunc --filter status=dead --filter status=exited --filter name=common_application-runner \
+  | xargs docker rm -v || true
 }
 
 function stop_all_containers() {


### PR DESCRIPTION
Multiple application-runner containers are created during product-tests
execution. Post successful execution of tests, these containers are no
longer needed and should be removed.