### PR TITLE
Close spill files as soon as they are read

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/util/PrestoIterators.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/PrestoIterators.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.util;
+
+import com.google.common.collect.AbstractIterator;
+
+import java.util.Iterator;
+
+import static java.util.Objects.requireNonNull;
+
+public class PrestoIterators
+{
+    private PrestoIterators()
+    {
+    }
+
+    public static <T> Iterator<T> closeWhenExhausted(Iterator<T> iterator, AutoCloseable resource)
+    {
+        requireNonNull(iterator, "iterator is null");
+        requireNonNull(resource, "resource is null");
+
+        return new AbstractIterator<T>()
+        {
+            @Override
+            protected T computeNext()
+            {
+                if (iterator.hasNext()) {
+                    return iterator.next();
+                }
+                else {
+                    try {
+                        resource.close();
+                    }
+                    catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                    return endOfData();
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
Close spill files as soon as they are read

So far, when spill files were read they were collected and then closed
all together. This commit changes that. Now they are closed as soon they
are read and no longer needed. Thanks to that there is no file
descriptors "temporary leak".
