### PR TITLE
Don't execute shouldExecuteQueryWithSelectedCatalogAndSchema for JDBC 4

### DIFF
--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/jdbc/JdbcTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/jdbc/JdbcTests.java
@@ -113,6 +113,10 @@ public class JdbcTests
     public void shouldExecuteQueryWithSelectedCatalogAndSchema()
             throws SQLException
     {
+        if (usingTeradataJdbc4Driver(connection)) {
+            LOGGER.warn("shouldExecuteQueryWithSelectedCatalogAndSchema() does not apply to JDBC 4");
+            return;
+        }
         connection.setCatalog("hive");
         connection.setSchema("default");
         try (Statement statement = connection.createStatement()) {


### PR DESCRIPTION
These methods are not supported in the JDBC 4 API.