### PR TITLE
Fix HivePartitionManager's handling of empty TupleDomain

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionManager.java
@@ -160,20 +160,20 @@ public class HivePartitionManager
 
     private static TupleDomain<HiveColumnHandle> toCompactTupleDomain(TupleDomain<ColumnHandle> effectivePredicate, int threshold)
     {
-        checkArgument(effectivePredicate.getDomains().isPresent());
-
         ImmutableMap.Builder<HiveColumnHandle, Domain> builder = ImmutableMap.builder();
-        for (Map.Entry<ColumnHandle, Domain> entry : effectivePredicate.getDomains().get().entrySet()) {
-            HiveColumnHandle hiveColumnHandle = (HiveColumnHandle) entry.getKey();
+        effectivePredicate.getDomains().ifPresent(domains -> {
+            for (Map.Entry<ColumnHandle, Domain> entry : domains.entrySet()) {
+                HiveColumnHandle hiveColumnHandle = (HiveColumnHandle) entry.getKey();
 
-            ValueSet values = entry.getValue().getValues();
-            ValueSet compactValueSet = values.getValuesProcessor().<Optional<ValueSet>>transform(
-                    ranges -> ranges.getRangeCount() > threshold ? Optional.of(ValueSet.ofRanges(ranges.getSpan())) : Optional.empty(),
-                    discreteValues -> discreteValues.getValues().size() > threshold ? Optional.of(ValueSet.all(values.getType())) : Optional.empty(),
-                    allOrNone -> Optional.empty())
-                    .orElse(values);
-            builder.put(hiveColumnHandle, Domain.create(compactValueSet, entry.getValue().isNullAllowed()));
-        }
+                ValueSet values = entry.getValue().getValues();
+                ValueSet compactValueSet = values.getValuesProcessor().<Optional<ValueSet>>transform(
+                        ranges -> ranges.getRangeCount() > threshold ? Optional.of(ValueSet.ofRanges(ranges.getSpan())) : Optional.empty(),
+                        discreteValues -> discreteValues.getValues().size() > threshold ? Optional.of(ValueSet.all(values.getType())) : Optional.empty(),
+                        allOrNone -> Optional.empty())
+                        .orElse(values);
+                builder.put(hiveColumnHandle, Domain.create(compactValueSet, entry.getValue().isNullAllowed()));
+            }
+        });
         return TupleDomain.withColumnDomains(builder.build());
     }
 


### PR DESCRIPTION
This incorporates 32c5054b2a91f62bc770392c53e31fcdbcbebda8's fix onto release branch. Otherwise tpcds q54 fails (as long as it doesn't have constant padded with spaces -- https://github.td.teradata.com/center-for-hadoop/benchto-benchmarks/blob/ebd9c01696595fccb0e72fa621d172b7f3f58b9b/src/main/resources/sql/presto/tpcds/q54.sql#L26)