### PR TITLE
Close spill files as soon as they are read

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/spiller/FileSingleStreamSpiller.java
+++ b/presto-main/src/main/java/com/facebook/presto/spiller/FileSingleStreamSpiller.java
@@ -20,6 +20,8 @@ import com.facebook.presto.memory.LocalMemoryContext;
 import com.facebook.presto.operator.SpillContext;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.util.PrestoCloseables;
+import com.facebook.presto.util.PrestoIterators;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Closer;
@@ -32,6 +34,7 @@ import io.airlift.slice.SliceOutput;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
+import java.io.Closeable;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -148,9 +151,10 @@ public class FileSingleStreamSpiller
         try {
             InputStream input = new FileInputStream(targetFileName.toFile());
             memoryContext.setBytes(BUFFER_SIZE);
-            closer.register(input);
-            closer.register(() -> memoryContext.setBytes(0));
-            return PagesSerdeUtil.readPages(serde, new InputStreamSliceInput(input, BUFFER_SIZE));
+            Closeable resources = PrestoCloseables.combine(input, () -> memoryContext.setBytes(0));
+            closer.register(resources);
+            Iterator<Page> pages = PagesSerdeUtil.readPages(serde, new InputStreamSliceInput(input, BUFFER_SIZE));
+            return PrestoIterators.closeWhenExhausted(pages, resources);
         }
         catch (IOException e) {
             throw new PrestoException(GENERIC_INTERNAL_ERROR, "Failed to read spilled pages", e);

--- a/presto-main/src/main/java/com/facebook/presto/util/PrestoCloseables.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/PrestoCloseables.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.util;
+
+import com.google.common.io.Closer;
+
+import java.io.Closeable;
+
+import static java.util.Objects.requireNonNull;
+
+public class PrestoCloseables
+{
+    private PrestoCloseables()
+    {
+    }
+
+    public static Closeable combine(Closeable first, Closeable second)
+    {
+        requireNonNull(first, "first is null");
+        requireNonNull(second, "second is null");
+
+        Closer closer = Closer.create();
+        closer.register(first);
+        closer.register(second);
+        return closer;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/util/PrestoIterators.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/PrestoIterators.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.util;
+
+import com.google.common.collect.AbstractIterator;
+
+import java.util.Iterator;
+
+import static java.util.Objects.requireNonNull;
+
+public class PrestoIterators
+{
+    private PrestoIterators()
+    {
+    }
+
+    public static <T> Iterator<T> closeWhenExhausted(Iterator<T> iterator, AutoCloseable resource)
+    {
+        requireNonNull(iterator, "iterator is null");
+        requireNonNull(resource, "resource is null");
+
+        return new AbstractIterator<T>()
+        {
+            @Override
+            protected T computeNext()
+            {
+                if (iterator.hasNext()) {
+                    return iterator.next();
+                }
+                else {
+                    try {
+                        resource.close();
+                    }
+                    catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                    return endOfData();
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
Close spill files as soon as they are read

So far, when spill files were read they were collected and then closed
all together. This commit changes that. Now they are closed as soon they
are read and no longer needed. Thanks to that there is no file
descriptors "temporary leak".
