### PR TITLE
Join reordering

### DIFF
--- a/presto-benchto-benchmarks/src/main/resources/benchmarks/presto/tpcds.yaml
+++ b/presto-benchto-benchmarks/src/main/resources/benchmarks/presto/tpcds.yaml
@@ -2,7 +2,7 @@ datasource: presto
 query-names: presto/tpcds/${query}.sql
 runs: 6
 prewarm-runs: 2
-before-execution: sleep-4s, presto/session_set_reorder_joins.sql
+before-execution: sleep-4s, presto/session_set_join_reordering_strategy.sql
 frequency: 7
 database: hive
 tpcds_small: tpcds_10gb_orc
@@ -12,22 +12,22 @@ variables:
   1:
     query: q01,q06,q14_1,q39_1,q39_2,q47,q57,q67,q81
     schema: ${tpcds_small}
-    reorder_joins: true, false
+    join_reordering_strategy: ELIMINATE_CROSS_JOINS, NONE
   2:
     query: q02,q03,q04,q05,q07,q09,q10,q11,q13,q14_2,q16,q17,q19,q22,q23_1,q23_2,q24_1,q24_2,q25,q28,q29,q30,q31,q32,q33,q35,q37,q38,q42,q43,q44,q46,q48,q49,q50,q51,q52,q53,q54,q55,q56,q58,q59,q60,q61,q63,q65,q66,q68,q69,q70,q71,q72,q74,q75,q77,q78,q80,q82,q88,q89,q94,q95
     schema: ${tpcds_medium}
-    reorder_joins: true, false
+    join_reordering_strategy: ELIMINATE_CROSS_JOINS, NONE
   3:
     # query not passing quick enough without reordering
     query: q18,q64
     schema: ${tpcds_medium}
-    reorder_joins: true
+    join_reordering_strategy: ELIMINATE_CROSS_JOINS
   4:
     query: q08,q12,q15,q20,q21,q26,q27,q34,q36,q40,q41,q45,q62,q73,q76,q79,q83,q84,q85,q86,q87,q90,q91,q92,q93,q96,q97,q98,q99
     schema: ${tpcds_large}
-    reorder_joins: true, false
+    join_reordering_strategy: ELIMINATE_CROSS_JOINS, NONE
   5:
     # extra runs with reordering on 1tb schema (too slow without reordering on 1tb). For 100g we keep both runs, with and without reordering
     query: q03,q37,q42,q43,q52,q53
     schema: ${tpcds_large}
-    reorder_joins: true
+    join_reordering_strategy: ELIMINATE_CROSS_JOIN

--- a/presto-benchto-benchmarks/src/main/resources/benchmarks/presto/tpch.yaml
+++ b/presto-benchto-benchmarks/src/main/resources/benchmarks/presto/tpch.yaml
@@ -2,7 +2,7 @@ datasource: presto
 query-names: presto/tpch/${query}.sql
 runs: 6
 prewarm-runs: 2
-before-execution: sleep-4s, presto/session_set_reorder_joins.sql
+before-execution: sleep-4s, presto/session_set_join_reordering_strategy.sql
 frequency: 7
 database: hive
 tpch_small: tpch_10gb_orc
@@ -14,28 +14,28 @@ variables:
     # queries too slow to run on 100gb without reordering
     query: q2, q8, q9
     schema: ${tpch_small}
-    reorder_joins: true, false
+    join_reordering_strategy: ELIMINATE_CROSS_JOINS, NONE
   2:
     # queries too slow to run on 100gb without reordering
     query: q8, q9
     schema: ${tpch_medium}
-    reorder_joins: true
+    join_reordering_strategy: ELIMINATE_CROSS_JOINS
   3:
     # queries too slow to run on 100gb without reordering
     query: q2
     schema: ${tpch_large}
-    reorder_joins: true
+    join_reordering_strategy: ELIMINATE_CROSS_JOINS
   4:
     # queries too slow to run on 1tb
     query: q3, q4, q5, q7, q17, q18, q21
     schema: ${tpch_medium}
-    reorder_joins: true, false
+    join_reordering_strategy: ELIMINATE_CROSS_JOINS, NONE
   5:
     query: q10, q11, q12, q13, q14, q15, q16, q19, q20, q22
     schema: ${tpch_large}
-    reorder_joins: true, false
+    join_reordering_strategy: ELIMINATE_CROSS_JOINS, NONE
   6:
     # queries without joins
     query: q1, q6
     schema: ${tpch_large}
-    reorder_joins: false
+    join_reordering_strategy: NONE

--- a/presto-benchto-benchmarks/src/main/resources/sql/presto/session_set_join_reordering_strategy.sql
+++ b/presto-benchto-benchmarks/src/main/resources/sql/presto/session_set_join_reordering_strategy.sql
@@ -1,0 +1,1 @@
+SET SESSION join_reordering_strategy='${join_reordering_strategy}'

--- a/presto-benchto-benchmarks/src/main/resources/sql/presto/session_set_reorder_joins.sql
+++ b/presto-benchto-benchmarks/src/main/resources/sql/presto/session_set_reorder_joins.sql
@@ -1,1 +1,0 @@
-SET SESSION reorder_joins='${reorder_joins}'

--- a/presto-cli/src/test/java/com/facebook/presto/cli/TestClientOptions.java
+++ b/presto-cli/src/test/java/com/facebook/presto/cli/TestClientOptions.java
@@ -143,27 +143,27 @@ public class TestClientOptions
         ClientSession session = options.toClientSession();
         SqlParser sqlParser = new SqlParser();
 
-        ImmutableMap<String, String> existingProperties = ImmutableMap.of("query_max_memory", "10GB", "distributed_join", "true");
+        ImmutableMap<String, String> existingProperties = ImmutableMap.of("query_max_memory", "10GB", "join_distribution_type", "repartitioned");
         ImmutableMap<String, String> preparedStatements = ImmutableMap.of("my_query", "select * from foo");
         session = Console.processSessionParameterChange(sqlParser.createStatement("USE test_catalog.test_schema"), session, existingProperties, preparedStatements);
         assertEquals(session.getCatalog(), "test_catalog");
         assertEquals(session.getSchema(), "test_schema");
         assertEquals(session.getProperties().get("query_max_memory"), "10GB");
-        assertEquals(session.getProperties().get("distributed_join"), "true");
+        assertEquals(session.getProperties().get("join_distribution_type"), "repartitioned");
         assertEquals(session.getPreparedStatements().get("my_query"), "select * from foo");
 
         session = Console.processSessionParameterChange(sqlParser.createStatement("USE test_schema_b"), session, existingProperties, preparedStatements);
         assertEquals(session.getCatalog(), "test_catalog");
         assertEquals(session.getSchema(), "test_schema_b");
         assertEquals(session.getProperties().get("query_max_memory"), "10GB");
-        assertEquals(session.getProperties().get("distributed_join"), "true");
+        assertEquals(session.getProperties().get("join_distribution_type"), "repartitioned");
         assertEquals(session.getPreparedStatements().get("my_query"), "select * from foo");
 
         session = Console.processSessionParameterChange(sqlParser.createStatement("USE test_catalog_2.test_schema"), session, existingProperties, preparedStatements);
         assertEquals(session.getCatalog(), "test_catalog_2");
         assertEquals(session.getSchema(), "test_schema");
         assertEquals(session.getProperties().get("query_max_memory"), "10GB");
-        assertEquals(session.getProperties().get("distributed_join"), "true");
+        assertEquals(session.getProperties().get("join_distribution_type"), "repartitioned");
         assertEquals(session.getPreparedStatements().get("my_query"), "select * from foo");
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadataFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadataFactory.java
@@ -169,6 +169,6 @@ public class HiveMetadataFactory
                 partitionUpdateCodec,
                 typeTranslator,
                 prestoVersion,
-                new MetastoreHiveStatisticsProvider(typeManager, metastore));
+                new MetastoreHiveStatisticsProvider(typeManager, metastore, timeZone));
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/statistics/MetastoreHiveStatisticsProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/statistics/MetastoreHiveStatisticsProvider.java
@@ -27,16 +27,27 @@ import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.predicate.NullableValue;
 import com.facebook.presto.spi.statistics.ColumnStatistics;
 import com.facebook.presto.spi.statistics.Estimate;
 import com.facebook.presto.spi.statistics.RangeColumnStatistics;
 import com.facebook.presto.spi.statistics.TableStatistics;
+import com.facebook.presto.spi.type.DecimalType;
+import com.facebook.presto.spi.type.Decimals;
+import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.joda.time.DateTimeZone;
 
 import javax.annotation.Nullable;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.LocalDate;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -50,7 +61,18 @@ import java.util.stream.Collectors;
 import java.util.stream.DoubleStream;
 
 import static com.facebook.presto.hive.HiveSessionProperties.isStatisticsEnabled;
+import static com.facebook.presto.spi.predicate.Utils.nativeValueToBlock;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.RealType.REAL;
+import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
+import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.Float.floatToRawIntBits;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
@@ -60,11 +82,13 @@ public class MetastoreHiveStatisticsProvider
 {
     private final TypeManager typeManager;
     private final SemiTransactionalHiveMetastore metastore;
+    private final DateTimeZone timeZone;
 
-    public MetastoreHiveStatisticsProvider(TypeManager typeManager, SemiTransactionalHiveMetastore metastore)
+    public MetastoreHiveStatisticsProvider(TypeManager typeManager, SemiTransactionalHiveMetastore metastore, DateTimeZone timeZone)
     {
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.metastore = requireNonNull(metastore, "metastore is null");
+        this.timeZone = timeZone;
     }
 
     @Override
@@ -86,21 +110,131 @@ public class MetastoreHiveStatisticsProvider
             }
             ColumnStatistics.Builder columnStatistics = ColumnStatistics.builder();
             RangeColumnStatistics.Builder rangeStatistics = RangeColumnStatistics.builder();
+
+            List<Object> lowValueCandidates = ImmutableList.of();
+            List<Object> highValueCandidates = ImmutableList.of();
+
+            Type prestoType = typeManager.getType(hiveColumnHandle.getTypeSignature());
             Estimate nullsFraction;
             if (hiveColumnHandle.isPartitionKey()) {
                 rangeStatistics.setDistinctValuesCount(countDistinctPartitionKeys(hiveColumnHandle, hivePartitions));
                 nullsFraction = calculateNullsFractionForPartitioningKey(hiveColumnHandle, hivePartitions, partitionStatistics);
+                if (isLowHighSupportedForType(prestoType)) {
+                    lowValueCandidates = hivePartitions.stream()
+                            .map(HivePartition::getKeys)
+                            .map(keys -> keys.get(hiveColumnHandle))
+                            .filter(value -> !value.isNull())
+                            .map(NullableValue::getValue)
+                            .collect(toImmutableList());
+                    highValueCandidates = lowValueCandidates;
+                }
             }
             else {
                 rangeStatistics.setDistinctValuesCount(calculateDistinctValuesCount(partitionStatistics, columnName));
                 nullsFraction = calculateNullsFraction(partitionStatistics, columnName, rowCount);
+
+                // TODO[lo] Maybe we do not want to expose high/low value if it is based on too small fraction of
+                //          partitions. And return unknown if most of the partitions we are working with do not have
+                //          statistics computed.
+
+                if (isLowHighSupportedForType(prestoType)) {
+                    lowValueCandidates = partitionStatistics.values().stream()
+                            .map(PartitionStatistics::getColumnStatistics)
+                            .filter(stats -> stats.containsKey(columnName))
+                            .map(stats -> stats.get(columnName))
+                            .map(HiveColumnStatistics::getLowValue)
+                            .filter(Optional::isPresent)
+                            .map(Optional::get)
+                            .map(value -> highLowValueAsPrestoType(value, prestoType))
+                            .collect(toImmutableList());
+
+                    highValueCandidates = partitionStatistics.values().stream()
+                            .map(PartitionStatistics::getColumnStatistics)
+                            .filter(stats -> stats.containsKey(columnName))
+                            .map(stats -> stats.get(columnName))
+                            .map(HiveColumnStatistics::getHighValue)
+                            .filter(Optional::isPresent)
+                            .map(Optional::get)
+                            .map(value -> highLowValueAsPrestoType(value, prestoType))
+                            .collect(toImmutableList());
+                }
             }
             columnStatistics.setNullsFraction(nullsFraction);
             rangeStatistics.setFraction(nullsFraction.map(value -> 1.0 - value));
+
+            Comparator<Object> comparator = (leftValue, rightValue) -> {
+                Block leftBlock = nativeValueToBlock(prestoType, leftValue);
+                Block rightBlock = nativeValueToBlock(prestoType, rightValue);
+                return prestoType.compareTo(leftBlock, 0, rightBlock, 0);
+            };
+            rangeStatistics.setLowValue(lowValueCandidates.stream().min(comparator));
+            rangeStatistics.setHighValue(highValueCandidates.stream().max(comparator));
+
             columnStatistics.addRange(rangeStatistics.build());
             tableStatistics.setColumnStatistics(hiveColumnHandle, columnStatistics.build());
         }
         return tableStatistics.build();
+    }
+
+    private boolean isLowHighSupportedForType(Type type)
+    {
+        if (type instanceof DecimalType) {
+            return true;
+        }
+        if (type.equals(TINYINT)
+                || type.equals(SMALLINT)
+                || type.equals(INTEGER)
+                || type.equals(BIGINT)
+                || type.equals(REAL)
+                || type.equals(DOUBLE)
+                || type.equals(DATE)
+                || type.equals(TIMESTAMP)) {
+            return true;
+        }
+        return false;
+    }
+
+    private Object highLowValueAsPrestoType(Object value, Type prestoType)
+    {
+        checkArgument(isLowHighSupportedForType(prestoType), "Unsupported type " + prestoType);
+        requireNonNull(value, "high/low value connot be null");
+
+        if (prestoType.equals(BIGINT)
+                || prestoType.equals(INTEGER)
+                || prestoType.equals(SMALLINT)
+                || prestoType.equals(TINYINT)) {
+            checkArgument(value instanceof Long, "expected Long value but got " + value.getClass());
+            return value;
+        }
+        else if (prestoType.equals(DOUBLE)) {
+            checkArgument(value instanceof Double, "expected Double value but got " + value.getClass());
+            return value;
+        }
+        else if (prestoType.equals(REAL)) {
+            checkArgument(value instanceof Double, "expected Double value but got " + value.getClass());
+            return floatToRawIntBits((float) (double) value);
+        }
+        else if (prestoType.equals(DATE)) {
+            checkArgument(value instanceof LocalDate, "expected LocalDate value but got " + value.getClass());
+            return ((LocalDate) value).toEpochDay();
+        }
+        else if (prestoType.equals(TIMESTAMP)) {
+            checkArgument(value instanceof Long, "expected Long value but got " + value.getClass());
+            return timeZone.convertLocalToUTC((long) value * 1000, false);
+        }
+        else if (prestoType instanceof DecimalType) {
+            checkArgument(value instanceof BigDecimal, "expected BigDecimal value but got " + value.getClass());
+            BigInteger unscaled = Decimals.rescale((BigDecimal) value, (DecimalType) prestoType).unscaledValue();
+            if (Decimals.isShortDecimal(prestoType)) {
+                return unscaled.longValueExact();
+            }
+            else {
+                return Decimals.encodeUnscaledValue(unscaled);
+            }
+        }
+        else {
+            throw new IllegalArgumentException("Unsupported presto type " + prestoType);
+        }
     }
 
     private Estimate calculateRowsCount(Map<String, PartitionStatistics> partitionStatistics)
@@ -175,6 +309,7 @@ public class MetastoreHiveStatisticsProvider
         }
         return new Estimate(totalNullsCount.getValue() / totalRowsCount.getValue());
     }
+
     private Estimate countDistinctPartitionKeys(HiveColumnHandle partitionColumn, List<HivePartition> partitions)
     {
         return new Estimate(partitions.stream()
@@ -204,6 +339,7 @@ public class MetastoreHiveStatisticsProvider
                 .sum();
         return new Estimate(estimatedNullsCount / estimatedTotalRowsCount);
     }
+
     private Estimate summarizePartitionStatistics(
             Collection<PartitionStatistics> partitionStatistics,
             String column,

--- a/presto-main/etc/config.properties
+++ b/presto-main/etc/config.properties
@@ -41,5 +41,4 @@ plugin.bundles=\
   ../presto-postgresql/pom.xml
 
 presto.version=testversion
-distributed-joins-enabled=true
 node-scheduler.include-coordinator=true

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -21,6 +21,7 @@ import com.facebook.presto.spi.StandardErrorCode;
 import com.facebook.presto.spi.session.PropertyMetadata;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType;
+import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStrategy;
 import com.google.common.collect.ImmutableList;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
@@ -61,7 +62,7 @@ public final class SystemSessionProperties
     public static final String DICTIONARY_AGGREGATION = "dictionary_aggregation";
     public static final String PLAN_WITH_TABLE_NODE_PARTITIONING = "plan_with_table_node_partitioning";
     public static final String COLOCATED_JOIN = "colocated_join";
-    public static final String REORDER_JOINS = "reorder_joins";
+    public static final String JOIN_REORDERING_STRATEGY = "join_reordering_strategy";
     public static final String INITIAL_SPLITS_PER_NODE = "initial_splits_per_node";
     public static final String SPLIT_CONCURRENCY_ADJUSTMENT_INTERVAL = "split_concurrency_adjustment_interval";
     public static final String OPTIMIZE_METADATA_QUERIES = "optimize_metadata_queries";
@@ -249,11 +250,18 @@ public final class SystemSessionProperties
                         "Experimental: Adapt plan to pre-partitioned tables",
                         true,
                         false),
-                booleanSessionProperty(
-                        REORDER_JOINS,
-                        "Experimental: Reorder joins to optimize plan",
-                        featuresConfig.isJoinReorderingEnabled(),
-                        false),
+                new PropertyMetadata<>(
+                        JOIN_REORDERING_STRATEGY,
+                        format("The join reordering strategy to use. Options are %s",
+                                Stream.of(JoinReorderingStrategy.values())
+                                        .map(FeaturesConfig.JoinReorderingStrategy::name)
+                                        .collect(joining(","))),
+                        VARCHAR,
+                        JoinReorderingStrategy.class,
+                        featuresConfig.getJoinReorderingStrategy(),
+                        false,
+                        value -> JoinReorderingStrategy.valueOf(((String) value).toUpperCase()),
+                        JoinReorderingStrategy::name),
                 booleanSessionProperty(
                         FAST_INEQUALITY_JOINS,
                         "Use faster handling of inequality join if it is possible",
@@ -426,9 +434,9 @@ public final class SystemSessionProperties
         return session.getSystemProperty(FAST_INEQUALITY_JOINS, Boolean.class);
     }
 
-    public static boolean isJoinReorderingEnabled(Session session)
+    public static JoinReorderingStrategy getJoinReorderingStrategy(Session session)
     {
-        return session.getSystemProperty(REORDER_JOINS, Boolean.class);
+        return session.getSystemProperty(JOIN_REORDERING_STRATEGY, JoinReorderingStrategy.class);
     }
 
     public static boolean isColocatedJoinEnabled(Session session)

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.StandardErrorCode;
 import com.facebook.presto.spi.session.PropertyMetadata;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType;
 import com.google.common.collect.ImmutableList;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
@@ -27,6 +28,7 @@ import io.airlift.units.Duration;
 import javax.inject.Inject;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 import static com.facebook.presto.spi.session.PropertyMetadata.booleanSessionProperty;
 import static com.facebook.presto.spi.session.PropertyMetadata.integerSessionProperty;
@@ -37,11 +39,12 @@ import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.units.DataSize.succinctBytes;
 import static java.lang.String.format;
+import static java.util.stream.Collectors.joining;
 
 public final class SystemSessionProperties
 {
     public static final String OPTIMIZE_HASH_GENERATION = "optimize_hash_generation";
-    public static final String DISTRIBUTED_JOIN = "distributed_join";
+    public static final String JOIN_DISTRIBUTION_TYPE = "join_distribution_type";
     public static final String DISTRIBUTED_INDEX_JOIN = "distributed_index_join";
     public static final String HASH_PARTITION_COUNT = "hash_partition_count";
     public static final String PREFER_STREAMING_OPERATORS = "prefer_streaming_operators";
@@ -100,11 +103,18 @@ public final class SystemSessionProperties
                         "Compute hash codes for distribution, joins, and aggregations early in query plan",
                         featuresConfig.isOptimizeHashGeneration(),
                         false),
-                booleanSessionProperty(
-                        DISTRIBUTED_JOIN,
-                        "Use a distributed join instead of a broadcast join",
-                        featuresConfig.isDistributedJoinsEnabled(),
-                        false),
+                new PropertyMetadata<>(
+                        JOIN_DISTRIBUTION_TYPE,
+                        format("The join method to use. Options are %s",
+                                Stream.of(JoinDistributionType.values())
+                                        .map(FeaturesConfig.JoinDistributionType::name)
+                                        .collect(joining(","))),
+                        VARCHAR,
+                        JoinDistributionType.class,
+                        featuresConfig.getJoinDistributionType(),
+                        false,
+                        value -> JoinDistributionType.valueOf(((String) value).toUpperCase()),
+                        JoinDistributionType::name),
                 booleanSessionProperty(
                         DISTRIBUTED_INDEX_JOIN,
                         "Distribute index joins on join keys instead of executing inline",
@@ -341,11 +351,6 @@ public final class SystemSessionProperties
         return session.getSystemProperty(OPTIMIZE_HASH_GENERATION, Boolean.class);
     }
 
-    public static boolean isDistributedJoinEnabled(Session session)
-    {
-        return session.getSystemProperty(DISTRIBUTED_JOIN, Boolean.class);
-    }
-
     public static boolean isDistributedIndexJoinEnabled(Session session)
     {
         return session.getSystemProperty(DISTRIBUTED_INDEX_JOIN, Boolean.class);
@@ -503,5 +508,10 @@ public final class SystemSessionProperties
     public static boolean isPushAggregationThroughJoin(Session session)
     {
         return session.getSystemProperty(PUSH_PARTIAL_AGGREGATION_THROUGH_JOIN, Boolean.class);
+    }
+
+    public static JoinDistributionType getJoinDistributionType(Session session)
+    {
+        return session.getSystemProperty(JOIN_DISTRIBUTION_TYPE, JoinDistributionType.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/cost/ComposableStatsCalculator.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/ComposableStatsCalculator.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cost;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.PlanVisitor;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class ComposableStatsCalculator
+        implements StatsCalculator
+{
+    private final List<Rule> rules;
+
+    public ComposableStatsCalculator(List<Rule> rules)
+    {
+        this.rules = ImmutableList.copyOf(rules);
+    }
+
+    @Override
+    public PlanNodeStatsEstimate calculateStats(PlanNode planNode, Lookup lookup, Session session, Map<Symbol, Type> types)
+    {
+        Visitor visitor = new Visitor(lookup, session, types);
+        return planNode.accept(visitor, null);
+    }
+
+    public interface Rule
+    {
+        Optional<PlanNodeStatsEstimate> calculate(PlanNode node, Lookup lookup, Session session, Map<Symbol, Type> types);
+    }
+
+    private class Visitor
+            extends PlanVisitor<PlanNodeStatsEstimate, Void>
+    {
+        private final Lookup lookup;
+        private final Session session;
+        private final Map<Symbol, Type> types;
+
+        public Visitor(Lookup lookup, Session session, Map<Symbol, Type> types)
+        {
+            this.lookup = lookup;
+            this.session = session;
+            this.types = ImmutableMap.copyOf(types);
+        }
+
+        @Override
+        protected PlanNodeStatsEstimate visitPlan(PlanNode node, Void context)
+        {
+            for (Rule rule : rules) {
+                Optional<PlanNodeStatsEstimate> calculatedStats = rule.calculate(node, lookup, session, types);
+                if (calculatedStats.isPresent()) {
+                    return calculatedStats.get();
+                }
+            }
+            return PlanNodeStatsEstimate.UNKNOWN_STATS;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/cost/EnforceSingleRowStatsRule.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/EnforceSingleRowStatsRule.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cost;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.plan.EnforceSingleRowNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class EnforceSingleRowStatsRule
+        implements ComposableStatsCalculator.Rule
+{
+    @Override
+    public Optional<PlanNodeStatsEstimate> calculate(PlanNode node, Lookup lookup, Session session, Map<Symbol, Type> types)
+    {
+        if (!(node instanceof EnforceSingleRowNode)) {
+            return Optional.empty();
+        }
+        return Optional.of(
+                PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(1)
+                        .build());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/cost/ExchangeStatsRule.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/ExchangeStatsRule.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cost;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.plan.ExchangeNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+// WIP
+public class ExchangeStatsRule
+        implements ComposableStatsCalculator.Rule
+{
+    @Override
+    public Optional<PlanNodeStatsEstimate> calculate(PlanNode node, Lookup lookup, Session session, Map<Symbol, Type> types)
+    {
+        if (!(node instanceof ExchangeNode)) {
+            return Optional.empty();
+        }
+        ExchangeNode exchangeNode = (ExchangeNode) node;
+
+        if (exchangeNode.getSources().size() > 1) {
+            return Optional.of(PlanNodeStatsEstimate.UNKNOWN_STATS);
+        }
+
+        PlanNode source = exchangeNode.getSources().get(0);
+        PlanNodeStatsEstimate sourceStats = lookup.getStats(source, session, types);
+        List<Symbol> sourceSymbols = exchangeNode.getInputs().get(0);
+
+        PlanNodeStatsEstimate.Builder outputStats = PlanNodeStatsEstimate.builder();
+        outputStats.setOutputRowCount(sourceStats.getOutputRowCount());
+        for (int symbolIndex = 0; symbolIndex < sourceSymbols.size(); ++symbolIndex) {
+            Symbol sourceSymbol = sourceSymbols.get(symbolIndex);
+            Symbol outputSymbol = exchangeNode.getOutputSymbols().get(symbolIndex);
+            outputStats.addSymbolStatistics(outputSymbol, sourceStats.getSymbolStatistics(sourceSymbol));
+        }
+        return Optional.of(outputStats.build());
+    }
+
+    /*
+        // we do not replicate logic for rows replication here as stats
+        // are used mostly in phase where exchanges are not in plan anyway
+        List<Symbol> outputSymbols = exchangeNode.getOutputSymbols();
+        Map<Symbol, ColumnStatistics> resultSymbolStatistics = new HashMap<>();
+        Estimate resultOutputRowCount = Estimate.zeroValue();
+        for (int sourceIndex = 0; sourceIndex < exchangeNode.getSources().size(); ++sourceIndex) {
+            PlanNode source = exchangeNode.getSources().get(sourceIndex);
+            PlanNodeStatsEstimate sourceStats = lookup.getStats(source, session, types);
+            for (int outputIndex = 0; outputIndex < outputSymbols.size(); outputIndex++) {
+                Symbol outputSymbol = exchangeNode.getOutputSymbols().get(outputIndex);
+                Symbol sourceSymbol = exchangeNode.getInputs().get(sourceIndex).get(outputIndex);
+
+                Optional<ColumnStatistics> outputSymbolStatistics = Optional.ofNullable(resultSymbolStatistics.get(outputSymbol));
+                ColumnStatistics sourceSymbolStatistics = sourceStats.getSymbolStatistics(sourceSymbol);
+                if (outputSymbolStatistics.isPresent()) {
+                    resultSymbolStatistics.put(outputSymbol, mergeSymbolStatistics(outputSymbolStatistics.get(), sourceSymbolStatistics));
+                }
+                else {
+                    resultSymbolStatistics.put(outputSymbol, sourceSymbolStatistics);
+                }
+            }
+            resultOutputRowCount = resultOutputRowCount.add(sourceStats.getOutputRowCount());
+        }
+
+        return Optional.of(PlanNodeStatsEstimate.builder()
+                .setOutputRowCount(resultOutputRowCount)
+                .setSymbolStatistics(resultSymbolStatistics)
+                .build());
+    }
+
+    private ColumnStatistics mergeSymbolStatistics(ColumnStatistics left, ColumnStatistics right)
+    {
+        return ColumnStatistics.builder()
+                .setNullsFraction(left.getNullsFraction().add(right.getNullsFraction()))
+                .addRange(mergeRange(left.getOnlyRangeColumnStatistics(), right.getOnlyRangeColumnStatistics()))
+                .build();
+    }
+
+    private RangeColumnStatistics mergeRange(RangeColumnStatistics left, RangeColumnStatistics right)
+    {
+        return RangeColumnStatistics.builder()
+                .set
+    }
+    */
+}

--- a/presto-main/src/main/java/com/facebook/presto/cost/FilterStatsCalculator.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/FilterStatsCalculator.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cost;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.LiteralInterpreter;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.tree.AstVisitor;
+import com.facebook.presto.sql.tree.BooleanLiteral;
+import com.facebook.presto.sql.tree.ComparisonExpression;
+import com.facebook.presto.sql.tree.ComparisonExpressionType;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.Literal;
+import com.facebook.presto.sql.tree.SymbolReference;
+
+import javax.inject.Inject;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalDouble;
+
+import static java.lang.Double.NEGATIVE_INFINITY;
+import static java.lang.Double.POSITIVE_INFINITY;
+import static java.lang.Double.isNaN;
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+
+public class FilterStatsCalculator
+{
+    private final Metadata metadata;
+
+    @Inject
+    public FilterStatsCalculator(Metadata metadata)
+    {
+        this.metadata = metadata;
+    }
+
+    public PlanNodeStatsEstimate filterStats(
+            PlanNodeStatsEstimate statsEstimate,
+            Expression predicate,
+            Session session,
+            Map<Symbol, Type> types)
+    {
+        return new FilterExpressionStatsCalculatingVisitor(statsEstimate, session, types).process(predicate);
+    }
+
+    private class FilterExpressionStatsCalculatingVisitor
+            extends AstVisitor<PlanNodeStatsEstimate, Void>
+    {
+        private final PlanNodeStatsEstimate input;
+        private final Session session;
+        private final Map<Symbol, Type> types;
+
+        FilterExpressionStatsCalculatingVisitor(PlanNodeStatsEstimate input, Session session, Map<Symbol, Type> types)
+        {
+            this.input = input;
+            this.session = session;
+            this.types = types;
+        }
+
+        @Override
+        protected PlanNodeStatsEstimate visitExpression(Expression node, Void context)
+        {
+            return filterForUnknownExpression();
+        }
+
+        private PlanNodeStatsEstimate filterForUnknownExpression()
+        {
+            return filterStatsByFactor(0.5);
+        }
+
+        @Override
+        protected PlanNodeStatsEstimate visitComparisonExpression(ComparisonExpression node, Void context)
+        {
+            // FIXME left and right might not be exactly SymbolReference and Literal
+            if (node.getLeft() instanceof SymbolReference && node.getRight() instanceof SymbolReference) {
+                return comparisonSymbolToSymbolStats(
+                        Symbol.from(node.getLeft()),
+                        Symbol.from(node.getRight()),
+                        node.getType()
+                );
+            }
+            else if (node.getLeft() instanceof SymbolReference && node.getRight() instanceof Literal) {
+                return comparisonSymbolToLiteralStats(
+                        Symbol.from(node.getLeft()),
+                        (Literal) node.getRight(),
+                        node.getType()
+                );
+            }
+            else if (node.getLeft() instanceof Literal && node.getRight() instanceof SymbolReference) {
+                return comparisonSymbolToLiteralStats(
+                        Symbol.from(node.getRight()),
+                        (Literal) node.getLeft(),
+                        node.getType().flip()
+                );
+            }
+            else {
+                return filterForUnknownExpression();
+            }
+        }
+
+        @Override
+        protected PlanNodeStatsEstimate visitBooleanLiteral(BooleanLiteral node, Void context)
+        {
+            if (node.getValue()) {
+                return input;
+            }
+            else {
+                return filterStatsByFactor(0.0);
+            }
+        }
+
+        private PlanNodeStatsEstimate comparisonSymbolToLiteralStats(Symbol symbol, Literal literal, ComparisonExpressionType type)
+        {
+            Object literalValue = LiteralInterpreter.evaluate(metadata, session.toConnectorSession(), literal);
+            TypeStatOperatorCaller operatorCaller = new TypeStatOperatorCaller(types.get(symbol), metadata.getFunctionRegistry(), session.toConnectorSession());
+            OptionalDouble doubleLiteral = operatorCaller.translateToDouble(literalValue);
+            if (doubleLiteral.isPresent()) {
+                switch (type) {
+                    case EQUAL:
+                        return symbolToLiteralEquality(symbol, doubleLiteral.getAsDouble());
+                    case NOT_EQUAL:
+                        return symbolToLiteralNonEquality(symbol, doubleLiteral.getAsDouble());
+                    case LESS_THAN:
+                    case LESS_THAN_OR_EQUAL:
+                        return symbolToLiteralLessThan(symbol, doubleLiteral.getAsDouble());
+                    case GREATER_THAN:
+                    case GREATER_THAN_OR_EQUAL:
+                        return symbolToLiteralGreaterThan(symbol, doubleLiteral.getAsDouble());
+                    case IS_DISTINCT_FROM:
+                        break;
+                }
+            }
+            return filterForUnknownExpression();
+        }
+
+        private PlanNodeStatsEstimate symbolToLiteralGreaterThan(Symbol symbol, double literal)
+        {
+            SymbolStatsEstimate symbolStats = input.getSymbolStatistics().get(symbol);
+
+            SimplifiedHistogramStats histogram = SimplifiedHistogramStats.of(symbolStats);
+            SimplifiedHistogramStats newStats = histogram.intersect(new StatsHistogramRange(literal, POSITIVE_INFINITY, Optional.empty()));
+            double filtered = newStats.getFilteredPercent();
+            return filterStatsByFactor(filtered).mapSymbolColumnStatistics(symbol, x -> newStats.toSymbolsStatistics());
+        }
+
+        private PlanNodeStatsEstimate symbolToLiteralLessThan(Symbol symbol, double literal)
+        {
+            SymbolStatsEstimate symbolStats = input.getSymbolStatistics().get(symbol);
+
+            SimplifiedHistogramStats histogram = SimplifiedHistogramStats.of(symbolStats);
+            SimplifiedHistogramStats newStats = histogram.intersect(new StatsHistogramRange(NEGATIVE_INFINITY, literal, Optional.empty()));
+            double filtered = newStats.getFilteredPercent();
+            return filterStatsByFactor(filtered).mapSymbolColumnStatistics(symbol, x -> newStats.toSymbolsStatistics());
+        }
+
+        private PlanNodeStatsEstimate symbolToLiteralNonEquality(Symbol symbol, double literal)
+        {
+            SymbolStatsEstimate symbolStats = input.getSymbolStatistics().get(symbol);
+
+            SimplifiedHistogramStats histogram = SimplifiedHistogramStats.of(symbolStats);
+            SimplifiedHistogramStats intersectStats = histogram.intersect(new StatsHistogramRange(literal, literal, Optional.empty()));
+            double filtered = 1.0 - intersectStats.getFilteredPercent();
+            return filterStatsByFactor(filtered)
+                    .mapSymbolColumnStatistics(symbol,
+                            stats -> SymbolStatsEstimate.buildFrom(stats)
+                                    .setNullsFraction(0)
+                                    .setDataSize(stats.getDataSize() * filtered)
+                                    .setDistinctValuesCount(stats.getDistinctValuesCount() - 1)
+                                    .build());
+        }
+
+        private PlanNodeStatsEstimate symbolToLiteralEquality(Symbol symbol, double literal)
+        {
+            SymbolStatsEstimate symbolStats = input.getSymbolStatistics().get(symbol);
+
+            SimplifiedHistogramStats histogram = SimplifiedHistogramStats.of(symbolStats);
+            SimplifiedHistogramStats newStats = histogram.intersect(new StatsHistogramRange(literal, literal, Optional.empty()));
+            double filtered = newStats.getFilteredPercent();
+            return filterStatsByFactor(filtered).mapSymbolColumnStatistics(symbol, x -> newStats.toSymbolsStatistics());
+        }
+
+        private PlanNodeStatsEstimate filterStatsByFactor(double filterRate)
+        {
+            return input
+                    .mapOutputRowCount(size -> size * filterRate);
+        }
+
+        private PlanNodeStatsEstimate comparisonSymbolToSymbolStats(Symbol left, Symbol right, ComparisonExpressionType type)
+        {
+            switch (type) {
+                case EQUAL:
+                    return symbolToSymbolEquality(left, right);
+                case NOT_EQUAL:
+                case LESS_THAN:
+                case LESS_THAN_OR_EQUAL:
+                case GREATER_THAN:
+                case GREATER_THAN_OR_EQUAL:
+                case IS_DISTINCT_FROM:
+            }
+            return filterStatsByFactor(0.5); //fixme
+        }
+
+        private PlanNodeStatsEstimate symbolToSymbolEquality(Symbol left, Symbol right)
+        {
+            SymbolStatsEstimate leftStats = input.getSymbolStatistics().get(left);
+            SymbolStatsEstimate rightStats = input.getSymbolStatistics().get(right);
+
+            if (isNaN(leftStats.getDistinctValuesCount()) || isNaN(rightStats.getDistinctValuesCount())) {
+                return filterStatsByFactor(0.5); //fixme
+            }
+
+            double maxDistinctValues = max(leftStats.getDistinctValuesCount(), rightStats.getDistinctValuesCount());
+            double minDistinctValues = min(leftStats.getDistinctValuesCount(), rightStats.getDistinctValuesCount());
+
+            double filterRate = 1 / maxDistinctValues * (1 - leftStats.getNullsFraction()) * (1 - rightStats.getNullsFraction());
+
+            SymbolStatsEstimate newRightStats = SymbolStatsEstimate.buildFrom(rightStats)
+                    .setNullsFraction(0)
+                    .setDistinctValuesCount(minDistinctValues)
+                    .build();
+            SymbolStatsEstimate newLeftStats = SymbolStatsEstimate.buildFrom(leftStats)
+                    .setNullsFraction(0)
+                    .setDistinctValuesCount(minDistinctValues)
+                    .build();
+
+            return filterStatsByFactor(filterRate)
+                    .mapSymbolColumnStatistics(left, x -> newLeftStats)
+                    .mapSymbolColumnStatistics(right, x -> newRightStats);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/cost/FilterStatsRule.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/FilterStatsRule.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cost;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.plan.FilterNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class FilterStatsRule
+        implements ComposableStatsCalculator.Rule
+{
+    private final FilterStatsCalculator filterStatsCalculator;
+
+    public FilterStatsRule(FilterStatsCalculator filterStatsCalculator)
+    {
+        this.filterStatsCalculator = filterStatsCalculator;
+    }
+
+    @Override
+    public Optional<PlanNodeStatsEstimate> calculate(PlanNode node, Lookup lookup, Session session, Map<Symbol, Type> types)
+    {
+        if (!(node instanceof FilterNode)) {
+            return Optional.empty();
+        }
+        FilterNode filterNode = (FilterNode) node;
+        PlanNodeStatsEstimate sourceStats = lookup.getStats(filterNode.getSource(), session, types);
+        return Optional.of(filterStatsCalculator.filterStats(sourceStats, filterNode.getPredicate(), session, types));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/cost/JoinStatsRule.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/JoinStatsRule.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cost;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.tree.ComparisonExpression;
+import com.facebook.presto.sql.tree.Expression;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.sql.ExpressionUtils.combineConjuncts;
+import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
+import static com.facebook.presto.sql.tree.ComparisonExpressionType.EQUAL;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+public class JoinStatsRule
+        implements ComposableStatsCalculator.Rule
+{
+    private final FilterStatsCalculator filterStatsCalculator;
+
+    public JoinStatsRule(FilterStatsCalculator filterStatsCalculator)
+    {
+        this.filterStatsCalculator = filterStatsCalculator;
+    }
+
+    @Override
+    public Optional<PlanNodeStatsEstimate> calculate(PlanNode node, Lookup lookup, Session session, Map<Symbol, Type> types)
+    {
+        if (!(node instanceof JoinNode)) {
+            return Optional.empty();
+        }
+        JoinNode joinNode = (JoinNode) node;
+
+        PlanNodeStatsEstimate leftStats = lookup.getStats(joinNode.getLeft(), session, types);
+        PlanNodeStatsEstimate rightStats = lookup.getStats(joinNode.getRight(), session, types);
+
+        List<Expression> comparisons = joinNode.getCriteria().stream()
+                .map(criteria -> new ComparisonExpression(EQUAL, criteria.getLeft().toSymbolReference(), criteria.getRight().toSymbolReference()))
+                .collect(toImmutableList());
+
+        PlanNodeStatsEstimate mergedInputCosts = crossJoinStats(leftStats, rightStats);
+        Expression predicate = combineConjuncts(combineConjuncts(comparisons), joinNode.getFilter().orElse(TRUE_LITERAL));
+        return Optional.of(filterStatsCalculator.filterStats(mergedInputCosts, predicate, session, types));
+    }
+
+    private PlanNodeStatsEstimate crossJoinStats(PlanNodeStatsEstimate left, PlanNodeStatsEstimate right)
+    {
+        ImmutableMap.Builder<Symbol, SymbolStatsEstimate> symbolsStatsBuilder = ImmutableMap.builder();
+        symbolsStatsBuilder.putAll(left.getSymbolStatistics()).putAll(right.getSymbolStatistics());
+
+        PlanNodeStatsEstimate.Builder statsBuilder = PlanNodeStatsEstimate.builder();
+        return statsBuilder.setSymbolStatistics(symbolsStatsBuilder.build())
+                .setOutputRowCount(left.getOutputRowCount() * right.getOutputRowCount())
+                .build();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/cost/LimitStatsRule.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/LimitStatsRule.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cost;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.plan.LimitNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class LimitStatsRule
+        implements ComposableStatsCalculator.Rule
+{
+    @Override
+    public Optional<PlanNodeStatsEstimate> calculate(PlanNode node, Lookup lookup, Session session, Map<Symbol, Type> types)
+    {
+        if (!(node instanceof LimitNode)) {
+            return Optional.empty();
+        }
+        LimitNode limitNode = (LimitNode) node;
+
+        PlanNodeStatsEstimate sourceStats = lookup.getStats(limitNode.getSource(), session, types);
+        PlanNodeStatsEstimate.Builder limitCost = PlanNodeStatsEstimate.builder();
+        // TODO special handling for NaN?
+        if (sourceStats.getOutputRowCount() < limitNode.getCount()) {
+            limitCost.setOutputRowCount(sourceStats.getOutputRowCount());
+        }
+        else {
+            limitCost.setOutputRowCount(limitNode.getCount());
+        }
+        return Optional.of(limitCost.build());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/cost/OutputStatsRule.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/OutputStatsRule.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cost;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.plan.OutputNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class OutputStatsRule
+        implements ComposableStatsCalculator.Rule
+{
+    @Override
+    public Optional<PlanNodeStatsEstimate> calculate(PlanNode node, Lookup lookup, Session session, Map<Symbol, Type> types)
+    {
+        if (!(node instanceof OutputNode)) {
+            return Optional.empty();
+        }
+        OutputNode outputNode = (OutputNode) node;
+        return Optional.of(lookup.getStats(outputNode.getSource(), session, types));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/cost/PlanNodeStatsEstimate.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/PlanNodeStatsEstimate.java
@@ -84,6 +84,18 @@ public class PlanNodeStatsEstimate
                 .build();
     }
 
+    public PlanNodeStatsEstimate add(PlanNodeStatsEstimate other)
+    {
+        // TODO this is broken (it does not operate on symbol stats at all). Remove or fix
+        ImmutableMap.Builder<Symbol, SymbolStatsEstimate> symbolsStatsBuilder = ImmutableMap.builder();
+        symbolsStatsBuilder.putAll(getSymbolStatistics()).putAll(other.getSymbolStatistics()); // This may not count all information
+
+        PlanNodeStatsEstimate.Builder statsBuilder = PlanNodeStatsEstimate.builder();
+        return statsBuilder.setSymbolStatistics(symbolsStatsBuilder.build())
+                .setOutputRowCount(getOutputRowCount() + other.getOutputRowCount())
+                .build();
+    }
+
     public SymbolStatsEstimate getSymbolStatistics(Symbol symbol)
     {
         return symbolStatistics.getOrDefault(symbol, SymbolStatsEstimate.UNKNOWN_STATS);

--- a/presto-main/src/main/java/com/facebook/presto/cost/PlanNodeStatsEstimate.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/PlanNodeStatsEstimate.java
@@ -13,9 +13,16 @@
  */
 package com.facebook.presto.cost;
 
+import com.facebook.presto.sql.planner.Symbol;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.lang.Double.NaN;
 import static java.lang.Double.isNaN;
 
@@ -26,11 +33,13 @@ public class PlanNodeStatsEstimate
 
     private final double outputRowCount;
     private final double outputSizeInBytes;
+    private final Map<Symbol, SymbolStatsEstimate> symbolStatistics;
 
-    private PlanNodeStatsEstimate(double outputRowCount, double outputSizeInBytes)
+    private PlanNodeStatsEstimate(double outputRowCount, double outputSizeInBytes, Map<Symbol, SymbolStatsEstimate> symbolStatistics)
     {
         this.outputRowCount = outputRowCount;
         this.outputSizeInBytes = outputSizeInBytes;
+        this.symbolStatistics = ImmutableMap.copyOf(symbolStatistics);
     }
 
     public double getOutputRowCount()
@@ -53,10 +62,39 @@ public class PlanNodeStatsEstimate
         return buildFrom(this).setOutputSizeInBytes(mappingFunction.apply(outputRowCount)).build();
     }
 
+    public PlanNodeStatsEstimate mapSymbolColumnStatistics(Symbol symbol, Function<SymbolStatsEstimate, SymbolStatsEstimate> mappingFunction)
+    {
+        return buildFrom(this)
+                .setSymbolStatistics(symbolStatistics.entrySet().stream()
+                        .collect(Collectors.toMap(
+                                Map.Entry::getKey,
+                                e -> {
+                                    if (e.getKey().equals(symbol)) {
+                                        return mappingFunction.apply(e.getValue());
+                                    }
+                                    return e.getValue();
+                                })))
+                .build();
+    }
+
+    public SymbolStatsEstimate getSymbolStatistics(Symbol symbol)
+    {
+        return symbolStatistics.getOrDefault(symbol, SymbolStatsEstimate.UNKNOWN_STATS);
+    }
+
+    public Map<Symbol, SymbolStatsEstimate> getSymbolStatistics()
+    {
+        return symbolStatistics;
+    }
+
     @Override
     public String toString()
     {
-        return "PlanNodeStatsEstimate{outputRowCount=" + outputRowCount + ", outputSizeInBytes=" + outputSizeInBytes + '}';
+        return toStringHelper(this)
+                .add("outputRowCount", outputRowCount)
+                .add("outputSizeInBytes", outputSizeInBytes)
+                .add("symbolStatistics", symbolStatistics)
+                .toString();
     }
 
     @Override
@@ -69,14 +107,15 @@ public class PlanNodeStatsEstimate
             return false;
         }
         PlanNodeStatsEstimate that = (PlanNodeStatsEstimate) o;
-        return Objects.equals(outputRowCount, that.outputRowCount) &&
-                Objects.equals(outputSizeInBytes, that.outputSizeInBytes);
+        return Double.compare(that.outputRowCount, outputRowCount) == 0 &&
+                Double.compare(that.outputSizeInBytes, outputSizeInBytes) == 0 &&
+                Objects.equals(symbolStatistics, that.symbolStatistics);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(outputRowCount, outputSizeInBytes);
+        return Objects.hash(outputRowCount, outputSizeInBytes, symbolStatistics);
     }
 
     public static Builder builder()
@@ -87,13 +126,15 @@ public class PlanNodeStatsEstimate
     public static Builder buildFrom(PlanNodeStatsEstimate other)
     {
         return builder().setOutputRowCount(other.getOutputRowCount())
-                .setOutputSizeInBytes(other.getOutputSizeInBytes());
+                .setOutputSizeInBytes(other.getOutputSizeInBytes())
+                .setSymbolStatistics(other.getSymbolStatistics());
     }
 
     public static final class Builder
     {
         private double outputRowCount = NaN;
         private double outputSizeInBytes = NaN;
+        private Map<Symbol, SymbolStatsEstimate> symbolStatistics = new HashMap<>();
 
         public Builder setOutputRowCount(double outputRowCount)
         {
@@ -107,12 +148,24 @@ public class PlanNodeStatsEstimate
             return this;
         }
 
+        public Builder setSymbolStatistics(Map<Symbol, SymbolStatsEstimate> symbolStatistics)
+        {
+            this.symbolStatistics = new HashMap<>(symbolStatistics);
+            return this;
+        }
+
+        public Builder addSymbolStatistics(Symbol symbol, SymbolStatsEstimate statistics)
+        {
+            this.symbolStatistics.put(symbol, statistics);
+            return this;
+        }
+
         public PlanNodeStatsEstimate build()
         {
             if (isNaN(outputSizeInBytes) && !isNaN(outputRowCount)) {
                 outputSizeInBytes = DEFAULT_ROW_SIZE * outputRowCount;
             }
-            return new PlanNodeStatsEstimate(outputRowCount, outputSizeInBytes);
+            return new PlanNodeStatsEstimate(outputRowCount, outputSizeInBytes, symbolStatistics);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/cost/ProjectStatsRule.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/ProjectStatsRule.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cost;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.tree.Expression;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class ProjectStatsRule
+        implements ComposableStatsCalculator.Rule
+{
+    private final ScalarStatsCalculator scalarStatsCalculator;
+
+    public ProjectStatsRule(ScalarStatsCalculator scalarStatsCalculator)
+    {
+        this.scalarStatsCalculator = scalarStatsCalculator;
+    }
+
+    @Override
+    public Optional<PlanNodeStatsEstimate> calculate(PlanNode node, Lookup lookup, Session session, Map<Symbol, Type> types)
+    {
+        if (!(node instanceof ProjectNode)) {
+            return Optional.empty();
+        }
+        ProjectNode projectNode = (ProjectNode) node;
+
+        PlanNodeStatsEstimate sourceStats = lookup.getStats(projectNode.getSource(), session, types);
+        // TODO handle output size in bytes
+        PlanNodeStatsEstimate.Builder calculatedStats = PlanNodeStatsEstimate.builder()
+                .setOutputRowCount(sourceStats.getOutputRowCount());
+
+        for (Map.Entry<Symbol, Expression> entry : projectNode.getAssignments().entrySet()) {
+            calculatedStats.addSymbolStatistics(entry.getKey(), scalarStatsCalculator.calculate(entry.getValue(), sourceStats, session, types));
+        }
+        return Optional.of(calculatedStats.build());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/cost/ScalarStatsCalculator.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/ScalarStatsCalculator.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cost;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.tree.AstVisitor;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.Node;
+
+import javax.inject.Inject;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public class ScalarStatsCalculator
+{
+    private final Metadata metadata;
+
+    @Inject
+    public ScalarStatsCalculator(Metadata metadata)
+    {
+        this.metadata = requireNonNull(metadata, "metadata can not be null");
+    }
+
+    public SymbolStatsEstimate calculate(Expression scalarExpression, PlanNodeStatsEstimate inputStatistics, Session session, Map<Symbol, Type> types)
+    {
+        return new Visitor(inputStatistics, session, types).process(scalarExpression);
+    }
+
+    private class Visitor
+            extends AstVisitor<SymbolStatsEstimate, Void>
+    {
+        private final PlanNodeStatsEstimate input;
+        private final Session session;
+        private final Map<Symbol, Type> types;
+
+        Visitor(PlanNodeStatsEstimate input, Session session, Map<Symbol, Type> types)
+        {
+            this.input = input;
+            this.session = session;
+            this.types = types;
+        }
+
+        @Override
+        protected SymbolStatsEstimate visitNode(Node node, Void context)
+        {
+            return SymbolStatsEstimate.UNKNOWN_STATS;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/cost/ScalarStatsCalculator.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/ScalarStatsCalculator.java
@@ -20,6 +20,7 @@ import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.tree.AstVisitor;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.Node;
+import com.facebook.presto.sql.tree.SymbolReference;
 
 import javax.inject.Inject;
 
@@ -60,6 +61,12 @@ public class ScalarStatsCalculator
         protected SymbolStatsEstimate visitNode(Node node, Void context)
         {
             return SymbolStatsEstimate.UNKNOWN_STATS;
+        }
+
+        @Override
+        protected SymbolStatsEstimate visitSymbolReference(SymbolReference node, Void context)
+        {
+            return input.getSymbolStatistics().getOrDefault(Symbol.from(node), SymbolStatsEstimate.UNKNOWN_STATS);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/cost/SimplifiedHistogramStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/SimplifiedHistogramStats.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.cost;
+
+import java.util.Optional;
+
+import static com.facebook.presto.cost.SimplifiedHistogramStats.SimplifedHistogramStatsBuilder.aSimplifedHistogramStats;
+
+public class SimplifiedHistogramStats
+{
+    private final StatsHistogramRange range;
+
+    private final double dataSize;
+    private final double nullsFraction;
+    private final double distinctValuesCount;
+    private final double filteredPercent; // HACK!
+
+    private SimplifiedHistogramStats(StatsHistogramRange range, double dataSize, double nullsFraction, double distinctValuesCount, double filteredPercent)
+    {
+        this.range = range;
+        this.dataSize = dataSize;
+        this.nullsFraction = nullsFraction;
+        this.distinctValuesCount = distinctValuesCount;
+        this.filteredPercent = filteredPercent;
+    }
+
+    public SymbolStatsEstimate toSymbolsStatistics()
+    {
+        return SymbolStatsEstimate.builder()
+                .setNullsFraction(nullsFraction)
+                .setLowValue(range.getLow())
+                .setHighValue(range.getHigh())
+                .setDistinctValuesCount(distinctValuesCount)
+                .setDataSize(dataSize)
+                .build();
+    }
+
+    public static SimplifiedHistogramStats of(SymbolStatsEstimate symbolStats)
+    {
+        SimplifiedHistogramStats newStats = new SimplifiedHistogramStats(
+                new StatsHistogramRange(symbolStats.getLowValue(), symbolStats.getHighValue(), Optional.empty()),
+                symbolStats.getDataSize(),
+                symbolStats.getNullsFraction(),
+                symbolStats.getDistinctValuesCount(),
+                Double.NaN);
+        newStats.range.setStatsParent(Optional.of(newStats));
+        return newStats;
+    }
+
+    public double getLow()
+    {
+        return range.getLow();
+    }
+
+    public double getHigh()
+    {
+        return range.getHigh();
+    }
+
+    public SimplifiedHistogramStats intersect(StatsHistogramRange other)
+    {
+        StatsHistogramRange newRange = range.intersect(other);
+        double percentOfDataLeft = range.overlapPartOf(newRange);
+
+        return aSimplifedHistogramStats().withRange(newRange)
+                .withDataSize(dataSize * percentOfDataLeft)
+                .withNullsFraction(0)
+                .withDistinctValuesCount(distinctValuesCount * percentOfDataLeft) // FIXME nulls not counted!
+                .withFilteredPercent(percentOfDataLeft)
+                .build();
+    }
+
+    public double getDistinctValuesCount()
+    {
+        return distinctValuesCount;
+    }
+
+    public double getNullsFraction()
+    {
+        return nullsFraction;
+    }
+
+    public double getFilteredPercent()
+    {
+        return filteredPercent;
+    }
+
+    public StatsHistogramRange getRange()
+    {
+        return range;
+    }
+
+    public static final class SimplifedHistogramStatsBuilder
+    {
+        private StatsHistogramRange range;
+        private double dataSize;
+        private double nullsFraction;
+        private double distinctValuesCount;
+        private double filteredPercent; //FIXME HACK!
+
+        private SimplifedHistogramStatsBuilder() {}
+
+        public static SimplifedHistogramStatsBuilder aSimplifedHistogramStats()
+        {
+            return new SimplifedHistogramStatsBuilder();
+        }
+
+        public SimplifedHistogramStatsBuilder withRange(StatsHistogramRange range)
+        {
+            this.range = range;
+            return this;
+        }
+
+        public SimplifedHistogramStatsBuilder withDataSize(double dataSize)
+        {
+            this.dataSize = dataSize;
+            return this;
+        }
+
+        public SimplifedHistogramStatsBuilder withNullsFraction(double nullsFraction)
+        {
+            this.nullsFraction = nullsFraction;
+            return this;
+        }
+
+        public SimplifedHistogramStatsBuilder withDistinctValuesCount(double distinctValuesCount)
+        {
+            this.distinctValuesCount = distinctValuesCount;
+            return this;
+        }
+
+        public SimplifedHistogramStatsBuilder withFilteredPercent(double filtered) // HACK!
+        {
+            this.filteredPercent = filtered;
+            return this;
+        }
+
+        public SimplifiedHistogramStats build()
+        {
+            SimplifiedHistogramStats simplifiedHistogramStats = new SimplifiedHistogramStats(
+                    range, dataSize, nullsFraction, distinctValuesCount, filteredPercent);
+            simplifiedHistogramStats.range.setStatsParent(Optional.of(simplifiedHistogramStats));
+            return simplifiedHistogramStats;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/cost/StatsHistogramRange.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/StatsHistogramRange.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.cost;
+
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.stream.DoubleStream;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.Double.NEGATIVE_INFINITY;
+import static java.lang.Double.POSITIVE_INFINITY;
+import static java.lang.Double.isFinite;
+import static java.lang.Double.isNaN;
+
+public class StatsHistogramRange
+{
+    private final double low;
+    private final double high;
+    private Optional<SimplifiedHistogramStats> statsParent;
+
+    public StatsHistogramRange(double low, double high, Optional<SimplifiedHistogramStats> statsParent)
+    {
+        checkArgument(!isNaN(low), "NaN is not valid low");
+        checkArgument(!isNaN(high), "NaN is not valid low");
+        checkArgument(low <= high, "low must be less than or equal high");
+        this.low = low;
+        this.high = high;
+        this.statsParent = statsParent;
+    }
+
+    public void setStatsParent(Optional<SimplifiedHistogramStats> statsParent)
+    {
+        this.statsParent = statsParent;
+    }
+
+    public double getHigh()
+    {
+        return high;
+    }
+
+    public double getLow()
+    {
+        return low;
+    }
+
+    public OptionalDouble minKnown(double first, double second)
+    {
+        return DoubleStream.of(first, second).filter(Double::isFinite).min();
+    }
+
+    public OptionalDouble maxKnown(double first, double second)
+    {
+        return DoubleStream.of(first, second).filter(Double::isFinite).max();
+    }
+
+    public double overlapPartOf(StatsHistogramRange other)
+    {
+        if (low != NEGATIVE_INFINITY && high != POSITIVE_INFINITY) {
+            return overlapPartOfClosedRange(other);
+        }
+        if (low == NEGATIVE_INFINITY && high != POSITIVE_INFINITY) {
+            return overlapPartOfRightClosedRange(other);
+        }
+        if (low != NEGATIVE_INFINITY && high == POSITIVE_INFINITY) {
+            return overlapPartOfLeftClosedRange(other);
+        }
+        return overlapPartOfUnknownRange(other);
+    }
+
+    private double overlapPartOfRightClosedRange(StatsHistogramRange other)
+    {
+        if (isFinite(other.low) || isFinite(other.high)) {
+            double lowestKnown = minKnown(other.high, other.low).getAsDouble();
+            if (lowestKnown < high) {
+                return 0.5; // Heuristic? FIXME multiply by nulls factor
+            }
+            return 0;
+        }
+        return 1; // FIXME multiply by nulls factor
+    }
+
+    private double overlapPartOfLeftClosedRange(StatsHistogramRange other)
+    {
+        // TODO check arguments
+        if (isFinite(other.low) || isFinite(other.high)) {
+            double highestKnown = maxKnown(other.high, other.low).getAsDouble();
+            if (highestKnown > low) {
+                return 0.5; // Heuristic? FIXME multiply by nulls factor
+            }
+            return 0;
+        }
+        return 1; // FIXME multiply by nulls factor
+    }
+
+    private double overlapPartOfUnknownRange(StatsHistogramRange other)
+    {
+        // TODO check arguments
+        if (isFinite(other.low) && isFinite(other.high)) {
+            return 0;
+        }
+        if (isFinite(other.low) || isFinite(other.high)) {
+            return 0.5; // Heuristic? TODO multiply by  nullsfact
+        }
+        return 1.0; // TODO multiply by  nullsfact
+    }
+
+    private double overlapPartOfClosedRange(StatsHistogramRange other)
+    {
+        // TODO check argumentss
+
+        double leftValue = maxKnown(low, other.low).getAsDouble();
+        double rightValue = minKnown(high, other.high).getAsDouble();
+
+        if (leftValue > rightValue) {
+            return 0;
+        }
+        if (leftValue == rightValue) {
+            return (1 - statsParent.get().getNullsFraction()) / statsParent.get().getDistinctValuesCount();
+        }
+        double histogramOverlap = (rightValue - leftValue) / (high - low);
+        return histogramOverlap * (1 - orDefault(statsParent.get().getNullsFraction(), 0));
+    }
+
+    double orDefault(double value, double defaultValue)
+    {
+        if (isNaN(value)) {
+            return defaultValue;
+        }
+        return value;
+    }
+
+    public StatsHistogramRange intersect(StatsHistogramRange other)
+    {
+        return new StatsHistogramRange(Double.max(low, other.low), Double.min(high, other.high), Optional.empty());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/cost/SymbolStatsEstimate.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/SymbolStatsEstimate.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cost;
+
+import java.util.Objects;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.Double.NaN;
+import static java.lang.Double.isNaN;
+
+public class SymbolStatsEstimate
+{
+    public static final SymbolStatsEstimate UNKNOWN_STATS = SymbolStatsEstimate.builder().build();
+
+    // for now we support only types which map to real domain naturally and keep low/high value as doulbe in stats.
+    private final double lowValue;
+    private final double highValue;
+    private final double nullsFraction;
+    private final double dataSize;
+    private final double distinctValuesCount;
+
+    public SymbolStatsEstimate(double lowValue, double highValue, double nullsFraction, double dataSize, double distinctValuesCount)
+    {
+        checkArgument(!isNaN(lowValue), "NaN is not valid lowValue");
+        checkArgument(!isNaN(highValue), "NaN is not valid lowValue");
+        checkArgument(lowValue <= highValue, "lowValue must be less than or equal highValue");
+        this.lowValue = lowValue;
+        this.highValue = highValue;
+        this.nullsFraction = nullsFraction;
+        this.dataSize = dataSize;
+        this.distinctValuesCount = distinctValuesCount;
+    }
+
+    public double getLowValue()
+    {
+        return lowValue;
+    }
+
+    public double getHighValue()
+    {
+        return highValue;
+    }
+
+    public double getNullsFraction()
+    {
+        return nullsFraction;
+    }
+
+    public double getDataSize()
+    {
+        return dataSize;
+    }
+
+    public double getDistinctValuesCount()
+    {
+        return distinctValuesCount;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SymbolStatsEstimate that = (SymbolStatsEstimate) o;
+        return Double.compare(that.nullsFraction, nullsFraction) == 0 &&
+                Double.compare(that.dataSize, dataSize) == 0 &&
+                Double.compare(that.distinctValuesCount, distinctValuesCount) == 0 &&
+                Objects.equals(lowValue, that.lowValue) &&
+                Objects.equals(highValue, that.highValue);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(lowValue, highValue, nullsFraction, dataSize, distinctValuesCount);
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static Builder buildFrom(SymbolStatsEstimate other)
+    {
+        return builder()
+                .setLowValue(other.getLowValue())
+                .setHighValue(other.getHighValue())
+                .setNullsFraction(other.getNullsFraction())
+                .setDataSize(other.getDataSize())
+                .setDistinctValuesCount(other.getDistinctValuesCount());
+    }
+
+    public static final class Builder
+    {
+        private double lowValue = Double.NEGATIVE_INFINITY;
+        private double highValue = Double.POSITIVE_INFINITY;
+        private double nullsFraction = NaN;
+        private double dataSize = NaN;
+        private double distinctValuesCount = NaN;
+
+        public Builder setLowValue(double lowValue)
+        {
+            this.lowValue = lowValue;
+            return this;
+        }
+
+        public Builder setHighValue(double highValue)
+        {
+            this.highValue = highValue;
+            return this;
+        }
+
+        public Builder setNullsFraction(double nullsFraction)
+        {
+            this.nullsFraction = nullsFraction;
+            return this;
+        }
+
+        public Builder setDataSize(double dataSize)
+        {
+            this.dataSize = dataSize;
+            return this;
+        }
+
+        public Builder setDistinctValuesCount(double distinctValuesCount)
+        {
+            this.distinctValuesCount = distinctValuesCount;
+            return this;
+        }
+
+        public SymbolStatsEstimate build()
+        {
+            return new SymbolStatsEstimate(lowValue, highValue, nullsFraction, dataSize, distinctValuesCount);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/cost/TableScanStatsRule.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/TableScanStatsRule.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cost;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.Constraint;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.statistics.ColumnStatistics;
+import com.facebook.presto.spi.statistics.TableStatistics;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.DomainTranslator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.TableScanNode;
+import com.facebook.presto.sql.tree.BooleanLiteral;
+import com.facebook.presto.sql.tree.Expression;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalDouble;
+
+import static com.facebook.presto.cost.SymbolStatsEstimate.UNKNOWN_STATS;
+import static java.lang.Double.NEGATIVE_INFINITY;
+import static java.lang.Double.POSITIVE_INFINITY;
+import static java.util.Objects.requireNonNull;
+
+public class TableScanStatsRule
+        implements ComposableStatsCalculator.Rule
+{
+    private final Metadata metadata;
+
+    public TableScanStatsRule(Metadata metadata)
+    {
+        this.metadata = requireNonNull(metadata, "metadata can not be null");
+    }
+
+    @Override
+    public Optional<PlanNodeStatsEstimate> calculate(PlanNode node, Lookup lookup, Session session, Map<Symbol, Type> types)
+    {
+        if (!(node instanceof TableScanNode)) {
+            return Optional.empty();
+        }
+
+        TableScanNode tableScanNode = (TableScanNode) node;
+
+        Constraint<ColumnHandle> constraint = getConstraint(tableScanNode, BooleanLiteral.TRUE_LITERAL, session, types);
+
+        TableStatistics tableStatistics = metadata.getTableStatistics(session, tableScanNode.getTable(), constraint);
+        Map<Symbol, SymbolStatsEstimate> outputSymbolStats = new HashMap<>();
+
+        for (Map.Entry<Symbol, ColumnHandle> entry : tableScanNode.getAssignments().entrySet()) {
+            Symbol symbol = entry.getKey();
+            Type symbolType = types.get(symbol);
+            Optional<ColumnStatistics> columnStatistics = Optional.ofNullable(tableStatistics.getColumnStatistics().get(entry.getValue()));
+            outputSymbolStats.put(symbol, columnStatistics.map(statistics -> toSymbolStatistics(statistics, session, symbolType)).orElse(UNKNOWN_STATS));
+        }
+
+        return Optional.of(PlanNodeStatsEstimate.builder()
+                .setOutputRowCount(tableStatistics.getRowCount().getValue())
+                .setSymbolStatistics(outputSymbolStats)
+                .build());
+    }
+
+    private SymbolStatsEstimate toSymbolStatistics(ColumnStatistics columnStatistics, Session session, Type type)
+    {
+        TypeStatOperatorCaller operatorCaller = new TypeStatOperatorCaller(type, metadata.getFunctionRegistry(), session.toConnectorSession());
+
+        return SymbolStatsEstimate.builder()
+                .setLowValue(asDouble(columnStatistics.getOnlyRangeColumnStatistics().getLowValue(), operatorCaller).orElse(NEGATIVE_INFINITY))
+                .setHighValue(asDouble(columnStatistics.getOnlyRangeColumnStatistics().getHighValue(), operatorCaller).orElse(POSITIVE_INFINITY))
+                .setNullsFraction(
+                        columnStatistics.getNullsFraction().getValue()
+                                / (columnStatistics.getNullsFraction().getValue() + columnStatistics.getOnlyRangeColumnStatistics().getFraction().getValue()))
+                .setDistinctValuesCount(columnStatistics.getOnlyRangeColumnStatistics().getDistinctValuesCount().getValue())
+                .setDataSize(columnStatistics.getOnlyRangeColumnStatistics().getDataSize().getValue())
+                .build();
+    }
+
+    private OptionalDouble asDouble(Optional<Object> optionalValue, TypeStatOperatorCaller operatorCaller)
+    {
+        return optionalValue.map(operatorCaller::translateToDouble).orElseGet(OptionalDouble::empty);
+    }
+
+    private Constraint<ColumnHandle> getConstraint(TableScanNode node, Expression predicate, Session session, Map<Symbol, Type> types)
+    {
+        DomainTranslator.ExtractionResult decomposedPredicate = DomainTranslator.fromPredicate(
+                metadata,
+                session,
+                predicate,
+                types);
+
+        TupleDomain<ColumnHandle> simplifiedConstraint = decomposedPredicate.getTupleDomain()
+                .transform(node.getAssignments()::get)
+                .intersect(node.getCurrentConstraint());
+
+        return new Constraint<>(simplifiedConstraint, bindings -> true);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/cost/TypeStatOperatorCaller.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/TypeStatOperatorCaller.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.cost;
+
+import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.operator.scalar.ScalarFunctionImplementation;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.type.BigintType;
+import com.facebook.presto.spi.type.DecimalType;
+import com.facebook.presto.spi.type.DoubleType;
+import com.facebook.presto.spi.type.IntegerType;
+import com.facebook.presto.spi.type.RealType;
+import com.facebook.presto.spi.type.SmallintType;
+import com.facebook.presto.spi.type.TinyintType;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.VarcharType;
+import com.facebook.presto.sql.planner.ExpressionInterpreter;
+import io.airlift.slice.Slice;
+
+import java.util.OptionalDouble;
+
+import static java.util.Collections.singletonList;
+
+/**
+ * This will contain set of all function used in process of calculation stats.
+ * It will be created based on Type and TypeRegistry.
+ */
+public class TypeStatOperatorCaller
+{
+    private final Type type;
+    private final FunctionRegistry functionRegistry;
+    private final ConnectorSession session;
+
+    public TypeStatOperatorCaller(Type type, FunctionRegistry functionRegistry, ConnectorSession session)
+    {
+        this.type = type;
+        this.functionRegistry = functionRegistry;
+        this.session = session;
+    }
+
+    public Slice castToVarchar(Object object)
+    {
+        Signature castSignature = functionRegistry.getCoercion(type, VarcharType.createUnboundedVarcharType());
+        ScalarFunctionImplementation castImplementation = functionRegistry.getScalarFunctionImplementation(castSignature);
+        return (Slice) ExpressionInterpreter.invoke(session, castImplementation, singletonList(object));
+    }
+
+    public OptionalDouble translateToDouble(Object object)
+    {
+        if (!isDoubleTranslateSupported(type)) {
+            return OptionalDouble.empty();
+        }
+        Signature castSignature = functionRegistry.getCoercion(type, DoubleType.DOUBLE);
+        ScalarFunctionImplementation castImplementation = functionRegistry.getScalarFunctionImplementation(castSignature);
+        return OptionalDouble.of((double) ExpressionInterpreter.invoke(session, castImplementation, singletonList(object)));
+    }
+
+    private boolean isDoubleTranslateSupported(Type type)
+    {
+        return type instanceof DecimalType
+                || DoubleType.DOUBLE.equals(type)
+                || RealType.REAL.equals(type)
+                || BigintType.BIGINT.equals(type)
+                || IntegerType.INTEGER.equals(type)
+                || SmallintType.SMALLINT.equals(type)
+                || TinyintType.TINYINT.equals(type);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/cost/ValuesStatsRule.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/ValuesStatsRule.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cost;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ValuesNode;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class ValuesStatsRule
+        implements ComposableStatsCalculator.Rule
+{
+    @Override
+    public Optional<PlanNodeStatsEstimate> calculate(PlanNode node, Lookup lookup, Session session, Map<Symbol, Type> types)
+    {
+        if (!(node instanceof ValuesNode)) {
+            return Optional.empty();
+        }
+        ValuesNode valuesNode = (ValuesNode) node;
+
+        // TODO symbol stats
+        return Optional.of(PlanNodeStatsEstimate.builder()
+                .setOutputRowCount(valuesNode.getRows().size())
+                .build());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/SemiJoinStatsRule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/SemiJoinStatsRule.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.SemiJoinNode;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class SemiJoinStatsRule
+        implements com.facebook.presto.cost.ComposableStatsCalculator.Rule
+{
+    @Override
+    public Optional<PlanNodeStatsEstimate> calculate(PlanNode node, Lookup lookup, Session session, Map<Symbol, Type> types)
+    {
+        if (!(node instanceof SemiJoinNode)) {
+            return Optional.empty();
+        }
+        SemiJoinNode semiJoinNode = (SemiJoinNode) node;
+        PlanNodeStatsEstimate sourceStats = lookup.getStats(semiJoinNode.getSource(), session, types);
+        return Optional.of(sourceStats.mapOutputRowCount(rowCount -> rowCount * 0.5));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -28,6 +28,7 @@ import com.facebook.presto.cost.CostCalculatorUsingExchanges;
 import com.facebook.presto.cost.CostCalculatorWithEstimatedExchanges;
 import com.facebook.presto.cost.CostComparator;
 import com.facebook.presto.cost.EnforceSingleRowStatsRule;
+import com.facebook.presto.cost.ExchangeStatsRule;
 import com.facebook.presto.cost.FilterStatsCalculator;
 import com.facebook.presto.cost.LimitStatsRule;
 import com.facebook.presto.cost.OutputStatsRule;
@@ -471,6 +472,7 @@ public class ServerMainModule
         rules.add(new ValuesStatsRule());
         rules.add(new LimitStatsRule());
         rules.add(new EnforceSingleRowStatsRule());
+        rules.add(new ExchangeStatsRule());
 
         return new ComposableStatsCalculator(rules.build());
     }

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -28,6 +28,7 @@ import com.facebook.presto.cost.CostCalculatorUsingExchanges;
 import com.facebook.presto.cost.CostCalculatorWithEstimatedExchanges;
 import com.facebook.presto.cost.CostComparator;
 import com.facebook.presto.cost.FilterStatsCalculator;
+import com.facebook.presto.cost.ScalarStatsCalculator;
 import com.facebook.presto.cost.StatsCalculator;
 import com.facebook.presto.event.query.QueryMonitor;
 import com.facebook.presto.event.query.QueryMonitorConfig;
@@ -357,6 +358,7 @@ public class ServerMainModule
                 .to(CostCalculatorWithEstimatedExchanges.class).in(Scopes.SINGLETON);
         binder.bind(Lookup.class).to(StatelessLookup.class).in(Scopes.SINGLETON);
         binder.bind(FilterStatsCalculator.class).in(Scopes.SINGLETON);
+        binder.bind(ScalarStatsCalculator.class).in(Scopes.SINGLETON);
 
         // type
         binder.bind(TypeRegistry.class).in(Scopes.SINGLETON);
@@ -456,7 +458,7 @@ public class ServerMainModule
 
     @Provides
     @Singleton
-    public static StatsCalculator createStatsCalculator(Metadata metadata, FilterStatsCalculator filterStatsCalculator)
+    public static StatsCalculator createStatsCalculator(Metadata metadata, FilterStatsCalculator filterStatsCalculator, ScalarStatsCalculator scalarStatsCalculator)
     {
         ImmutableList.Builder<ComposableStatsCalculator.Rule> rules = ImmutableList.builder();
         return new ComposableStatsCalculator(rules.build());

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -27,6 +27,7 @@ import com.facebook.presto.cost.CostCalculator.EstimatedExchanges;
 import com.facebook.presto.cost.CostCalculatorUsingExchanges;
 import com.facebook.presto.cost.CostCalculatorWithEstimatedExchanges;
 import com.facebook.presto.cost.CostComparator;
+import com.facebook.presto.cost.EnforceSingleRowStatsRule;
 import com.facebook.presto.cost.FilterStatsCalculator;
 import com.facebook.presto.cost.LimitStatsRule;
 import com.facebook.presto.cost.OutputStatsRule;
@@ -469,6 +470,7 @@ public class ServerMainModule
         rules.add(new TableScanStatsRule(metadata));
         rules.add(new ValuesStatsRule());
         rules.add(new LimitStatsRule());
+        rules.add(new EnforceSingleRowStatsRule());
 
         return new ComposableStatsCalculator(rules.build());
     }

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -32,6 +32,7 @@ import com.facebook.presto.cost.OutputStatsRule;
 import com.facebook.presto.cost.ScalarStatsCalculator;
 import com.facebook.presto.cost.StatsCalculator;
 import com.facebook.presto.cost.TableScanStatsRule;
+import com.facebook.presto.cost.ValuesStatsRule;
 import com.facebook.presto.event.query.QueryMonitor;
 import com.facebook.presto.event.query.QueryMonitorConfig;
 import com.facebook.presto.execution.LocationFactory;
@@ -465,6 +466,8 @@ public class ServerMainModule
         ImmutableList.Builder<ComposableStatsCalculator.Rule> rules = ImmutableList.builder();
         rules.add(new OutputStatsRule());
         rules.add(new TableScanStatsRule(metadata));
+        rules.add(new ValuesStatsRule());
+
         return new ComposableStatsCalculator(rules.build());
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -27,6 +27,7 @@ import com.facebook.presto.cost.CostCalculator.EstimatedExchanges;
 import com.facebook.presto.cost.CostCalculatorUsingExchanges;
 import com.facebook.presto.cost.CostCalculatorWithEstimatedExchanges;
 import com.facebook.presto.cost.CostComparator;
+import com.facebook.presto.cost.FilterStatsCalculator;
 import com.facebook.presto.cost.StatsCalculator;
 import com.facebook.presto.event.query.QueryMonitor;
 import com.facebook.presto.event.query.QueryMonitorConfig;
@@ -355,6 +356,7 @@ public class ServerMainModule
                 .annotatedWith(EstimatedExchanges.class)
                 .to(CostCalculatorWithEstimatedExchanges.class).in(Scopes.SINGLETON);
         binder.bind(Lookup.class).to(StatelessLookup.class).in(Scopes.SINGLETON);
+        binder.bind(FilterStatsCalculator.class).in(Scopes.SINGLETON);
 
         // type
         binder.bind(TypeRegistry.class).in(Scopes.SINGLETON);
@@ -454,7 +456,7 @@ public class ServerMainModule
 
     @Provides
     @Singleton
-    public static StatsCalculator createStatsCalculator(Metadata metadata)
+    public static StatsCalculator createStatsCalculator(Metadata metadata, FilterStatsCalculator filterStatsCalculator)
     {
         ImmutableList.Builder<ComposableStatsCalculator.Rule> rules = ImmutableList.builder();
         return new ComposableStatsCalculator(rules.build());

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -31,6 +31,7 @@ import com.facebook.presto.cost.FilterStatsCalculator;
 import com.facebook.presto.cost.OutputStatsRule;
 import com.facebook.presto.cost.ScalarStatsCalculator;
 import com.facebook.presto.cost.StatsCalculator;
+import com.facebook.presto.cost.TableScanStatsRule;
 import com.facebook.presto.event.query.QueryMonitor;
 import com.facebook.presto.event.query.QueryMonitorConfig;
 import com.facebook.presto.execution.LocationFactory;
@@ -463,6 +464,7 @@ public class ServerMainModule
     {
         ImmutableList.Builder<ComposableStatsCalculator.Rule> rules = ImmutableList.builder();
         rules.add(new OutputStatsRule());
+        rules.add(new TableScanStatsRule(metadata));
         return new ComposableStatsCalculator(rules.build());
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -28,6 +28,7 @@ import com.facebook.presto.cost.CostCalculatorUsingExchanges;
 import com.facebook.presto.cost.CostCalculatorWithEstimatedExchanges;
 import com.facebook.presto.cost.CostComparator;
 import com.facebook.presto.cost.FilterStatsCalculator;
+import com.facebook.presto.cost.LimitStatsRule;
 import com.facebook.presto.cost.OutputStatsRule;
 import com.facebook.presto.cost.ScalarStatsCalculator;
 import com.facebook.presto.cost.StatsCalculator;
@@ -467,6 +468,7 @@ public class ServerMainModule
         rules.add(new OutputStatsRule());
         rules.add(new TableScanStatsRule(metadata));
         rules.add(new ValuesStatsRule());
+        rules.add(new LimitStatsRule());
 
         return new ComposableStatsCalculator(rules.build());
     }

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -30,6 +30,7 @@ import com.facebook.presto.cost.CostComparator;
 import com.facebook.presto.cost.EnforceSingleRowStatsRule;
 import com.facebook.presto.cost.ExchangeStatsRule;
 import com.facebook.presto.cost.FilterStatsCalculator;
+import com.facebook.presto.cost.FilterStatsRule;
 import com.facebook.presto.cost.LimitStatsRule;
 import com.facebook.presto.cost.OutputStatsRule;
 import com.facebook.presto.cost.ProjectStatsRule;
@@ -475,6 +476,7 @@ public class ServerMainModule
         rules.add(new EnforceSingleRowStatsRule());
         rules.add(new ExchangeStatsRule());
         rules.add(new ProjectStatsRule(scalarStatsCalculator));
+        rules.add(new FilterStatsRule(filterStatsCalculator));
 
         return new ComposableStatsCalculator(rules.build());
     }

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -32,6 +32,7 @@ import com.facebook.presto.cost.ExchangeStatsRule;
 import com.facebook.presto.cost.FilterStatsCalculator;
 import com.facebook.presto.cost.LimitStatsRule;
 import com.facebook.presto.cost.OutputStatsRule;
+import com.facebook.presto.cost.ProjectStatsRule;
 import com.facebook.presto.cost.ScalarStatsCalculator;
 import com.facebook.presto.cost.StatsCalculator;
 import com.facebook.presto.cost.TableScanStatsRule;
@@ -473,6 +474,7 @@ public class ServerMainModule
         rules.add(new LimitStatsRule());
         rules.add(new EnforceSingleRowStatsRule());
         rules.add(new ExchangeStatsRule());
+        rules.add(new ProjectStatsRule(scalarStatsCalculator));
 
         return new ComposableStatsCalculator(rules.build());
     }

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -31,6 +31,7 @@ import com.facebook.presto.cost.EnforceSingleRowStatsRule;
 import com.facebook.presto.cost.ExchangeStatsRule;
 import com.facebook.presto.cost.FilterStatsCalculator;
 import com.facebook.presto.cost.FilterStatsRule;
+import com.facebook.presto.cost.JoinStatsRule;
 import com.facebook.presto.cost.LimitStatsRule;
 import com.facebook.presto.cost.OutputStatsRule;
 import com.facebook.presto.cost.ProjectStatsRule;
@@ -477,6 +478,7 @@ public class ServerMainModule
         rules.add(new ExchangeStatsRule());
         rules.add(new ProjectStatsRule(scalarStatsCalculator));
         rules.add(new FilterStatsRule(filterStatsCalculator));
+        rules.add(new JoinStatsRule(filterStatsCalculator));
 
         return new ComposableStatsCalculator(rules.build());
     }

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -28,6 +28,7 @@ import com.facebook.presto.cost.CostCalculatorUsingExchanges;
 import com.facebook.presto.cost.CostCalculatorWithEstimatedExchanges;
 import com.facebook.presto.cost.CostComparator;
 import com.facebook.presto.cost.FilterStatsCalculator;
+import com.facebook.presto.cost.OutputStatsRule;
 import com.facebook.presto.cost.ScalarStatsCalculator;
 import com.facebook.presto.cost.StatsCalculator;
 import com.facebook.presto.event.query.QueryMonitor;
@@ -461,6 +462,7 @@ public class ServerMainModule
     public static StatsCalculator createStatsCalculator(Metadata metadata, FilterStatsCalculator filterStatsCalculator, ScalarStatsCalculator scalarStatsCalculator)
     {
         ImmutableList.Builder<ComposableStatsCalculator.Rule> rules = ImmutableList.builder();
+        rules.add(new OutputStatsRule());
         return new ComposableStatsCalculator(rules.build());
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -479,6 +479,7 @@ public class ServerMainModule
         rules.add(new ProjectStatsRule(scalarStatsCalculator));
         rules.add(new FilterStatsRule(filterStatsCalculator));
         rules.add(new JoinStatsRule(filterStatsCalculator));
+        rules.add(new SemiJoinStatsRule());
 
         return new ComposableStatsCalculator(rules.build());
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/ExpressionUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/ExpressionUtils.java
@@ -26,7 +26,6 @@ import com.facebook.presto.sql.tree.LambdaExpression;
 import com.facebook.presto.sql.tree.LogicalBinaryExpression;
 import com.facebook.presto.sql.tree.NotExpression;
 import com.facebook.presto.sql.tree.SymbolReference;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 
@@ -103,7 +102,10 @@ public final class ExpressionUtils
     {
         requireNonNull(type, "type is null");
         requireNonNull(expressions, "expressions is null");
-        Preconditions.checkArgument(!expressions.isEmpty(), "expressions is empty");
+
+        if (expressions.isEmpty()) {
+            return TRUE_LITERAL;
+        }
 
         // Build balanced tree for efficient recursive processing that
         // preserves the evaluation order of the input expressions.
@@ -309,7 +311,8 @@ public final class ExpressionUtils
 
     public static Expression rewriteIdentifiersToSymbolReferences(Expression expression)
     {
-        return ExpressionTreeRewriter.rewriteWith(new ExpressionRewriter<Void>() {
+        return ExpressionTreeRewriter.rewriteWith(new ExpressionRewriter<Void>()
+        {
             @Override
             public Expression rewriteIdentifier(Identifier node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
             {

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -28,6 +28,7 @@ import java.nio.file.Paths;
 import java.util.List;
 
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType.REPARTITIONED;
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStrategy.ELIMINATE_CROSS_JOINS;
 import static com.facebook.presto.sql.analyzer.RegexLibrary.JONI;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
@@ -65,7 +66,7 @@ public class FeaturesConfig
     private boolean distributedIndexJoinsEnabled;
     private boolean colocatedJoinsEnabled;
     private boolean fastInequalityJoins = true;
-    private boolean reorderJoins = true;
+    private JoinReorderingStrategy joinReorderingStrategy = ELIMINATE_CROSS_JOINS;
     private boolean redistributeWrites = true;
     private boolean optimizeMetadataQueries;
     private boolean optimizeHashGeneration = true;
@@ -94,6 +95,13 @@ public class FeaturesConfig
     private boolean pushAggregationThroughJoin = true;
 
     private Duration iterativeOptimizerTimeout = new Duration(3, MINUTES); // by default let optimizer wait a long time in case it retrieves some data from ConnectorMetadata
+
+    public enum JoinReorderingStrategy
+    {
+        ELIMINATE_CROSS_JOINS,
+        COST_BASED,
+        NONE
+    }
 
     public double getCpuCostWeight()
     {
@@ -217,16 +225,16 @@ public class FeaturesConfig
         return fastInequalityJoins;
     }
 
-    public boolean isJoinReorderingEnabled()
+    public JoinReorderingStrategy getJoinReorderingStrategy()
     {
-        return reorderJoins;
+        return joinReorderingStrategy;
     }
 
-    @Config("reorder-joins")
-    @ConfigDescription("Experimental: Reorder joins to optimize plan")
-    public FeaturesConfig setJoinReorderingEnabled(boolean reorderJoins)
+    @Config("join-reordering-strategy")
+    @ConfigDescription("The strategy to use for reordering joins")
+    public FeaturesConfig setJoinReorderingStrategy(JoinReorderingStrategy joinReorderingStrategy)
     {
-        this.reorderJoins = reorderJoins;
+        this.joinReorderingStrategy = joinReorderingStrategy;
         return this;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -27,8 +27,10 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType.REPARTITIONED;
 import static com.facebook.presto.sql.analyzer.RegexLibrary.JONI;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
 @DefunctConfig({
@@ -42,8 +44,25 @@ public class FeaturesConfig
     private double cpuCostWeight = 0.75;
     private double memoryCostWeight = 0;
     private double networkCostWeight = 0.25;
+
+    public enum JoinDistributionType
+    {
+        AUTOMATIC,
+        REPLICATED,
+        REPARTITIONED;
+
+        public boolean canRepartition()
+        {
+            return this == REPARTITIONED || this == AUTOMATIC;
+        }
+
+        public boolean canReplicate()
+        {
+            return this == REPLICATED || this == AUTOMATIC;
+        }
+    }
+
     private boolean distributedIndexJoinsEnabled;
-    private boolean distributedJoinsEnabled = true;
     private boolean colocatedJoinsEnabled;
     private boolean fastInequalityJoins = true;
     private boolean reorderJoins = true;
@@ -58,6 +77,7 @@ public class FeaturesConfig
     private boolean legacyOrderBy;
     private boolean legacyMapSubscript;
     private boolean optimizeMixedDistinctAggregations;
+    private JoinDistributionType joinDistributionType = REPARTITIONED;
 
     private boolean dictionaryAggregation;
     private boolean resourceGroups;
@@ -135,11 +155,6 @@ public class FeaturesConfig
         return this;
     }
 
-    public boolean isDistributedJoinsEnabled()
-    {
-        return distributedJoinsEnabled;
-    }
-
     @Config("deprecated.legacy-array-agg")
     public FeaturesConfig setLegacyArrayAgg(boolean legacyArrayAgg)
     {
@@ -174,13 +189,6 @@ public class FeaturesConfig
     public boolean isLegacyMapSubscript()
     {
         return legacyMapSubscript;
-    }
-
-    @Config("distributed-joins-enabled")
-    public FeaturesConfig setDistributedJoinsEnabled(boolean distributedJoinsEnabled)
-    {
-        this.distributedJoinsEnabled = distributedJoinsEnabled;
-        return this;
     }
 
     public boolean isColocatedJoinsEnabled()
@@ -463,5 +471,17 @@ public class FeaturesConfig
     {
         this.pushAggregationThroughJoin = value;
         return this;
+    }
+
+    @Config("join-distribution-type")
+    public FeaturesConfig setJoinDistributionType(JoinDistributionType joinDistributionType)
+    {
+        this.joinDistributionType = requireNonNull(joinDistributionType, "joinDistributionType is null");
+        return this;
+    }
+
+    public JoinDistributionType getJoinDistributionType()
+    {
+        return joinDistributionType;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/EffectivePredicateExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/EffectivePredicateExtractor.java
@@ -224,12 +224,9 @@ public class EffectivePredicateExtractor
         Expression leftPredicate = node.getLeft().accept(this, context);
         Expression rightPredicate = node.getRight().accept(this, context);
 
-        List<Expression> joinConjuncts = new ArrayList<>();
-        for (JoinNode.EquiJoinClause clause : node.getCriteria()) {
-            joinConjuncts.add(new ComparisonExpression(ComparisonExpressionType.EQUAL,
-                    clause.getLeft().toSymbolReference(),
-                    clause.getRight().toSymbolReference()));
-        }
+        List<Expression> joinConjuncts = node.getCriteria().stream()
+                .map(JoinNode.EquiJoinClause::toExpression)
+                .collect(toImmutableList());
 
         switch (node.getType()) {
             case INNER:

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -304,6 +304,7 @@ public class PlanOptimizers
                 // Because ReorderJoins runs only once,
                 // PredicatePushDown, PruneUnreferenedOutputpus and RemoveRedundantIdentityProjections
                 // need to run beforehand in order to produce an optimal join order
+                // It also needs to run after EliminateCrossJoins so that it's chosen order doesn't get undone.
                 new IterativeOptimizer(
                         stats,
                         statsCalculator,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/EliminateCrossJoins.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/EliminateCrossJoins.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.sql.planner.iterative.rule;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.SystemSessionProperties;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolAllocator;
@@ -39,6 +38,8 @@ import java.util.Optional;
 import java.util.PriorityQueue;
 import java.util.Set;
 
+import static com.facebook.presto.SystemSessionProperties.getJoinReorderingStrategy;
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStrategy.ELIMINATE_CROSS_JOINS;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -54,7 +55,7 @@ public class EliminateCrossJoins
             return Optional.empty();
         }
 
-        if (!SystemSessionProperties.isJoinReorderingEnabled(session)) {
+        if (getJoinReorderingStrategy(session) != ELIMINATE_CROSS_JOINS) {
             return Optional.empty();
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/EliminateCrossJoins.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/EliminateCrossJoins.java
@@ -39,6 +39,7 @@ import java.util.PriorityQueue;
 import java.util.Set;
 
 import static com.facebook.presto.SystemSessionProperties.getJoinReorderingStrategy;
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStrategy.COST_BASED;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStrategy.ELIMINATE_CROSS_JOINS;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -55,7 +56,8 @@ public class EliminateCrossJoins
             return Optional.empty();
         }
 
-        if (getJoinReorderingStrategy(session) != ELIMINATE_CROSS_JOINS) {
+        // we run this for cost_based reordering also for cases when some of the tables do not have statistics
+        if (getJoinReorderingStrategy(session) != ELIMINATE_CROSS_JOINS || getJoinReorderingStrategy(session) != COST_BASED) {
             return Optional.empty();
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MultiJoinNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MultiJoinNode.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.tree.Expression;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import static com.facebook.presto.sql.ExpressionUtils.and;
+import static com.facebook.presto.sql.ExpressionUtils.extractConjuncts;
+import static com.facebook.presto.sql.planner.DeterminismEvaluator.isDeterministic;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
+import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * This class represents a set of inner joins that can be executed in any order.
+ */
+public class MultiJoinNode
+{
+    private final List<PlanNode> sources;
+    private final Expression filter;
+    private final List<Symbol> outputSymbols;
+
+    public MultiJoinNode(List<PlanNode> sources, Expression filter, List<Symbol> outputSymbols)
+    {
+        this.sources = ImmutableList.copyOf(requireNonNull(sources, "sources is null"));
+        this.filter = requireNonNull(filter, "filter is null");
+        this.outputSymbols = ImmutableList.copyOf(requireNonNull(outputSymbols, "outputSymbols is null"));
+
+        List<Symbol> inputSymbols = sources.stream().flatMap(source -> source.getOutputSymbols().stream()).collect(toImmutableList());
+        checkArgument(inputSymbols.containsAll(outputSymbols), "inputs do not contain all output symbols");
+    }
+
+    public Expression getFilter()
+    {
+        return filter;
+    }
+
+    public List<PlanNode> getSources()
+    {
+        return sources;
+    }
+
+    public List<Symbol> getOutputSymbols()
+    {
+        return outputSymbols;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(
+                ImmutableSet.copyOf(this.getOutputSymbols()),
+                ImmutableSet.copyOf(extractConjuncts(this.getFilter())),
+                this.getSources().stream()
+                        .map(PlanNode::getId)
+                        .collect(toImmutableSet()));
+    }
+
+    @Override
+    public boolean equals(Object other)
+    {
+        if (!(other instanceof MultiJoinNode)) {
+            return false;
+        }
+
+        MultiJoinNode otherNode = (MultiJoinNode) other;
+        return ImmutableSet.copyOf(this.getOutputSymbols()).equals(ImmutableSet.copyOf(otherNode.getOutputSymbols()))
+                && ImmutableSet.copyOf(extractConjuncts(this.getFilter())).equals(ImmutableSet.copyOf(extractConjuncts(otherNode.getFilter())))
+                && this.getSources().stream().map(PlanNode::getId).collect(toImmutableSet()).equals(otherNode.getSources().stream().map(PlanNode::getId).collect(toImmutableSet()));
+    }
+
+    static MultiJoinNode toMultiJoinNode(JoinNode joinNode, Lookup lookup)
+    {
+        return new MultiJoinNodeBuilder(joinNode, lookup).toMultiJoinNode();
+    }
+
+    private static class MultiJoinNodeBuilder
+    {
+        private final List<PlanNode> sources = new ArrayList<>();
+        private final List<Expression> filters = new ArrayList<>();
+        private final List<Symbol> outputSymbols;
+        private final Lookup lookup;
+
+        MultiJoinNodeBuilder(JoinNode node, Lookup lookup)
+        {
+            requireNonNull(node, "node is null");
+            checkState(node.getType() == INNER, "join type must be INNER");
+            this.outputSymbols = node.getOutputSymbols();
+            this.lookup = requireNonNull(lookup, "lookup is null");
+            flattenNode(node);
+        }
+
+        private void flattenNode(PlanNode node)
+        {
+            PlanNode resolved = lookup.resolve(node);
+            if (resolved instanceof JoinNode) {
+                JoinNode joinNode = (JoinNode) resolved;
+                if (joinNode.getType() == INNER && isDeterministic(joinNode.getFilter().orElse(TRUE_LITERAL))) {
+                    flattenNode(joinNode.getLeft());
+                    flattenNode(joinNode.getRight());
+                    joinNode.getCriteria().stream()
+                            .map(JoinNode.EquiJoinClause::toExpression)
+                            .forEach(filters::add);
+                    joinNode.getFilter().ifPresent(filters::add);
+                    return;
+                }
+            }
+            sources.add(node);
+        }
+
+        MultiJoinNode toMultiJoinNode()
+        {
+            return new MultiJoinNode(sources, and(filters), outputSymbols);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MultiJoinNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MultiJoinNode.java
@@ -20,21 +20,17 @@ import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.tree.Expression;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import static com.facebook.presto.sql.ExpressionUtils.and;
-import static com.facebook.presto.sql.ExpressionUtils.extractConjuncts;
 import static com.facebook.presto.sql.planner.DeterminismEvaluator.isDeterministic;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
 import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -69,30 +65,6 @@ public class MultiJoinNode
     public List<Symbol> getOutputSymbols()
     {
         return outputSymbols;
-    }
-
-    @Override
-    public int hashCode()
-    {
-        return Objects.hash(
-                ImmutableSet.copyOf(this.getOutputSymbols()),
-                ImmutableSet.copyOf(extractConjuncts(this.getFilter())),
-                this.getSources().stream()
-                        .map(PlanNode::getId)
-                        .collect(toImmutableSet()));
-    }
-
-    @Override
-    public boolean equals(Object other)
-    {
-        if (!(other instanceof MultiJoinNode)) {
-            return false;
-        }
-
-        MultiJoinNode otherNode = (MultiJoinNode) other;
-        return ImmutableSet.copyOf(this.getOutputSymbols()).equals(ImmutableSet.copyOf(otherNode.getOutputSymbols()))
-                && ImmutableSet.copyOf(extractConjuncts(this.getFilter())).equals(ImmutableSet.copyOf(extractConjuncts(otherNode.getFilter())))
-                && this.getSources().stream().map(PlanNode::getId).collect(toImmutableSet()).equals(otherNode.getSources().stream().map(PlanNode::getId).collect(toImmutableSet()));
     }
 
     static MultiJoinNode toMultiJoinNode(JoinNode joinNode, Lookup lookup)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ReorderJoins.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ReorderJoins.java
@@ -1,0 +1,346 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.cost.CostComparator;
+import com.facebook.presto.cost.PlanNodeCostEstimate;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.planner.DependencyExtractor;
+import com.facebook.presto.sql.planner.EqualityInference;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.FilterNode;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.tree.ComparisonExpression;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.SymbolReference;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Ordering;
+import com.google.common.collect.Sets;
+import io.airlift.log.Logger;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static com.facebook.presto.SystemSessionProperties.getJoinDistributionType;
+import static com.facebook.presto.SystemSessionProperties.getJoinReorderingStrategy;
+import static com.facebook.presto.sql.ExpressionUtils.and;
+import static com.facebook.presto.sql.ExpressionUtils.combineConjuncts;
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStrategy.COST_BASED;
+import static com.facebook.presto.sql.planner.EqualityInference.createEqualityInference;
+import static com.facebook.presto.sql.planner.iterative.rule.MultiJoinNode.toMultiJoinNode;
+import static com.facebook.presto.sql.planner.plan.Assignments.identity;
+import static com.facebook.presto.sql.planner.plan.JoinNode.DistributionType.PARTITIONED;
+import static com.facebook.presto.sql.planner.plan.JoinNode.DistributionType.REPLICATED;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
+import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
+import static com.facebook.presto.sql.tree.ComparisonExpressionType.EQUAL;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Predicates.in;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static java.util.Objects.requireNonNull;
+
+public class ReorderJoins
+        implements Rule
+{
+    private static final Logger log = Logger.get(ReorderJoins.class);
+
+    private final CostComparator costComparator;
+
+    public ReorderJoins(CostComparator costComparator)
+    {
+        this.costComparator = requireNonNull(costComparator, "costComparator is null");
+    }
+
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Lookup lookup, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session)
+    {
+        if (!(node instanceof JoinNode) || getJoinReorderingStrategy(session) != COST_BASED) {
+            return Optional.empty();
+        }
+
+        JoinNode joinNode = (JoinNode) node;
+        // We check that join distribution type is absent because we only want to do this transformation once (reordered joins will have distribution type already set).
+        if (!(joinNode.getType() == INNER) || joinNode.getDistributionType().isPresent()) {
+            return Optional.empty();
+        }
+
+        MultiJoinNode multiJoinNode = toMultiJoinNode(joinNode, lookup);
+        return Optional.of(new JoinEnumerator(idAllocator, symbolAllocator, session, lookup, multiJoinNode.getFilter(), costComparator).chooseJoinOrder(multiJoinNode.getSources(), multiJoinNode.getOutputSymbols()));
+    }
+
+    @VisibleForTesting
+    public static class JoinEnumerator
+    {
+        private final Map<Set<PlanNode>, PlanNode> memo = new HashMap<>();
+        private final PlanNodeIdAllocator idAllocator;
+        private final Session session;
+        private final Ordering<PlanNode> planNodeOrdering;
+        private final EqualityInference allInference;
+        private final Expression allFilter;
+
+        public JoinEnumerator(PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Session session, Lookup lookup, Expression filter, CostComparator costComparator)
+        {
+            requireNonNull(idAllocator, "idAllocator is null");
+            requireNonNull(symbolAllocator, "symbolAllocator is null");
+            requireNonNull(session, "session is null");
+            requireNonNull(lookup, "lookup is null");
+            requireNonNull(filter, "filter is null");
+            requireNonNull(costComparator, "costComparator is null");
+            this.idAllocator = idAllocator;
+            this.session = session;
+            this.planNodeOrdering = getPlanNodeOrdering(costComparator, lookup, session, symbolAllocator);
+            this.allInference = createEqualityInference(filter);
+            this.allFilter = filter;
+        }
+
+        private static Ordering<PlanNode> getPlanNodeOrdering(CostComparator costComparator, Lookup lookup, Session session, SymbolAllocator symbolAllocator)
+        {
+            return new Ordering<PlanNode>()
+            {
+                @Override
+                public int compare(PlanNode node1, PlanNode node2)
+                {
+                    PlanNodeCostEstimate node1Cost = lookup.getCumulativeCost(node1, session, symbolAllocator.getTypes());
+                    PlanNodeCostEstimate node2Cost = lookup.getCumulativeCost(node2, session, symbolAllocator.getTypes());
+                    return costComparator.compare(session, node1Cost, node2Cost);
+                }
+            };
+        }
+
+        private PlanNode chooseJoinOrder(List<PlanNode> sources, List<Symbol> outputSymbols)
+        {
+            Set<PlanNode> multiJoinKey = ImmutableSet.copyOf(sources);
+            PlanNode node = memo.get(multiJoinKey);
+            if (node == null) {
+                checkState(sources.size() > 1);
+                node = generatePartitions(sources.size())
+                        .map(partitioning -> createJoinAccordingToPartitioning(sources, outputSymbols, partitioning))
+                        .filter(Optional::isPresent)
+                        .map(Optional::get)
+                        .min(planNodeOrdering)
+                        .orElseGet(() -> createCrossJoins(sources, outputSymbols));
+                log.debug("Least cost join was: " + node.toString());
+                memo.put(multiJoinKey, node);
+            }
+            return node;
+        }
+
+        /**
+         * This method produces a cross join of all the sources in multiJoinNode.
+         * This gets called once there are no longer edges between any of the join sources.
+         */
+        private PlanNode createCrossJoins(List<PlanNode> sources, List<Symbol> outputSymbols)
+        {
+            // cross joins cannot filter output symbols
+            PlanNode result = createJoin(
+                    ImmutableSet.of(sources.get(0)),
+                    ImmutableSet.copyOf(sources.subList(1, sources.size())),
+                    outputSymbols,
+                    true,
+                    this::createCrossJoins).orElseThrow(() -> new IllegalStateException("cross join not present"));
+            return result;
+        }
+
+        /**
+         * This method generates all the ways of dividing  totalNodes into two sets
+         * each containing at least one node. It will generate one set for each
+         * possible partitioning. The other partition is implied in the absent values.
+         * In order not to generate the inverse of any set, we always include the 0th
+         * node in our sets.
+         *
+         * @param totalNodes
+         * @return A set of sets each of which defines a partitioning of totalNodes
+         */
+        @VisibleForTesting
+        static Stream<Set<Integer>> generatePartitions(int totalNodes)
+        {
+            checkArgument(totalNodes >= 2, "totalNodes must be greater than or equal to 2");
+            Set<Integer> numbers = IntStream.range(0, totalNodes)
+                    .boxed()
+                    .collect(toImmutableSet());
+            return Sets.powerSet(numbers).stream()
+                    .filter(subSet -> subSet.contains(0))
+                    .filter(subSet -> subSet.size() < numbers.size());
+        }
+
+        @VisibleForTesting
+        Optional<PlanNode> createJoinAccordingToPartitioning(List<PlanNode> sources, List<Symbol> outputSymbols, Set<Integer> partitioning)
+        {
+            Set<PlanNode> leftSources = partitioning.stream()
+                    .map(sources::get)
+                    .collect(toImmutableSet());
+            Set<PlanNode> rightSources = Sets.difference(ImmutableSet.copyOf(sources), ImmutableSet.copyOf(leftSources));
+            return createJoin(leftSources, rightSources, outputSymbols, false, this::chooseJoinOrder);
+        }
+
+        private Optional<PlanNode> createJoin(
+                Set<PlanNode> leftSources,
+                Set<PlanNode> rightSources,
+                List<Symbol> outputSymbols,
+                boolean allowCrossJoins,
+                BiFunction<List<PlanNode>, List<Symbol>, PlanNode> joinCreationFunction)
+        {
+            Set<Symbol> leftSymbols = leftSources.stream()
+                    .flatMap(node -> node.getOutputSymbols().stream())
+                    .collect(toImmutableSet());
+            Set<Symbol> rightSymbols = rightSources.stream()
+                    .flatMap(node -> node.getOutputSymbols().stream())
+                    .collect(toImmutableSet());
+            ImmutableList.Builder<Expression> joinPredicatesBuilder = ImmutableList.builder();
+
+            // add join conjucts that were not used for inference
+            StreamSupport.stream(EqualityInference.nonInferrableConjuncts(allFilter).spliterator(), false)
+                    .map(conjuct -> allInference.rewriteExpression(conjuct, symbol -> leftSymbols.contains(symbol) || rightSymbols.contains(symbol)))
+                    .filter(Objects::nonNull)
+                    // filter expressions that contain only left or right symbols
+                    .filter(conjuct -> allInference.rewriteExpression(conjuct, leftSymbols::contains) == null)
+                    .filter(conjuct -> allInference.rewriteExpression(conjuct, rightSymbols::contains) == null)
+                    .forEach(joinPredicatesBuilder::add);
+
+            // create equality inference on available symbols
+            // TODO: make generateEqualitiesPartitionedBy take left and right scope
+            List<Expression> joinEqualities = allInference.generateEqualitiesPartitionedBy(symbol -> leftSymbols.contains(symbol) || rightSymbols.contains(symbol)).getScopeEqualities();
+            EqualityInference joinInference = createEqualityInference(joinEqualities.toArray(new Expression[joinEqualities.size()]));
+            joinPredicatesBuilder.addAll(joinInference.generateEqualitiesPartitionedBy(in(leftSymbols)).getScopeStraddlingEqualities());
+
+            List<Expression> joinPredicates = joinPredicatesBuilder.build();
+            List<JoinNode.EquiJoinClause> joinConditions = joinPredicates.stream()
+                    .filter(JoinEnumerator::isJoinEqualityCondition)
+                    .map(predicate -> toEquiJoinClause((ComparisonExpression) predicate, leftSymbols))
+                    .collect(toImmutableList());
+            if (!allowCrossJoins && joinConditions.isEmpty()) {
+                return Optional.empty();
+            }
+            List<Expression> joinFilters = joinPredicates.stream()
+                    .filter(predicate -> !isJoinEqualityCondition(predicate))
+                    .collect(toImmutableList());
+
+            Set<Symbol> requiredJoinSymbols = ImmutableSet.<Symbol>builder()
+                    .addAll(outputSymbols)
+                    .addAll(DependencyExtractor.extractUnique(joinPredicates))
+                    .build();
+            PlanNode left = getJoinSource(
+                    idAllocator,
+                    ImmutableList.copyOf(leftSources),
+                    requiredJoinSymbols.stream().filter(leftSymbols::contains).collect(toImmutableList()),
+                    joinCreationFunction);
+            PlanNode right = getJoinSource(
+                    idAllocator,
+                    ImmutableList.copyOf(rightSources),
+                    requiredJoinSymbols.stream()
+                            .filter(symbol -> !leftSymbols.contains(symbol))
+                            .collect(toImmutableList()),
+                    joinCreationFunction);
+
+            // sort output symbols so that the left input symbols are first
+            List<Symbol> sortedOutputSymbols = Stream.concat(left.getOutputSymbols().stream(), right.getOutputSymbols().stream())
+                    .filter(outputSymbols::contains)
+                    .collect(toImmutableList());
+
+            // Cross joins can't filter symbols as part of the join
+            // If we're doing a cross join, use all output symbols from the inputs and add a project node
+            // on top
+            List<Symbol> joinOutputSymbols = sortedOutputSymbols;
+            if (joinConditions.isEmpty() && joinFilters.isEmpty()) {
+                joinOutputSymbols = Stream.concat(left.getOutputSymbols().stream(), right.getOutputSymbols().stream())
+                        .collect(toImmutableList());
+            }
+
+            PlanNode result =
+                    setJoinNodeProperties(new JoinNode(
+                            idAllocator.getNextId(),
+                            INNER,
+                            left,
+                            right,
+                            joinConditions,
+                            joinOutputSymbols,
+                            joinFilters.isEmpty() ? Optional.empty() : Optional.of(and(joinFilters)),
+                            Optional.empty(),
+                            Optional.empty(),
+                            Optional.empty()));
+            if (!joinOutputSymbols.equals(sortedOutputSymbols)) {
+                result = new ProjectNode(idAllocator.getNextId(), result, identity(sortedOutputSymbols));
+            }
+            return Optional.of(result);
+        }
+
+        private PlanNode getJoinSource(PlanNodeIdAllocator idAllocator, List<PlanNode> nodes, List<Symbol> outputSymbols, BiFunction<List<PlanNode>, List<Symbol>, PlanNode> joinCreationFunction)
+        {
+            PlanNode planNode;
+            if (nodes.size() == 1) {
+                planNode = getOnlyElement(nodes);
+                Expression filter = combineConjuncts(allInference.generateEqualitiesPartitionedBy(outputSymbols::contains).getScopeEqualities());
+                if (!(TRUE_LITERAL).equals(filter)) {
+                    return new FilterNode(idAllocator.getNextId(), planNode, filter);
+                }
+                return planNode;
+            }
+            return joinCreationFunction.apply(nodes, outputSymbols);
+        }
+
+        private static boolean isJoinEqualityCondition(Expression expression)
+        {
+            return expression instanceof ComparisonExpression
+                    && ((ComparisonExpression) expression).getType() == EQUAL
+                    && ((ComparisonExpression) expression).getLeft() instanceof SymbolReference
+                    && ((ComparisonExpression) expression).getRight() instanceof SymbolReference;
+        }
+
+        private static JoinNode.EquiJoinClause toEquiJoinClause(ComparisonExpression equality, Set<Symbol> leftSymbols)
+        {
+            Symbol leftSymbol = Symbol.from(equality.getLeft());
+            Symbol rightSymbol = Symbol.from(equality.getRight());
+            JoinNode.EquiJoinClause equiJoinClause = new JoinNode.EquiJoinClause(leftSymbol, rightSymbol);
+            return leftSymbols.contains(leftSymbol) ? equiJoinClause : equiJoinClause.flip();
+        }
+
+        private JoinNode setJoinNodeProperties(JoinNode joinNode)
+        {
+            List<JoinNode> possibleJoinNodes = new ArrayList<>();
+            FeaturesConfig.JoinDistributionType joinDistributionType = getJoinDistributionType(session);
+            if (joinDistributionType.canRepartition()) {
+                possibleJoinNodes.add(joinNode.withDistributionType(PARTITIONED));
+                possibleJoinNodes.add(joinNode.flipChildren().withDistributionType(PARTITIONED));
+            }
+            if (joinDistributionType.canReplicate()) {
+                possibleJoinNodes.add(joinNode.withDistributionType(REPLICATED));
+                possibleJoinNodes.add(joinNode.flipChildren().withDistributionType(REPLICATED));
+            }
+
+            return planNodeOrdering.min(possibleJoinNodes);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ReorderJoins.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ReorderJoins.java
@@ -17,6 +17,7 @@ package com.facebook.presto.sql.planner.iterative.rule;
 import com.facebook.presto.Session;
 import com.facebook.presto.cost.CostComparator;
 import com.facebook.presto.cost.PlanNodeCostEstimate;
+import com.facebook.presto.cost.PlanNodeStatsEstimate;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.planner.DependencyExtractor;
 import com.facebook.presto.sql.planner.EqualityInference;
@@ -98,6 +99,10 @@ public class ReorderJoins
         }
 
         MultiJoinNode multiJoinNode = toMultiJoinNode(joinNode, lookup);
+        if(multiJoinNode.getSources().stream()
+                .anyMatch(source -> lookup.getStats(source, session, symbolAllocator.getTypes()).equals(PlanNodeStatsEstimate.UNKNOWN_STATS))) {
+            return Optional.empty();
+        }
         return Optional.of(new JoinEnumerator(idAllocator, symbolAllocator, session, lookup, multiJoinNode.getFilter(), costComparator).chooseJoinOrder(multiJoinNode.getSources(), multiJoinNode.getOutputSymbols()));
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/DetermineJoinDistributionType.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/DetermineJoinDistributionType.java
@@ -111,6 +111,9 @@ public class DetermineJoinDistributionType
 
         private JoinNode.DistributionType getTargetJoinDistributionType(JoinNode node)
         {
+            if (node.getDistributionType().isPresent()) {
+                return node.getDistributionType().get();
+            }
             // The implementation of full outer join only works if the data is hash partitioned. See LookupJoinOperators#buildSideOuterJoinUnvisitedPositions
             JoinNode.Type type = node.getType();
             if (type == RIGHT || type == FULL || (isRepartitionedJoinEnabled(session) && !mustBroadcastJoin(node))) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/DetermineJoinDistributionType.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/DetermineJoinDistributionType.java
@@ -27,7 +27,7 @@ import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.facebook.presto.SystemSessionProperties.isDistributedJoinEnabled;
+import static com.facebook.presto.SystemSessionProperties.getJoinDistributionType;
 import static com.facebook.presto.sql.planner.optimizations.ScalarQueryUtil.isScalar;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.FULL;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
@@ -113,7 +113,7 @@ public class DetermineJoinDistributionType
         {
             // The implementation of full outer join only works if the data is hash partitioned. See LookupJoinOperators#buildSideOuterJoinUnvisitedPositions
             JoinNode.Type type = node.getType();
-            if (type == RIGHT || type == FULL || (isDistributedJoinEnabled(session) && !mustBroadcastJoin(node))) {
+            if (type == RIGHT || type == FULL || (isRepartitionedJoinEnabled(session) && !mustBroadcastJoin(node))) {
                 return JoinNode.DistributionType.PARTITIONED;
             }
 
@@ -132,11 +132,16 @@ public class DetermineJoinDistributionType
 
         private SemiJoinNode.DistributionType getTargetSemiJoinDistributionType(boolean isDeleteQuery)
         {
-            if (isDistributedJoinEnabled(session) && !isDeleteQuery) {
+            if (isRepartitionedJoinEnabled(session) && !isDeleteQuery) {
                 return SemiJoinNode.DistributionType.PARTITIONED;
             }
 
             return SemiJoinNode.DistributionType.REPLICATED;
+        }
+
+        private static boolean isRepartitionedJoinEnabled(Session session)
+        {
+            return getJoinDistributionType(session).canRepartition();
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/EliminateCrossJoins.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/EliminateCrossJoins.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.sql.planner.optimizations;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.SystemSessionProperties;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
@@ -28,6 +27,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import static com.facebook.presto.SystemSessionProperties.getJoinReorderingStrategy;
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStrategy.ELIMINATE_CROSS_JOINS;
 import static com.facebook.presto.sql.planner.iterative.rule.EliminateCrossJoins.buildJoinTree;
 import static com.facebook.presto.sql.planner.iterative.rule.EliminateCrossJoins.getJoinOrder;
 import static com.facebook.presto.sql.planner.iterative.rule.EliminateCrossJoins.isOriginalOrder;
@@ -47,7 +48,7 @@ public class EliminateCrossJoins
             SymbolAllocator symbolAllocator,
             PlanNodeIdAllocator idAllocator)
     {
-        if (!SystemSessionProperties.isJoinReorderingEnabled(session)) {
+        if (getJoinReorderingStrategy(session) != ELIMINATE_CROSS_JOINS) {
             return plan;
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -715,17 +715,10 @@ public class PredicatePushDown
         {
             ImmutableList.Builder<Expression> builder = ImmutableList.builder();
             for (JoinNode.EquiJoinClause equiJoinClause : joinNode.getCriteria()) {
-                builder.add(equalsExpression(equiJoinClause.getLeft(), equiJoinClause.getRight()));
+                builder.add(equiJoinClause.toExpression());
             }
             joinNode.getFilter().ifPresent(builder::add);
             return combineConjuncts(builder.build());
-        }
-
-        private static Expression equalsExpression(Symbol symbol1, Symbol symbol2)
-        {
-            return new ComparisonExpression(ComparisonExpressionType.EQUAL,
-                    symbol1.toSymbolReference(),
-                    symbol2.toSymbolReference());
         }
 
         private Type extractType(Expression expression)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
@@ -14,6 +14,8 @@
 package com.facebook.presto.sql.planner.plan;
 
 import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.tree.ComparisonExpression;
+import com.facebook.presto.sql.tree.ComparisonExpressionType;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.Join;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -252,6 +254,11 @@ public class JoinNode
         public Symbol getRight()
         {
             return right;
+        }
+
+        public ComparisonExpression toExpression()
+        {
+            return new ComparisonExpression(ComparisonExpressionType.EQUAL, left.toSymbolReference(), right.toSymbolReference());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -474,9 +474,7 @@ public class PlanPrinter
         {
             List<Expression> joinExpressions = new ArrayList<>();
             for (JoinNode.EquiJoinClause clause : node.getCriteria()) {
-                joinExpressions.add(new ComparisonExpression(ComparisonExpressionType.EQUAL,
-                        clause.getLeft().toSymbolReference(),
-                        clause.getRight().toSymbolReference()));
+                joinExpressions.add(clause.toExpression());
             }
             node.getFilter().ifPresent(expression -> joinExpressions.add(expression));
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowStatsRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowStatsRewrite.java
@@ -101,6 +101,8 @@ public class ShowStatsRewrite
 
     private static final String COLUMN_NAME_COLUMN = "column_name";
     private static final String NULLS_FRACTION_COLUMN = "nulls_fraction";
+    private static final String LOW_VALUE_COLUMN = "low_value";
+    private static final String HIGH_VALUE_COLUMN = "high_value";
 
     @Override
     public Statement rewrite(Session session, Metadata metadata, SqlParser parser, Optional<QueryExplainer> queryExplainer, Statement node, List<Expression> parameters, AccessControl accessControl)
@@ -321,6 +323,8 @@ public class ShowStatsRewrite
                                     .collect(toList()))
                             .add(NULLS_FRACTION_COLUMN)
                             .build()));
+            columnNamesBuilder.add(LOW_VALUE_COLUMN);
+            columnNamesBuilder.add(HIGH_VALUE_COLUMN);
             return columnNamesBuilder.build();
         }
 
@@ -333,6 +337,12 @@ public class ShowStatsRewrite
                 switch (statColumnName) {
                     case COLUMN_NAME_COLUMN:
                         rowValues.add(new StringLiteral(columnName));
+                        break;
+                    case LOW_VALUE_COLUMN:
+                        rowValues.add(asVarcharLiteral(columnType, rangeStatistics.getLowValue()));
+                        break;
+                    case HIGH_VALUE_COLUMN:
+                        rowValues.add(asVarcharLiteral(columnType, rangeStatistics.getHighValue()));
                         break;
                     case NULLS_FRACTION_COLUMN:
                         rowValues.add(createStatisticValueOrNull(columnStatistics.getNullsFraction()));
@@ -364,6 +374,8 @@ public class ShowStatsRewrite
             for (String columnName : columnNames) {
                 switch (columnName) {
                     case COLUMN_NAME_COLUMN:
+                    case LOW_VALUE_COLUMN:
+                    case HIGH_VALUE_COLUMN:
                         rowValues.add(new Cast(new NullLiteral(), VARCHAR));
                         break;
                     case NULLS_FRACTION_COLUMN:

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowStatsRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowStatsRewrite.java
@@ -14,12 +14,10 @@
 package com.facebook.presto.sql.rewrite;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.cost.TypeStatOperatorCaller;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.QualifiedObjectName;
-import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.metadata.TableHandle;
-import com.facebook.presto.operator.scalar.ScalarFunctionImplementation;
 import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.Constraint;
@@ -29,12 +27,10 @@ import com.facebook.presto.spi.statistics.Estimate;
 import com.facebook.presto.spi.statistics.RangeColumnStatistics;
 import com.facebook.presto.spi.statistics.TableStatistics;
 import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.spi.type.VarcharType;
 import com.facebook.presto.sql.QueryUtil;
 import com.facebook.presto.sql.analyzer.QueryExplainer;
 import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.parser.SqlParser;
-import com.facebook.presto.sql.planner.ExpressionInterpreter;
 import com.facebook.presto.sql.planner.Plan;
 import com.facebook.presto.sql.planner.plan.TableScanNode;
 import com.facebook.presto.sql.tree.AllColumns;
@@ -64,7 +60,6 @@ import com.facebook.presto.sql.tree.Table;
 import com.facebook.presto.sql.tree.TableSubquery;
 import com.facebook.presto.sql.tree.Values;
 import com.google.common.collect.ImmutableList;
-import io.airlift.slice.Slice;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -86,7 +81,6 @@ import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.sea
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.sortedCopyOf;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static java.util.Collections.singletonList;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
@@ -360,11 +354,9 @@ public class ShowStatsRewrite
             if (!value.isPresent()) {
                 return new Cast(new NullLiteral(), VARCHAR);
             }
-            FunctionRegistry functionRegistry = metadata.getFunctionRegistry();
-            Signature castSignature = functionRegistry.getCoercion(valueType, VarcharType.createUnboundedVarcharType());
-            ScalarFunctionImplementation castImplementation = functionRegistry.getScalarFunctionImplementation(castSignature);
-            Slice varcharValue = (Slice) ExpressionInterpreter.invoke(session.toConnectorSession(), castImplementation, singletonList(value.get()));
-            return new StringLiteral(varcharValue.toStringUtf8());
+
+            TypeStatOperatorCaller operatorCaller = new TypeStatOperatorCaller(valueType, metadata.getFunctionRegistry(), session.toConnectorSession());
+            return new StringLiteral(operatorCaller.castToVarchar(value.get()).toStringUtf8());
         }
 
         private static Expression createTableStatsRow(List<String> columnNames, TableStatistics tableStatistics)

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -29,7 +29,6 @@ import com.facebook.presto.connector.system.NodeSystemTable;
 import com.facebook.presto.connector.system.SchemaPropertiesSystemTable;
 import com.facebook.presto.connector.system.TablePropertiesSystemTable;
 import com.facebook.presto.connector.system.TransactionsSystemTable;
-import com.facebook.presto.cost.CoefficientBasedStatsCalculator;
 import com.facebook.presto.cost.CostCalculator;
 import com.facebook.presto.cost.CostCalculatorUsingExchanges;
 import com.facebook.presto.cost.CostCalculatorWithEstimatedExchanges;
@@ -89,6 +88,7 @@ import com.facebook.presto.operator.index.IndexJoinLookupStats;
 import com.facebook.presto.operator.project.InterpretedPageProjection;
 import com.facebook.presto.operator.project.PageProcessor;
 import com.facebook.presto.operator.project.PageProjection;
+import com.facebook.presto.server.ServerMainModule;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorPageSource;
@@ -371,7 +371,7 @@ public class LocalQueryRunner
 
         SpillerStats spillerStats = new SpillerStats();
         this.spillerFactory = new GenericSpillerFactory(new FileSingleStreamSpillerFactory(blockEncodingSerde, spillerStats, featuresConfig));
-        this.statsCalculator = new CoefficientBasedStatsCalculator(metadata);
+        this.statsCalculator = ServerMainModule.createStatsCalculator(metadata);
         this.costCalculator = new CostCalculatorUsingExchanges(getNodeCount());
         this.estimatedExchangesCostCalculator = new CostCalculatorWithEstimatedExchanges(costCalculator, getNodeCount());
         this.lookup = new StatelessLookup(statsCalculator, costCalculator);

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -34,6 +34,7 @@ import com.facebook.presto.cost.CostCalculatorUsingExchanges;
 import com.facebook.presto.cost.CostCalculatorWithEstimatedExchanges;
 import com.facebook.presto.cost.CostComparator;
 import com.facebook.presto.cost.FilterStatsCalculator;
+import com.facebook.presto.cost.ScalarStatsCalculator;
 import com.facebook.presto.cost.StatsCalculator;
 import com.facebook.presto.execution.CommitTask;
 import com.facebook.presto.execution.CreateTableTask;
@@ -372,7 +373,7 @@ public class LocalQueryRunner
 
         SpillerStats spillerStats = new SpillerStats();
         this.spillerFactory = new GenericSpillerFactory(new FileSingleStreamSpillerFactory(blockEncodingSerde, spillerStats, featuresConfig));
-        this.statsCalculator = ServerMainModule.createStatsCalculator(metadata, new FilterStatsCalculator(metadata));
+        this.statsCalculator = ServerMainModule.createStatsCalculator(metadata, new FilterStatsCalculator(metadata), new ScalarStatsCalculator(metadata));
         this.costCalculator = new CostCalculatorUsingExchanges(getNodeCount());
         this.estimatedExchangesCostCalculator = new CostCalculatorWithEstimatedExchanges(costCalculator, getNodeCount());
         this.lookup = new StatelessLookup(statsCalculator, costCalculator);

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -33,6 +33,7 @@ import com.facebook.presto.cost.CostCalculator;
 import com.facebook.presto.cost.CostCalculatorUsingExchanges;
 import com.facebook.presto.cost.CostCalculatorWithEstimatedExchanges;
 import com.facebook.presto.cost.CostComparator;
+import com.facebook.presto.cost.FilterStatsCalculator;
 import com.facebook.presto.cost.StatsCalculator;
 import com.facebook.presto.execution.CommitTask;
 import com.facebook.presto.execution.CreateTableTask;
@@ -371,7 +372,7 @@ public class LocalQueryRunner
 
         SpillerStats spillerStats = new SpillerStats();
         this.spillerFactory = new GenericSpillerFactory(new FileSingleStreamSpillerFactory(blockEncodingSerde, spillerStats, featuresConfig));
-        this.statsCalculator = ServerMainModule.createStatsCalculator(metadata);
+        this.statsCalculator = ServerMainModule.createStatsCalculator(metadata, new FilterStatsCalculator(metadata));
         this.costCalculator = new CostCalculatorUsingExchanges(getNodeCount());
         this.estimatedExchangesCostCalculator = new CostCalculatorWithEstimatedExchanges(costCalculator, getNodeCount());
         this.lookup = new StatelessLookup(statsCalculator, costCalculator);

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingLookup.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingLookup.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.testing;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.cost.CostCalculator;
+import com.facebook.presto.cost.PlanNodeCostEstimate;
+import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.cost.StatsCalculator;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.GroupReference;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import static java.util.Objects.requireNonNull;
+
+public class TestingLookup
+        implements Lookup
+{
+    private final StatsCalculator statsCalculator;
+    private final CostCalculator costCalculator;
+    private final Map<PlanNode, PlanNodeStatsEstimate> stats = new HashMap<>();
+    private final Map<PlanNode, PlanNodeCostEstimate> costs = new HashMap<>();
+    private final Function<GroupReference, PlanNode> resolver;
+
+    public TestingLookup(StatsCalculator statsCalculator, CostCalculator costCalculator, Function<GroupReference, PlanNode> resolver)
+    {
+        this(statsCalculator, costCalculator, ImmutableMap.of(), ImmutableMap.of(), resolver);
+    }
+
+    private TestingLookup(StatsCalculator statsCalculator, CostCalculator costCalculator, Map<PlanNode, PlanNodeStatsEstimate> stats, Map<PlanNode, PlanNodeCostEstimate> costs, Function<GroupReference, PlanNode> resolver)
+    {
+        this.statsCalculator = requireNonNull(statsCalculator, "statsCalculator is null");
+        this.costCalculator = requireNonNull(costCalculator, "costCalculator is null");
+        this.stats.putAll(stats);
+        this.costs.putAll(costs);
+        this.resolver = requireNonNull(resolver, "resolver is null");
+    }
+
+    public TestingLookup withStats(Map<PlanNode, PlanNodeStatsEstimate> stats)
+    {
+        return new TestingLookup(statsCalculator, costCalculator, stats, costs, resolver);
+    }
+
+    @Override
+    public PlanNode resolve(PlanNode node)
+    {
+        if (node instanceof GroupReference) {
+            return resolver.apply((GroupReference) node);
+        }
+        return node;
+    }
+
+    @Override
+    public PlanNodeStatsEstimate getStats(PlanNode planNode, Session session, Map<Symbol, Type> types)
+    {
+        PlanNode resolved = resolve(planNode);
+        PlanNodeStatsEstimate statsEstimate = stats.get(resolved);
+        if (statsEstimate == null) {
+            statsEstimate = statsCalculator.calculateStats(resolved, this, session, types);
+            stats.put(resolved, statsEstimate);
+        }
+        return statsEstimate;
+    }
+
+    @Override
+    public PlanNodeCostEstimate getCumulativeCost(PlanNode planNode, Session session, Map<Symbol, Type> types)
+    {
+        PlanNode resolved = resolve(planNode);
+        PlanNodeCostEstimate costEstimate = costs.get(resolved);
+        if (costEstimate == null) {
+            costEstimate = costCalculator.calculateCost(resolved, this, session, types);
+            costs.put(resolved, costEstimate);
+        }
+        return costEstimate;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingLookup.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingLookup.java
@@ -87,7 +87,7 @@ public class TestingLookup
         PlanNode resolved = resolve(planNode);
         PlanNodeCostEstimate costEstimate = costs.get(resolved);
         if (costEstimate == null) {
-            costEstimate = costCalculator.calculateCost(resolved, this, session, types);
+            costEstimate = costCalculator.calculateCumulativeCost(resolved, this, session, types);
             costs.put(resolved, costEstimate);
         }
         return costEstimate;

--- a/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
@@ -437,9 +437,7 @@ public final class GraphvizPrinter
         {
             List<Expression> joinExpressions = new ArrayList<>();
             for (JoinNode.EquiJoinClause clause : node.getCriteria()) {
-                joinExpressions.add(new ComparisonExpression(ComparisonExpressionType.EQUAL,
-                        clause.getLeft().toSymbolReference(),
-                        clause.getRight().toSymbolReference()));
+                joinExpressions.add(clause.toExpression());
             }
 
             String criteria = Joiner.on(" AND ").join(joinExpressions);

--- a/presto-main/src/test/java/com/facebook/presto/cost/PlanNodeStatsAssertion.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/PlanNodeStatsAssertion.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cost;
+
+import com.facebook.presto.sql.planner.Symbol;
+
+import java.util.function.Consumer;
+
+import static com.google.common.collect.Sets.union;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class PlanNodeStatsAssertion
+{
+    private final PlanNodeStatsEstimate actual;
+
+    private PlanNodeStatsAssertion(PlanNodeStatsEstimate actual)
+    {
+        this.actual = actual;
+    }
+
+    public static PlanNodeStatsAssertion assertThat(PlanNodeStatsEstimate actual)
+    {
+        return new PlanNodeStatsAssertion(actual);
+    }
+
+    public PlanNodeStatsAssertion outputRowsCount(double expected)
+    {
+        assertEquals(actual.getOutputRowCount(), expected, "outputRowsCount mismatch");
+        return this;
+    }
+
+    public PlanNodeStatsAssertion outputRowsCountUnknown()
+    {
+        assertTrue(Double.isNaN(actual.getOutputRowCount()), "expected unknown outputRowsCount but got " + actual.getOutputRowCount());
+        return this;
+    }
+
+    public PlanNodeStatsAssertion symbolStats(String symbolName, Consumer<SymbolStatsAssertion> symbolStatsAssertionConsumer)
+    {
+        return symbolStats(new Symbol(symbolName), symbolStatsAssertionConsumer);
+    }
+
+    public PlanNodeStatsAssertion symbolStats(Symbol symbol, Consumer<SymbolStatsAssertion> columnAssertionConsumer)
+    {
+        SymbolStatsAssertion columnAssertion = SymbolStatsAssertion.assertThat(actual.getSymbolStatistics(symbol));
+        columnAssertionConsumer.accept(columnAssertion);
+        return this;
+    }
+
+    public PlanNodeStatsAssertion symbolStatsUnknown(String symbolName)
+    {
+        return symbolStatsUnknown(new Symbol(symbolName));
+    }
+
+    public PlanNodeStatsAssertion symbolStatsUnknown(Symbol symbol)
+    {
+        return symbolStats(symbol,
+                columnStats -> columnStats
+                        .lowValueUnknown()
+                        .highValueUnknown()
+                        .nullsFractionUnknown()
+                        .distinctValuesCountUnknown());
+    }
+
+    public PlanNodeStatsAssertion equalTo(PlanNodeStatsEstimate expected)
+    {
+        assertEquals(actual.getOutputRowCount(), expected.getOutputRowCount());
+
+        for (Symbol symbol : union(expected.getSymbolStatistics().keySet(), actual.getSymbolStatistics().keySet())) {
+            assertSymbolStatsEqual(symbol, actual.getSymbolStatistics(symbol), expected.getSymbolStatistics(symbol));
+        }
+        return this;
+    }
+
+    private void assertSymbolStatsEqual(Symbol symbol, SymbolStatsEstimate actual, SymbolStatsEstimate expected)
+    {
+        assertEquals(actual.getNullsFraction(), expected.getNullsFraction(), "nullsFraction mismatch for " + symbol.getName());
+        assertEquals(actual.getLowValue(), expected.getLowValue(), "lowValue mismatch for " + symbol.getName());
+        assertEquals(actual.getHighValue(), expected.getHighValue(), "lowValue mismatch for " + symbol.getName());
+        assertEquals(actual.getDistinctValuesCount(), expected.getDistinctValuesCount(), "lowValue mismatch for " + symbol.getName());
+        assertEquals(actual.getDataSize(), expected.getDataSize(), "datasize mismatch for " + symbol.getName());
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/cost/StatsCalculatorAssertion.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/StatsCalculatorAssertion.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cost;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import static com.facebook.presto.cost.PlanNodeCostEstimate.INFINITE_COST;
+import static com.facebook.presto.cost.PlanNodeStatsEstimate.UNKNOWN_STATS;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+public class StatsCalculatorAssertion
+{
+    private final StatsCalculator statsCalculator;
+    private final PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
+    private final Metadata metadata;
+    private final Session session;
+    private PlanNode planNode;
+    private Map<PlanNode, PlanNodeStatsEstimate> sourcesStats;
+    private Map<Symbol, Type> types;
+
+    public StatsCalculatorAssertion(StatsCalculator statsCalculator, Metadata metadata, Session session)
+    {
+        this.statsCalculator = requireNonNull(statsCalculator, "statsCalculator can not be null");
+        this.metadata = requireNonNull(metadata, "metadata can not be null");
+        this.session = requireNonNull(session, "sesssion can not be null");
+    }
+
+    public StatsCalculatorAssertion on(Function<PlanBuilder, PlanNode> planProvider)
+    {
+        PlanBuilder planBuilder = new PlanBuilder(idAllocator, metadata);
+        this.planNode = planProvider.apply(planBuilder);
+        this.sourcesStats = new HashMap<>();
+        this.planNode.getSources().forEach(child -> sourcesStats.put(child, UNKNOWN_STATS));
+        this.types = planBuilder.getSymbols();
+        return this;
+    }
+
+    public StatsCalculatorAssertion withSourceStats(Consumer<PlanNodeStatsEstimate.Builder> sourceStatsBuilderConsumer)
+    {
+        checkPlanNodeSet();
+        checkState(planNode.getSources().size() == 1, "expected single source");
+        return withSourceStats(0, sourceStatsBuilderConsumer);
+    }
+
+    public StatsCalculatorAssertion withSourceStats(PlanNodeStatsEstimate sourceStats)
+    {
+        checkPlanNodeSet();
+        checkState(planNode.getSources().size() == 1, "expected single source");
+        return withSourceStats(0, sourceStats);
+    }
+
+    public StatsCalculatorAssertion withSourceStats(int sourceIndex, Consumer<PlanNodeStatsEstimate.Builder> sourceStatsBuilderConsumer)
+    {
+        PlanNodeStatsEstimate.Builder sourceStatsBuilder = PlanNodeStatsEstimate.builder();
+        sourceStatsBuilderConsumer.accept(sourceStatsBuilder);
+        return withSourceStats(sourceIndex, sourceStatsBuilder.build());
+    }
+
+    public StatsCalculatorAssertion withSourceStats(int sourceIndex, PlanNodeStatsEstimate sourceStats)
+    {
+        checkPlanNodeSet();
+        checkArgument(sourceIndex < planNode.getSources().size(), "invalid sourceIndex %s; planNode has %s sources", sourceIndex, planNode.getSources().size());
+        sourcesStats.put(planNode.getSources().get(sourceIndex), sourceStats);
+        return this;
+    }
+
+    public StatsCalculatorAssertion check(Consumer<PlanNodeStatsAssertion> statisticsAssertionConsumer)
+    {
+        PlanNodeStatsEstimate statsEstimate = statsCalculator.calculateStats(planNode, mockLookup(), session, types);
+        statisticsAssertionConsumer.accept(PlanNodeStatsAssertion.assertThat(statsEstimate));
+        return this;
+    }
+
+    private void checkPlanNodeSet()
+    {
+        checkState(planNode != null, "tested planNode not set yet");
+    }
+
+    private Lookup mockLookup()
+    {
+        return new Lookup()
+        {
+            @Override
+            public PlanNode resolve(PlanNode node)
+            {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public PlanNodeStatsEstimate getStats(PlanNode node, Session session, Map<Symbol, Type> types)
+            {
+                checkArgument(sourcesStats.containsKey(node), "stats not found for source %s", node);
+                return sourcesStats.get(node);
+            }
+
+            @Override
+            public PlanNodeCostEstimate getCumulativeCost(PlanNode node, Session session, Map<Symbol, Type> types)
+            {
+                return INFINITE_COST;
+            }
+        };
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/cost/StatsCalculatorTester.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/StatsCalculatorTester.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cost;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.facebook.presto.tpch.TpchConnectorFactory;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.function.Function;
+
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+
+public class StatsCalculatorTester
+{
+    private final StatsCalculator statsCalculator;
+    private final Metadata metadata;
+    private final Session session;
+
+    public StatsCalculatorTester()
+    {
+        this(createQueryRunner());
+    }
+
+    private StatsCalculatorTester(LocalQueryRunner queryRunner)
+    {
+        this.statsCalculator = queryRunner.getStatsCalculator();
+        this.session = queryRunner.getDefaultSession();
+        this.metadata = queryRunner.getMetadata();
+    }
+
+    private static LocalQueryRunner createQueryRunner()
+    {
+        Session session = testSessionBuilder().build();
+
+        LocalQueryRunner queryRunner = new LocalQueryRunner(session);
+        queryRunner.createCatalog(session.getCatalog().get(),
+                new TpchConnectorFactory(1),
+                ImmutableMap.<String, String>of());
+        return queryRunner;
+    }
+
+    public StatsCalculatorAssertion assertStatsFor(Function<PlanBuilder, PlanNode> planProvider)
+    {
+        return new StatsCalculatorAssertion(statsCalculator, metadata, session).on(planProvider);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/cost/SymbolStatsAssertion.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/SymbolStatsAssertion.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cost;
+
+import static java.lang.Double.NEGATIVE_INFINITY;
+import static java.lang.Double.POSITIVE_INFINITY;
+import static java.lang.Double.isNaN;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class SymbolStatsAssertion
+{
+    private final SymbolStatsEstimate statistics;
+
+    private SymbolStatsAssertion(SymbolStatsEstimate statistics)
+    {
+        this.statistics = statistics;
+    }
+
+    public static SymbolStatsAssertion assertThat(SymbolStatsEstimate actual)
+    {
+        return new SymbolStatsAssertion(actual);
+    }
+
+    public SymbolStatsAssertion nullsFraction(double expected)
+    {
+        // we bind nullsFraction and nonNullsFraction together
+        assertEquals(statistics.getNullsFraction(), expected, "nullsFraction mismatch");
+        return this;
+    }
+
+    public SymbolStatsAssertion nullsFractionUnknown()
+    {
+        // we bind nullsFraction and nonNullsFraction together
+        assertTrue(isNaN(statistics.getNullsFraction()), "expected unknown nullsFraction but got " + statistics.getNullsFraction());
+        return this;
+    }
+
+    public SymbolStatsAssertion lowValue(Object expected)
+    {
+        assertEquals(statistics.getLowValue(), expected, "lowValue mismatch");
+        return this;
+    }
+
+    public SymbolStatsAssertion lowValueUnknown()
+    {
+        return lowValue(NEGATIVE_INFINITY);
+    }
+
+    public SymbolStatsAssertion highValue(Object expected)
+    {
+        assertEquals(statistics.getHighValue(), expected, "highValue mismatch");
+        return this;
+    }
+
+    public SymbolStatsAssertion highValueUnknown()
+    {
+        return highValue(POSITIVE_INFINITY);
+    }
+
+    public SymbolStatsAssertion distinctValuesCount(double expected)
+    {
+        assertEquals(statistics.getDistinctValuesCount(), expected, "distinctValuesCount mismatch");
+        return this;
+    }
+
+    public SymbolStatsAssertion distinctValuesCountUnknown()
+    {
+        assertTrue(isNaN(statistics.getDistinctValuesCount()), "expected unknown distinctValuesCount but got " + statistics.getDistinctValuesCount());
+        return this;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
@@ -246,7 +246,12 @@ public class TestCostCalculator
     {
         return PlanNodeStatsEstimate.builder()
                 .setOutputRowCount(Math.max(outputSizeInBytes / 8, 1))
-                .setOutputSizeInBytes(outputSizeInBytes).build();
+                .addSymbolStatistics(
+                        new Symbol("s"),
+                        SymbolStatsEstimate.builder()
+                                .setDataSize(outputSizeInBytes)
+                                .build())
+                .build();
     }
 
     private TableScanNode tableScan(int planNodeId, String... symbols)

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestOutputNodeStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestOutputNodeStats.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cost;
+
+import com.facebook.presto.sql.planner.Symbol;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static java.lang.Double.POSITIVE_INFINITY;
+
+public class TestOutputNodeStats
+{
+    private StatsCalculatorTester tester;
+
+    @BeforeMethod
+    public void setUp()
+            throws Exception
+    {
+        tester = new StatsCalculatorTester();
+    }
+
+    @Test
+    public void testStatsForOutputNode()
+            throws Exception
+    {
+        PlanNodeStatsEstimate stats = PlanNodeStatsEstimate.builder()
+                .setOutputRowCount(100)
+                .addSymbolStatistics(
+                        new Symbol("a"),
+                        SymbolStatsEstimate.builder()
+                                .setNullsFraction(0.3)
+                                .setLowValue(1)
+                                .setHighValue(10)
+                                .setDistinctValuesCount(20)
+                                .build())
+                .addSymbolStatistics(
+                        new Symbol("b"),
+                        SymbolStatsEstimate.builder()
+                                .setNullsFraction(0.6)
+                                .setLowValue(13.5)
+                                .setHighValue(POSITIVE_INFINITY)
+                                .setDistinctValuesCount(40)
+                                .build())
+                .build();
+
+        tester.assertStatsFor(pb -> pb
+                .output(outputBuilder -> {
+                    Symbol a = pb.symbol("a", BIGINT);
+                    Symbol b = pb.symbol("b", DOUBLE);
+                    outputBuilder
+                            .source(pb.values(a, b))
+                            .column(a, "a1")
+                            .column(a, "a2")
+                            .column(b, "b");
+                }))
+                .withSourceStats(stats)
+                .check(outputStats -> outputStats.equalTo(stats));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestScalarStatsCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestScalarStatsCalculator.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cost;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.tree.Expression;
+import org.testng.annotations.BeforeMethod;
+
+import java.util.Map;
+
+import static com.facebook.presto.cost.PlanNodeStatsEstimate.UNKNOWN_STATS;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static java.util.Collections.emptyMap;
+
+public class TestScalarStatsCalculator
+{
+    private ScalarStatsCalculator calculator;
+    private Session session;
+
+    @BeforeMethod
+    public void setUp()
+            throws Exception
+    {
+        calculator = new ScalarStatsCalculator(MetadataManager.createTestMetadataManager());
+        session = testSessionBuilder().build();
+    }
+
+    private SymbolStatsAssertion assertCalculate(Expression scalarExpression)
+    {
+        return assertCalculate(scalarExpression, UNKNOWN_STATS);
+    }
+
+    private SymbolStatsAssertion assertCalculate(Expression scalarExpression, PlanNodeStatsEstimate inputStatistics)
+    {
+        return assertCalculate(scalarExpression, inputStatistics, emptyMap());
+    }
+
+    private SymbolStatsAssertion assertCalculate(Expression scalarExpression, PlanNodeStatsEstimate inputStatistics, Map<Symbol, Type> types)
+    {
+        return SymbolStatsAssertion.assertThat(calculator.calculate(scalarExpression, inputStatistics, session, types));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestScalarStatsCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestScalarStatsCalculator.java
@@ -17,13 +17,19 @@ import com.facebook.presto.Session;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.tree.DecimalLiteral;
+import com.facebook.presto.sql.tree.DoubleLiteral;
 import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.NullLiteral;
+import com.facebook.presto.sql.tree.StringLiteral;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import java.util.Map;
 
 import static com.facebook.presto.cost.PlanNodeStatsEstimate.UNKNOWN_STATS;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static io.airlift.slice.Slices.utf8Slice;
 import static java.util.Collections.emptyMap;
 
 public class TestScalarStatsCalculator
@@ -52,5 +58,33 @@ public class TestScalarStatsCalculator
     private SymbolStatsAssertion assertCalculate(Expression scalarExpression, PlanNodeStatsEstimate inputStatistics, Map<Symbol, Type> types)
     {
         return SymbolStatsAssertion.assertThat(calculator.calculate(scalarExpression, inputStatistics, session, types));
+    }
+
+    @Test
+    public void testLiteral()
+    {
+        assertCalculate(new DoubleLiteral("7.5"))
+                .distinctValuesCount(1.0)
+                .lowValue(7.5)
+                .highValue(7.5)
+                .nullsFraction(0.0);
+
+        assertCalculate(new DecimalLiteral("7.5"))
+                .distinctValuesCount(1.0)
+                .lowValue(75L)
+                .highValue(75L)
+                .nullsFraction(0.0);
+
+        assertCalculate(new StringLiteral("blah"))
+                .distinctValuesCount(1.0)
+                .lowValue(utf8Slice("blah"))
+                .highValue(utf8Slice("blah"))
+                .nullsFraction(0.0);
+
+        assertCalculate(new NullLiteral())
+                .distinctValuesCount(0.0)
+                .lowValueUnknown()
+                .highValueUnknown()
+                .nullsFraction(1.0);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
@@ -18,7 +18,6 @@ import com.facebook.presto.ScheduledSplit;
 import com.facebook.presto.TaskSource;
 import com.facebook.presto.block.BlockEncodingManager;
 import com.facebook.presto.connector.ConnectorId;
-import com.facebook.presto.cost.CoefficientBasedStatsCalculator;
 import com.facebook.presto.cost.CostCalculatorUsingExchanges;
 import com.facebook.presto.execution.TestSqlTaskManager.MockExchangeClientSupplier;
 import com.facebook.presto.execution.scheduler.LegacyNetworkTopology;
@@ -32,6 +31,7 @@ import com.facebook.presto.metadata.TableHandle;
 import com.facebook.presto.operator.LookupJoinOperators;
 import com.facebook.presto.operator.PagesIndex;
 import com.facebook.presto.operator.index.IndexJoinLookupStats;
+import com.facebook.presto.server.ServerMainModule;
 import com.facebook.presto.spi.block.TestingBlockEncodingSerde;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.predicate.TupleDomain;
@@ -128,7 +128,7 @@ public final class TaskTestUtils
         return new LocalExecutionPlanner(
                 metadata,
                 new SqlParser(),
-                new CoefficientBasedStatsCalculator(metadata),
+                ServerMainModule.createStatsCalculator(metadata),
                 new CostCalculatorUsingExchanges(1),
                 Optional.empty(),
                 pageSourceManager,

--- a/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
@@ -20,6 +20,7 @@ import com.facebook.presto.block.BlockEncodingManager;
 import com.facebook.presto.connector.ConnectorId;
 import com.facebook.presto.cost.CostCalculatorUsingExchanges;
 import com.facebook.presto.cost.FilterStatsCalculator;
+import com.facebook.presto.cost.ScalarStatsCalculator;
 import com.facebook.presto.execution.TestSqlTaskManager.MockExchangeClientSupplier;
 import com.facebook.presto.execution.scheduler.LegacyNetworkTopology;
 import com.facebook.presto.execution.scheduler.NodeScheduler;
@@ -129,7 +130,7 @@ public final class TaskTestUtils
         return new LocalExecutionPlanner(
                 metadata,
                 new SqlParser(),
-                ServerMainModule.createStatsCalculator(metadata, new FilterStatsCalculator(metadata)),
+                ServerMainModule.createStatsCalculator(metadata, new FilterStatsCalculator(metadata), new ScalarStatsCalculator(metadata)),
                 new CostCalculatorUsingExchanges(1),
                 Optional.empty(),
                 pageSourceManager,

--- a/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
@@ -19,6 +19,7 @@ import com.facebook.presto.TaskSource;
 import com.facebook.presto.block.BlockEncodingManager;
 import com.facebook.presto.connector.ConnectorId;
 import com.facebook.presto.cost.CostCalculatorUsingExchanges;
+import com.facebook.presto.cost.FilterStatsCalculator;
 import com.facebook.presto.execution.TestSqlTaskManager.MockExchangeClientSupplier;
 import com.facebook.presto.execution.scheduler.LegacyNetworkTopology;
 import com.facebook.presto.execution.scheduler.NodeScheduler;
@@ -128,7 +129,7 @@ public final class TaskTestUtils
         return new LocalExecutionPlanner(
                 metadata,
                 new SqlParser(),
-                ServerMainModule.createStatsCalculator(metadata),
+                ServerMainModule.createStatsCalculator(metadata, new FilterStatsCalculator(metadata)),
                 new CostCalculatorUsingExchanges(1),
                 Optional.empty(),
                 pageSourceManager,

--- a/presto-main/src/test/java/com/facebook/presto/server/TestHttpRequestSessionFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestHttpRequestSessionFactory.java
@@ -27,8 +27,8 @@ import javax.ws.rs.WebApplicationException;
 
 import java.util.Locale;
 
-import static com.facebook.presto.SystemSessionProperties.DISTRIBUTED_JOIN;
 import static com.facebook.presto.SystemSessionProperties.HASH_PARTITION_COUNT;
+import static com.facebook.presto.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
 import static com.facebook.presto.SystemSessionProperties.QUERY_MAX_MEMORY;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_CATALOG;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_CLIENT_INFO;
@@ -59,7 +59,7 @@ public class TestHttpRequestSessionFactory
                         .put(PRESTO_TIME_ZONE, "Asia/Taipei")
                         .put(PRESTO_CLIENT_INFO, "client-info")
                         .put(PRESTO_SESSION, QUERY_MAX_MEMORY + "=1GB")
-                        .put(PRESTO_SESSION, DISTRIBUTED_JOIN + "=true," + HASH_PARTITION_COUNT + " = 43")
+                        .put(PRESTO_SESSION, JOIN_DISTRIBUTION_TYPE + "=repartitioned," + HASH_PARTITION_COUNT + " = 43")
                         .put(PRESTO_PREPARED_STATEMENT, "query1=select * from foo,query2=select * from bar")
                         .build(),
                 "testRemote");
@@ -82,7 +82,7 @@ public class TestHttpRequestSessionFactory
         assertEquals(session.getClientInfo().get(), "client-info");
         assertEquals(session.getSystemProperties(), ImmutableMap.<String, String>builder()
                 .put(QUERY_MAX_MEMORY, "1GB")
-                .put(DISTRIBUTED_JOIN, "true")
+                .put(JOIN_DISTRIBUTION_TYPE, "repartitioned")
                 .put(HASH_PARTITION_COUNT, "43")
                 .build());
         assertEquals(session.getPreparedStatements(), ImmutableMap.<String, String>builder()

--- a/presto-main/src/test/java/com/facebook/presto/server/TestServer.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestServer.java
@@ -35,8 +35,8 @@ import org.testng.annotations.Test;
 import java.net.URI;
 import java.util.List;
 
-import static com.facebook.presto.SystemSessionProperties.DISTRIBUTED_JOIN;
 import static com.facebook.presto.SystemSessionProperties.HASH_PARTITION_COUNT;
+import static com.facebook.presto.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
 import static com.facebook.presto.SystemSessionProperties.QUERY_MAX_MEMORY;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_CATALOG;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_CLIENT_INFO;
@@ -134,7 +134,7 @@ public class TestServer
                 .setHeader(PRESTO_SCHEMA, "schema")
                 .setHeader(PRESTO_CLIENT_INFO, "{\"clientVersion\":\"testVersion\"}")
                 .addHeader(PRESTO_SESSION, QUERY_MAX_MEMORY + "=1GB")
-                .addHeader(PRESTO_SESSION, DISTRIBUTED_JOIN + "=true," + HASH_PARTITION_COUNT + " = 43")
+                .addHeader(PRESTO_SESSION, JOIN_DISTRIBUTION_TYPE + "=repartitioned," + HASH_PARTITION_COUNT + " = 43")
                 .addHeader(PRESTO_PREPARED_STATEMENT, "foo=select * from bar")
                 .build();
 
@@ -146,7 +146,7 @@ public class TestServer
         // verify session properties
         assertEquals(queryInfo.getSession().getSystemProperties(), ImmutableMap.builder()
                 .put(QUERY_MAX_MEMORY, "1GB")
-                .put(DISTRIBUTED_JOIN, "true")
+                .put(JOIN_DISTRIBUTION_TYPE, "repartitioned")
                 .put(HASH_PARTITION_COUNT, "43")
                 .build());
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -21,6 +21,8 @@ import org.testng.annotations.Test;
 
 import java.util.Map;
 
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType.REPARTITIONED;
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType.REPLICATED;
 import static com.facebook.presto.sql.analyzer.RegexLibrary.JONI;
 import static com.facebook.presto.sql.analyzer.RegexLibrary.RE2J;
 import static io.airlift.configuration.testing.ConfigAssertions.assertDeprecatedEquivalence;
@@ -40,7 +42,7 @@ public class TestFeaturesConfig
                 .setNetworkCostWeight(0.25)
                 .setResourceGroupsEnabled(false)
                 .setDistributedIndexJoinsEnabled(false)
-                .setDistributedJoinsEnabled(true)
+                .setJoinDistributionType(REPARTITIONED)
                 .setFastInequalityJoins(true)
                 .setColocatedJoinsEnabled(false)
                 .setJoinReorderingEnabled(true)
@@ -83,7 +85,7 @@ public class TestFeaturesConfig
                 .put("deprecated.legacy-order-by", "true")
                 .put("deprecated.legacy-map-subscript", "true")
                 .put("distributed-index-joins-enabled", "true")
-                .put("distributed-joins-enabled", "false")
+                .put("join-distribution-type", "REPLICATED")
                 .put("fast-inequality-joins", "false")
                 .put("colocated-joins-enabled", "true")
                 .put("reorder-joins", "false")
@@ -117,7 +119,7 @@ public class TestFeaturesConfig
                 .put("deprecated.legacy-order-by", "true")
                 .put("deprecated.legacy-map-subscript", "true")
                 .put("distributed-index-joins-enabled", "true")
-                .put("distributed-joins-enabled", "false")
+                .put("join-distribution-type", "REPLICATED")
                 .put("fast-inequality-joins", "false")
                 .put("colocated-joins-enabled", "true")
                 .put("reorder-joins", "false")
@@ -149,7 +151,7 @@ public class TestFeaturesConfig
                 .setIterativeOptimizerEnabled(false)
                 .setIterativeOptimizerTimeout(new Duration(10, SECONDS))
                 .setDistributedIndexJoinsEnabled(true)
-                .setDistributedJoinsEnabled(false)
+                .setJoinDistributionType(REPLICATED)
                 .setFastInequalityJoins(false)
                 .setColocatedJoinsEnabled(true)
                 .setJoinReorderingEnabled(false)

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -23,6 +23,8 @@ import java.util.Map;
 
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType.REPARTITIONED;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType.REPLICATED;
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStrategy.ELIMINATE_CROSS_JOINS;
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStrategy.NONE;
 import static com.facebook.presto.sql.analyzer.RegexLibrary.JONI;
 import static com.facebook.presto.sql.analyzer.RegexLibrary.RE2J;
 import static io.airlift.configuration.testing.ConfigAssertions.assertDeprecatedEquivalence;
@@ -45,7 +47,7 @@ public class TestFeaturesConfig
                 .setJoinDistributionType(REPARTITIONED)
                 .setFastInequalityJoins(true)
                 .setColocatedJoinsEnabled(false)
-                .setJoinReorderingEnabled(true)
+                .setJoinReorderingStrategy(ELIMINATE_CROSS_JOINS)
                 .setRedistributeWrites(true)
                 .setOptimizeMetadataQueries(false)
                 .setOptimizeHashGeneration(true)
@@ -88,7 +90,7 @@ public class TestFeaturesConfig
                 .put("join-distribution-type", "REPLICATED")
                 .put("fast-inequality-joins", "false")
                 .put("colocated-joins-enabled", "true")
-                .put("reorder-joins", "false")
+                .put("join-reordering-strategy", "NONE")
                 .put("redistribute-writes", "false")
                 .put("optimizer.optimize-metadata-queries", "true")
                 .put("optimizer.optimize-hash-generation", "false")
@@ -122,7 +124,7 @@ public class TestFeaturesConfig
                 .put("join-distribution-type", "REPLICATED")
                 .put("fast-inequality-joins", "false")
                 .put("colocated-joins-enabled", "true")
-                .put("reorder-joins", "false")
+                .put("join-reordering-strategy", "NONE")
                 .put("redistribute-writes", "false")
                 .put("optimizer.optimize-metadata-queries", "true")
                 .put("optimizer.optimize-hash-generation", "false")
@@ -154,7 +156,7 @@ public class TestFeaturesConfig
                 .setJoinDistributionType(REPLICATED)
                 .setFastInequalityJoins(false)
                 .setColocatedJoinsEnabled(true)
-                .setJoinReorderingEnabled(false)
+                .setJoinReorderingStrategy(NONE)
                 .setRedistributeWrites(false)
                 .setOptimizeMetadataQueries(true)
                 .setOptimizeHashGeneration(false)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/JoinMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/JoinMatcher.java
@@ -37,12 +37,14 @@ final class JoinMatcher
     private final JoinNode.Type joinType;
     private final List<ExpectedValueProvider<JoinNode.EquiJoinClause>> equiCriteria;
     private final Optional<Expression> filter;
+    private final Optional<JoinNode.DistributionType> distributionType;
 
-    JoinMatcher(JoinNode.Type joinType, List<ExpectedValueProvider<JoinNode.EquiJoinClause>> equiCriteria, Optional<Expression> filter)
+    JoinMatcher(JoinNode.Type joinType, List<ExpectedValueProvider<JoinNode.EquiJoinClause>> equiCriteria, Optional<Expression> filter, Optional<JoinNode.DistributionType> distributionType)
     {
         this.joinType = requireNonNull(joinType, "joinType is null");
         this.equiCriteria = requireNonNull(equiCriteria, "equiCriteria is null");
         this.filter = requireNonNull(filter, "filter can not be null");
+        this.distributionType = requireNonNull(distributionType, "distribtuionType cannot be null");
     }
 
     @Override
@@ -79,6 +81,10 @@ final class JoinMatcher
             if (joinNode.getFilter().isPresent()) {
                 return NO_MATCH;
             }
+        }
+
+        if (distributionType.isPresent() && !distributionType.equals(joinNode.getDistributionType())) {
+            return NO_MATCH;
         }
 
         /*

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -242,11 +242,17 @@ public final class PlanMatchPattern
 
     public static PlanMatchPattern join(JoinNode.Type joinType, List<ExpectedValueProvider<JoinNode.EquiJoinClause>> expectedEquiCriteria, Optional<String> expectedFilter, PlanMatchPattern left, PlanMatchPattern right)
     {
+        return join(joinType, expectedEquiCriteria, expectedFilter, Optional.empty(), left, right);
+    }
+
+    public static PlanMatchPattern join(JoinNode.Type joinType, List<ExpectedValueProvider<JoinNode.EquiJoinClause>> expectedEquiCriteria, Optional<String> expectedFilter, Optional<JoinNode.DistributionType> distributionType, PlanMatchPattern left, PlanMatchPattern right)
+    {
         return node(JoinNode.class, left, right).with(
                 new JoinMatcher(
                         joinType,
                         expectedEquiCriteria,
-                        expectedFilter.map(predicate -> rewriteIdentifiersToSymbolReferences(new SqlParser().createExpression(predicate)))));
+                        expectedFilter.map(predicate -> rewriteIdentifiersToSymbolReferences(new SqlParser().createExpression(predicate))),
+                        distributionType));
     }
 
     public static PlanMatchPattern exchange(PlanMatchPattern... sources)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -339,7 +339,7 @@ public final class PlanMatchPattern
         return values(aliasToIndex, Optional.empty(), Optional.empty());
     }
 
-    public static PlanMatchPattern values(String ... aliases)
+    public static PlanMatchPattern values(String... aliases)
     {
         return values(ImmutableList.copyOf(aliases));
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/BenchmarkReorderJoins.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/BenchmarkReorderJoins.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tpch.TpchConnectorFactory;
+import com.google.common.collect.ImmutableMap;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.google.common.base.Preconditions.checkState;
+import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.openjdk.jmh.annotations.Mode.AverageTime;
+import static org.openjdk.jmh.annotations.Scope.Thread;
+
+@State(Thread)
+@OutputTimeUnit(MILLISECONDS)
+@BenchmarkMode(AverageTime)
+@Fork(3)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+public class BenchmarkReorderJoins
+{
+    @Benchmark
+    public MaterializedResult benchmarkReorderJoins(BenchmarkInfo benchmarkInfo)
+    {
+        return benchmarkInfo.getQueryRunner().execute(benchmarkInfo.getQuery());
+    }
+
+    @State(Thread)
+    public static class BenchmarkInfo
+    {
+        @Param({"ELIMINATE_CROSS_JOINS", "COST_BASED"})
+        private String joinReorderingStrategy;
+
+        @Param({"2", "4", "6", "8", "10"})
+        private int numberOfTables;
+
+        private String query;
+        private LocalQueryRunner queryRunner;
+
+        @Setup
+        public void setup()
+        {
+            checkState(numberOfTables >= 2, "numberOfTables must be >= 2");
+            Session session = testSessionBuilder()
+                    .setSystemProperty("join_reordering_strategy", joinReorderingStrategy)
+                    .setSystemProperty("join_distribution_type", "AUTOMATIC")
+                    .setCatalog("tpch")
+                    .setSchema("tiny")
+                    .build();
+            queryRunner = new LocalQueryRunner(session);
+            queryRunner.createCatalog("tpch", new TpchConnectorFactory(1), ImmutableMap.of());
+            StringBuilder stringBuilder = new StringBuilder();
+            stringBuilder.append("EXPLAIN SELECT * FROM NATION n1");
+            for (int i = 2; i <= numberOfTables; i++) {
+                stringBuilder.append(format(" JOIN nation n%s on n%s.nationkey = n%s.nationkey", i, i - 1, i));
+            }
+            query = stringBuilder.toString();
+        }
+
+        public String getQuery()
+        {
+            return query;
+        }
+
+        public QueryRunner getQueryRunner()
+        {
+            return queryRunner;
+        }
+
+        @TearDown
+        public void tearDown()
+        {
+            queryRunner.close();
+        }
+    }
+
+    public static void main(String[] args)
+            throws RunnerException
+    {
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkReorderJoins.class.getSimpleName() + ".*")
+                .build();
+
+        new Runner(options).run();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestEliminateCrossJoins.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestEliminateCrossJoins.java
@@ -35,7 +35,7 @@ import java.util.Arrays;
 import java.util.Optional;
 import java.util.function.Function;
 
-import static com.facebook.presto.SystemSessionProperties.REORDER_JOINS;
+import static com.facebook.presto.SystemSessionProperties.JOIN_REORDERING_STRATEGY;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.any;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
@@ -62,7 +62,7 @@ public class TestEliminateCrossJoins
     public void testEliminateCrossJoin()
     {
         tester.assertThat(new EliminateCrossJoins())
-                .setSystemProperty(REORDER_JOINS, "true")
+                .setSystemProperty(JOIN_REORDERING_STRATEGY, "ELIMINATE_CROSS_JOINS")
                 .on(crossJoinAndJoin(INNER))
                 .matches(
                         project(
@@ -83,7 +83,7 @@ public class TestEliminateCrossJoins
     public void testRetainOutgoingGroupReferences()
     {
         tester.assertThat(new EliminateCrossJoins())
-                .setSystemProperty(REORDER_JOINS, "true")
+                .setSystemProperty(JOIN_REORDERING_STRATEGY, "ELIMINATE_CROSS_JOINS")
                 .on(crossJoinAndJoin(INNER))
                 .matches(
                         any(
@@ -102,7 +102,7 @@ public class TestEliminateCrossJoins
     public void testDoNotReorderOuterJoin()
     {
         tester.assertThat(new EliminateCrossJoins())
-                .setSystemProperty(REORDER_JOINS, "true")
+                .setSystemProperty(JOIN_REORDERING_STRATEGY, "ELIMINATE_CROSS_JOINS")
                 .on(crossJoinAndJoin(JoinNode.Type.LEFT))
                 .doesNotFire();
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestJoinEnumerator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestJoinEnumerator.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.cost.CostComparator;
+import com.facebook.presto.sql.planner.Plan;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.tree.ComparisonExpression;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.SymbolReference;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.sql.ExpressionUtils.and;
+import static com.facebook.presto.sql.planner.assertions.PlanAssert.assertPlan;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.sql.planner.iterative.rule.ReorderJoins.JoinEnumerator.generatePartitions;
+import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
+import static com.facebook.presto.sql.tree.ComparisonExpressionType.EQUAL;
+import static com.facebook.presto.sql.tree.ComparisonExpressionType.GREATER_THAN;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.airlift.testing.Closeables.closeAllRuntimeException;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestJoinEnumerator
+{
+    private LocalQueryRunner queryRunner;
+
+    @BeforeClass
+    public void setUp()
+    {
+        queryRunner = new LocalQueryRunner(testSessionBuilder().build());
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        closeAllRuntimeException(queryRunner);
+        queryRunner = null;
+    }
+
+    @Test
+    public void testGeneratePartitions()
+    {
+        Set<Set<Integer>> partitions = generatePartitions(4).collect(toImmutableSet());
+        assertEquals(partitions,
+                ImmutableSet.of(
+                        ImmutableSet.of(0),
+                        ImmutableSet.of(0, 1),
+                        ImmutableSet.of(0, 2),
+                        ImmutableSet.of(0, 3),
+                        ImmutableSet.of(0, 1, 2),
+                        ImmutableSet.of(0, 1, 3),
+                        ImmutableSet.of(0, 2, 3)));
+
+        partitions = generatePartitions(3).collect(toImmutableSet());
+        assertEquals(partitions,
+                ImmutableSet.of(
+                        ImmutableSet.of(0),
+                        ImmutableSet.of(0, 1),
+                        ImmutableSet.of(0, 2)));
+    }
+
+    @Test
+    public void testCreatesJoinAccordingToPartitioning()
+    {
+        Session session = testSessionBuilder().build();
+        LocalQueryRunner queryRunner = new LocalQueryRunner(session);
+        PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
+        PlanBuilder planBuilder = new PlanBuilder(idAllocator, queryRunner.getMetadata());
+        Expression filter =
+                and(
+                        new ComparisonExpression(EQUAL, new SymbolReference("A1"), new SymbolReference("B1")),
+                        new ComparisonExpression(EQUAL, new SymbolReference("B1"), new SymbolReference("D1")),
+                        new ComparisonExpression(GREATER_THAN, planBuilder.symbol("A1", BIGINT).toSymbolReference(), planBuilder.symbol("C1", BIGINT).toSymbolReference()));
+        MultiJoinNode multiJoinNode = new MultiJoinNode(
+                ImmutableList.of(
+                        planBuilder.values(planBuilder.symbol("A1", BIGINT)),
+                        planBuilder.values(planBuilder.symbol("B1", BIGINT)),
+                        planBuilder.values(planBuilder.symbol("C1", BIGINT)),
+                        planBuilder.values(planBuilder.symbol("D1", BIGINT))),
+                filter,
+                ImmutableList.of());
+        ReorderJoins.JoinEnumerator joinEnumerator = new ReorderJoins.JoinEnumerator(
+                idAllocator,
+                new SymbolAllocator(),
+                queryRunner.getDefaultSession(),
+                queryRunner.getLookup(),
+                multiJoinNode.getFilter(),
+                new CostComparator(1, 1, 1));
+        Optional<PlanNode> actual = joinEnumerator.createJoinAccordingToPartitioning(multiJoinNode.getSources(), multiJoinNode.getOutputSymbols(), ImmutableSet.of(0, 2));
+        assertTrue(actual.isPresent());
+        assertPlan(
+                session,
+                queryRunner.getMetadata(),
+                queryRunner.getLookup(),
+                new Plan(actual.get(), planBuilder.getSymbols(), queryRunner.getLookup(), queryRunner.getDefaultSession()),
+                join(
+                        JoinNode.Type.INNER,
+                        ImmutableList.of(equiJoinClause("A1", "B1")),
+                        Optional.empty(),
+                        Optional.empty(),
+                        join(
+                                JoinNode.Type.INNER,
+                                ImmutableList.of(),
+                                Optional.of("A1 > C1"),
+                                values(ImmutableMap.of("A1", 0)),
+                                values(ImmutableMap.of("C1", 0))),
+                        join(
+                                JoinNode.Type.INNER,
+                                ImmutableList.of(equiJoinClause("B1", "D1")),
+                                values(ImmutableMap.of("B1", 0)),
+                                values(ImmutableMap.of("D1", 0)))));
+    }
+
+    @Test
+    public void testDoesNotCreateJoinWhenPartitionedOnCrossJoin()
+    {
+        PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
+        PlanBuilder planBuilder = new PlanBuilder(idAllocator, queryRunner.getMetadata());
+        Symbol a1 = planBuilder.symbol("A1", BIGINT);
+        Symbol b1 = planBuilder.symbol("B1", BIGINT);
+        MultiJoinNode multiJoinNode = new MultiJoinNode(
+                ImmutableList.of(planBuilder.values(a1), planBuilder.values(b1)),
+                TRUE_LITERAL,
+                ImmutableList.of(a1, b1));
+        ReorderJoins.JoinEnumerator joinEnumerator = new ReorderJoins.JoinEnumerator(
+                idAllocator,
+                new SymbolAllocator(),
+                queryRunner.getDefaultSession(),
+                queryRunner.getLookup(),
+                multiJoinNode.getFilter(),
+                new CostComparator(1, 1, 1));
+        Optional<PlanNode> actual = joinEnumerator.createJoinAccordingToPartitioning(multiJoinNode.getSources(), multiJoinNode.getOutputSymbols(), ImmutableSet.of(0));
+        assertFalse(actual.isPresent());
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestMultiJoinNodeBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestMultiJoinNodeBuilder.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.ValuesNode;
+import com.facebook.presto.sql.tree.ArithmeticBinaryExpression;
+import com.facebook.presto.sql.tree.ComparisonExpression;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.LongLiteral;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.sql.ExpressionUtils.and;
+import static com.facebook.presto.sql.planner.iterative.rule.MultiJoinNode.toMultiJoinNode;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.LEFT;
+import static com.facebook.presto.sql.tree.ArithmeticBinaryExpression.Type.ADD;
+import static com.facebook.presto.sql.tree.ComparisonExpressionType.EQUAL;
+import static com.facebook.presto.sql.tree.ComparisonExpressionType.GREATER_THAN;
+import static com.facebook.presto.sql.tree.ComparisonExpressionType.LESS_THAN;
+import static com.facebook.presto.sql.tree.ComparisonExpressionType.NOT_EQUAL;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static org.testng.Assert.assertEquals;
+
+public class TestMultiJoinNodeBuilder
+{
+    private final LocalQueryRunner queryRunner = new LocalQueryRunner(testSessionBuilder().build());
+
+    @Test(expectedExceptions = IllegalStateException.class)
+    public void testDoesNotFireForOuterJoins()
+    {
+        PlanBuilder p = new PlanBuilder(new PlanNodeIdAllocator(), queryRunner.getMetadata());
+        JoinNode outerJoin = p.join(
+                JoinNode.Type.FULL,
+                p.values(p.symbol("A1", BIGINT)),
+                p.values(p.symbol("B1", BIGINT)),
+                ImmutableList.of(new JoinNode.EquiJoinClause(p.symbol("A1", BIGINT), p.symbol("B1", BIGINT))),
+                ImmutableList.of(p.symbol("A1", BIGINT), p.symbol("B1", BIGINT)),
+                Optional.empty());
+        toMultiJoinNode(outerJoin, queryRunner.getLookup());
+    }
+
+    @Test
+    public void testDoesNotConvertNestedOuterJoins()
+    {
+        PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
+        PlanBuilder planBuilder = new PlanBuilder(idAllocator, queryRunner.getMetadata());
+        Symbol a1 = planBuilder.symbol("A1", BIGINT);
+        Symbol b1 = planBuilder.symbol("B1", BIGINT);
+        Symbol c1 = planBuilder.symbol("C1", BIGINT);
+        JoinNode leftJoin = planBuilder.join(
+                LEFT,
+                planBuilder.values(a1),
+                planBuilder.values(b1),
+                ImmutableList.of(new JoinNode.EquiJoinClause(a1, b1)),
+                ImmutableList.of(a1, b1),
+                Optional.empty());
+        ValuesNode valuesC = planBuilder.values(c1);
+        JoinNode joinNode = planBuilder.join(
+                INNER,
+                leftJoin,
+                valuesC,
+                ImmutableList.of(new JoinNode.EquiJoinClause(a1, c1)),
+                ImmutableList.of(a1, b1, c1),
+                Optional.empty());
+
+        MultiJoinNode expected = new MultiJoinNode(ImmutableList.of(leftJoin, valuesC), new ComparisonExpression(EQUAL, a1.toSymbolReference(), c1.toSymbolReference()), ImmutableList.of(a1, b1, c1));
+        assertEquals(toMultiJoinNode(joinNode, queryRunner.getLookup()), expected);
+    }
+
+    @Test
+    public void testRetainsOutputSymbols()
+    {
+        PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
+        PlanBuilder planBuilder = new PlanBuilder(idAllocator, queryRunner.getMetadata());
+        Symbol a1 = planBuilder.symbol("A1", BIGINT);
+        Symbol b1 = planBuilder.symbol("B1", BIGINT);
+        Symbol b2 = planBuilder.symbol("B2", BIGINT);
+        Symbol c1 = planBuilder.symbol("C1", BIGINT);
+        Symbol c2 = planBuilder.symbol("C2", BIGINT);
+        ValuesNode valuesA = planBuilder.values(a1);
+        ValuesNode valuesB = planBuilder.values(b1, b2);
+        ValuesNode valuesC = planBuilder.values(c1, c2);
+        JoinNode joinNode = planBuilder.join(
+                INNER,
+                valuesA,
+                planBuilder.join(
+                        INNER,
+                        valuesB,
+                        valuesC,
+                        ImmutableList.of(new JoinNode.EquiJoinClause(b1, c1)),
+                        ImmutableList.of(
+                                b1,
+                                b2,
+                                c1,
+                                c2),
+                        Optional.empty()),
+                ImmutableList.of(new JoinNode.EquiJoinClause(a1, b1)),
+                ImmutableList.of(a1, b1),
+                Optional.empty());
+        MultiJoinNode expected = new MultiJoinNode(
+                ImmutableList.of(valuesA, valuesB, valuesC),
+                and(new ComparisonExpression(EQUAL, b1.toSymbolReference(), c1.toSymbolReference()), new ComparisonExpression(EQUAL, a1.toSymbolReference(), b1.toSymbolReference())),
+                ImmutableList.of(a1, b1));
+        assertEquals(toMultiJoinNode(joinNode, queryRunner.getLookup()), expected);
+    }
+
+    @Test
+    public void testCombinesCriteriaAndFilters()
+    {
+        PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
+        PlanBuilder planBuilder = new PlanBuilder(idAllocator, queryRunner.getMetadata());
+        Symbol a1 = planBuilder.symbol("A1", BIGINT);
+        Symbol b1 = planBuilder.symbol("B1", BIGINT);
+        Symbol b2 = planBuilder.symbol("B2", BIGINT);
+        Symbol c1 = planBuilder.symbol("C1", BIGINT);
+        Symbol c2 = planBuilder.symbol("C2", BIGINT);
+        ValuesNode valuesA = planBuilder.values(a1);
+        ValuesNode valuesB = planBuilder.values(b1, b2);
+        ValuesNode valuesC = planBuilder.values(c1, c2);
+        Expression bcFilter = and(
+                new ComparisonExpression(GREATER_THAN, c2.toSymbolReference(), new LongLiteral("0")),
+                new ComparisonExpression(NOT_EQUAL, c2.toSymbolReference(), new LongLiteral("7")),
+                new ComparisonExpression(GREATER_THAN, b2.toSymbolReference(), c2.toSymbolReference()));
+        ComparisonExpression abcFilter = new ComparisonExpression(
+                LESS_THAN,
+                new ArithmeticBinaryExpression(ADD, a1.toSymbolReference(), c1.toSymbolReference()),
+                b1.toSymbolReference());
+        JoinNode joinNode = planBuilder.join(
+                INNER,
+                valuesA,
+                planBuilder.join(
+                        INNER,
+                        valuesB,
+                        valuesC,
+                        ImmutableList.of(new JoinNode.EquiJoinClause(b1, c1)),
+                        ImmutableList.of(
+                                b1,
+                                b2,
+                                c1,
+                                c2),
+                        Optional.of(bcFilter)),
+                ImmutableList.of(new JoinNode.EquiJoinClause(a1, b1)),
+                ImmutableList.of(a1, b1, b2, c1, c2),
+                Optional.of(abcFilter));
+        MultiJoinNode expected = new MultiJoinNode(
+                ImmutableList.of(valuesA, valuesB, valuesC),
+                and(new ComparisonExpression(EQUAL, b1.toSymbolReference(), c1.toSymbolReference()), new ComparisonExpression(EQUAL, a1.toSymbolReference(), b1.toSymbolReference()), bcFilter, abcFilter),
+                ImmutableList.of(a1, b1, b2, c1, c2));
+        assertEquals(toMultiJoinNode(joinNode, queryRunner.getLookup()), expected);
+    }
+
+    @Test
+    public void testConvertsBushyTrees()
+    {
+        PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
+        PlanBuilder planBuilder = new PlanBuilder(idAllocator, queryRunner.getMetadata());
+        Symbol a1 = planBuilder.symbol("A1", BIGINT);
+        Symbol b1 = planBuilder.symbol("B1", BIGINT);
+        Symbol c1 = planBuilder.symbol("C1", BIGINT);
+        Symbol d1 = planBuilder.symbol("D1", BIGINT);
+        Symbol d2 = planBuilder.symbol("D2", BIGINT);
+        Symbol e1 = planBuilder.symbol("E1", BIGINT);
+        Symbol e2 = planBuilder.symbol("E2", BIGINT);
+        ValuesNode valuesA = planBuilder.values(a1);
+        ValuesNode valuesB = planBuilder.values(b1);
+        ValuesNode valuesC = planBuilder.values(c1);
+        ValuesNode valuesD = planBuilder.values(d1, d2);
+        ValuesNode valuesE = planBuilder.values(e1, e2);
+        JoinNode joinNode = planBuilder.join(
+                INNER,
+                planBuilder.join(
+                        INNER,
+                        planBuilder.join(
+                                INNER,
+                                valuesA,
+                                valuesB,
+                                ImmutableList.of(new JoinNode.EquiJoinClause(a1, b1)),
+                                ImmutableList.of(a1, b1),
+                                Optional.empty()),
+                        valuesC,
+                        ImmutableList.of(new JoinNode.EquiJoinClause(a1, c1)),
+                        ImmutableList.of(a1, b1, c1),
+                        Optional.empty()),
+                planBuilder.join(
+                        INNER,
+                        valuesD,
+                        valuesE,
+                        ImmutableList.of(
+                                new JoinNode.EquiJoinClause(d1, e1),
+                                new JoinNode.EquiJoinClause(d2, e2)),
+                        ImmutableList.of(
+                                d1,
+                                d2,
+                                e1,
+                                e2),
+                        Optional.empty()),
+                ImmutableList.of(new JoinNode.EquiJoinClause(b1, e1)),
+                ImmutableList.of(
+                        a1,
+                        b1,
+                        c1,
+                        d1,
+                        d2,
+                        e1,
+                        e2),
+                Optional.empty());
+        MultiJoinNode expected = new MultiJoinNode(
+                ImmutableList.of(valuesA, valuesB, valuesC, valuesD, valuesE),
+                and(
+                        new ComparisonExpression(EQUAL, a1.toSymbolReference(), b1.toSymbolReference()),
+                        new ComparisonExpression(EQUAL, a1.toSymbolReference(), c1.toSymbolReference()),
+                        new ComparisonExpression(EQUAL, d1.toSymbolReference(), e1.toSymbolReference()),
+                        new ComparisonExpression(EQUAL, d2.toSymbolReference(), e2.toSymbolReference()),
+                        new ComparisonExpression(EQUAL, b1.toSymbolReference(), e1.toSymbolReference())),
+                ImmutableList.of(a1, b1, c1, d1, d2, e1, e2));
+        assertEquals(toMultiJoinNode(joinNode, queryRunner.getLookup()), expected);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestReorderJoins.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestReorderJoins.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.cost.CostComparator;
+import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.PlanNodeId;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.sql.planner.plan.JoinNode.DistributionType.PARTITIONED;
+import static com.facebook.presto.sql.planner.plan.JoinNode.DistributionType.REPLICATED;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
+import static com.facebook.presto.testing.LocalQueryRunner.queryRunnerWithFakeNodeCountForStats;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static io.airlift.testing.Closeables.closeAllRuntimeException;
+
+public class TestReorderJoins
+{
+    private RuleTester tester;
+
+    @BeforeClass
+    public void setUp()
+    {
+        Session session = testSessionBuilder()
+                .setCatalog("local")
+                .setSchema("tiny")
+                .setSystemProperty("join_distribution_type", "automatic")
+                .setSystemProperty("join_reordering_strategy", "COST_BASED")
+                .build();
+        LocalQueryRunner queryRunner = queryRunnerWithFakeNodeCountForStats(session, 4);
+        tester = new RuleTester(queryRunner);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        closeAllRuntimeException(tester);
+        tester = null;
+    }
+
+    @Test
+    public void testChoosesLeastCostOrder()
+    {
+        tester.assertThat(new ReorderJoins(new CostComparator(1, 1, 1)))
+                .on(p ->
+                        p.join(
+                                INNER,
+                                p.values(new PlanNodeId("valuesA"), p.symbol("A1", BIGINT)),
+                                p.join(
+                                        INNER,
+                                        p.values(new PlanNodeId("valuesB"), p.symbol("B1", BIGINT), p.symbol("B2", BIGINT)),
+                                        p.values(new PlanNodeId("ValuesC"), p.symbol("C1", BIGINT)),
+                                        ImmutableList.of(new JoinNode.EquiJoinClause(p.symbol("B1", BIGINT), p.symbol("C1", BIGINT))),
+                                        ImmutableList.of(p.symbol("B1", BIGINT)),
+                                        Optional.empty()),
+                                ImmutableList.of(new JoinNode.EquiJoinClause(p.symbol("A1", BIGINT), p.symbol("B2", BIGINT))),
+                                ImmutableList.of(p.symbol("A1", BIGINT), p.symbol("B1", BIGINT)),
+                                Optional.empty()))
+                .withStats(ImmutableMap.of(
+                        new PlanNodeId("valuesA"), PlanNodeStatsEstimate.builder().setOutputRowCount(10).build(),
+                        new PlanNodeId("valuesB"), PlanNodeStatsEstimate.builder().setOutputRowCount(10).build(),
+                        new PlanNodeId("ValuesC"), PlanNodeStatsEstimate.builder().setOutputRowCount(1000).build()))
+                .matches(join(
+                        INNER,
+                        ImmutableList.of(equiJoinClause("C1", "B1")),
+                        Optional.empty(),
+                        Optional.of(REPLICATED),
+                        values(ImmutableMap.of("C1", 0)),
+                        join(
+                                INNER,
+                                ImmutableList.of(equiJoinClause("A1", "B2")),
+                                Optional.empty(),
+                                Optional.of(PARTITIONED),
+                                values(ImmutableMap.of("A1", 0)),
+                                values(ImmutableMap.of("B1", 0, "B2", 1))
+                        )
+                ));
+    }
+
+    @Test
+    public void testKeepsOutputSymbols()
+    {
+        tester.assertThat(new ReorderJoins(new CostComparator(1, 1, 1)))
+                .on(p ->
+                        p.join(
+                                INNER,
+                                p.values(new PlanNodeId("valuesA"), p.symbol("A1", BIGINT), p.symbol("A2", BIGINT)),
+                                p.values(new PlanNodeId("valuesB"), p.symbol("B1", BIGINT)),
+                                ImmutableList.of(new JoinNode.EquiJoinClause(p.symbol("A1", BIGINT), p.symbol("B1", BIGINT))),
+                                ImmutableList.of(p.symbol("A2", BIGINT)),
+                                Optional.empty()))
+                .withStats(ImmutableMap.of(
+                        new PlanNodeId("valuesA"), PlanNodeStatsEstimate.builder().setOutputRowCount(10000).build(),
+                        new PlanNodeId("valuesB"), PlanNodeStatsEstimate.builder().setOutputRowCount(10000).build()))
+                .matches(join(
+                        INNER,
+                        ImmutableList.of(equiJoinClause("A1", "B1")),
+                        Optional.empty(),
+                        Optional.of(PARTITIONED),
+                        values(ImmutableMap.of("A1", 0, "A2", 1)),
+                        values(ImmutableMap.of("B1", 0))
+                ));
+    }
+
+    @Test
+    public void testReplicatesAndFlipsWhenOneTableMuchSmaller()
+    {
+        tester.assertThat(new ReorderJoins(new CostComparator(1, 1, 1)))
+                .on(p ->
+                        p.join(
+                                INNER,
+                                p.values(new PlanNodeId("valuesA"), p.symbol("A1", BIGINT)),
+                                p.values(new PlanNodeId("valuesB"), p.symbol("B1", BIGINT)),
+                                ImmutableList.of(new JoinNode.EquiJoinClause(p.symbol("A1", BIGINT), p.symbol("B1", BIGINT))),
+                                ImmutableList.of(p.symbol("A1", BIGINT), p.symbol("B1", BIGINT)),
+                                Optional.empty()))
+                .withStats(ImmutableMap.of(
+                        new PlanNodeId("valuesA"), PlanNodeStatsEstimate.builder().setOutputRowCount(100).build(),
+                        new PlanNodeId("valuesB"), PlanNodeStatsEstimate.builder().setOutputRowCount(10000).build()))
+                .matches(join(
+                        INNER,
+                        ImmutableList.of(equiJoinClause("B1", "A1")),
+                        Optional.empty(),
+                        Optional.of(REPLICATED),
+                        values(ImmutableMap.of("B1", 0)),
+                        values(ImmutableMap.of("A1", 0))
+                ));
+    }
+
+    @Test
+    public void testRepartitionsWhenRequiredBySession()
+    {
+        tester.assertThat(new ReorderJoins(new CostComparator(1, 1, 1)))
+                .on(p ->
+                        p.join(
+                                INNER,
+                                p.values(new PlanNodeId("valuesA"), p.symbol("A1", BIGINT)),
+                                p.values(new PlanNodeId("valuesB"), p.symbol("B1", BIGINT)),
+                                ImmutableList.of(new JoinNode.EquiJoinClause(p.symbol("A1", BIGINT), p.symbol("B1", BIGINT))),
+                                ImmutableList.of(p.symbol("A1", BIGINT), p.symbol("B1", BIGINT)),
+                                Optional.empty()))
+                .setSystemProperty("join_distribution_type", "REPARTITIONED")
+                .withStats(ImmutableMap.of(
+                        new PlanNodeId("valuesA"), PlanNodeStatsEstimate.builder().setOutputRowCount(100).build(),
+                        new PlanNodeId("valuesB"), PlanNodeStatsEstimate.builder().setOutputRowCount(10000).build()))
+                .matches(join(
+                        INNER,
+                        ImmutableList.of(equiJoinClause("B1", "A1")),
+                        Optional.empty(),
+                        Optional.of(PARTITIONED),
+                        values(ImmutableMap.of("B1", 0)),
+                        values(ImmutableMap.of("A1", 0))
+                ));
+    }
+
+    @Test
+    public void testRepartitionsWhenBothTablesEqual()
+    {
+        tester.assertThat(new ReorderJoins(new CostComparator(1, 1, 1)))
+                .on(p ->
+                        p.join(
+                                INNER,
+                                p.values(new PlanNodeId("valuesA"), p.symbol("A1", BIGINT)),
+                                p.values(new PlanNodeId("valuesB"), p.symbol("B1", BIGINT)),
+                                ImmutableList.of(new JoinNode.EquiJoinClause(p.symbol("A1", BIGINT), p.symbol("B1", BIGINT))),
+                                ImmutableList.of(p.symbol("A1", BIGINT), p.symbol("B1", BIGINT)),
+                                Optional.empty()))
+                .withStats(ImmutableMap.of(
+                        new PlanNodeId("valuesA"), PlanNodeStatsEstimate.builder().setOutputRowCount(10000).build(),
+                        new PlanNodeId("valuesB"), PlanNodeStatsEstimate.builder().setOutputRowCount(10000).build()))
+                .matches(join(
+                        INNER,
+                        ImmutableList.of(equiJoinClause("A1", "B1")),
+                        Optional.empty(),
+                        Optional.of(PARTITIONED),
+                        values(ImmutableMap.of("A1", 0)),
+                        values(ImmutableMap.of("B1", 0))
+                ));
+    }
+
+    @Test
+    public void testReplicatesWhenRequiredBySession()
+    {
+        tester.assertThat(new ReorderJoins(new CostComparator(1, 1, 1)))
+                .on(p ->
+                        p.join(
+                                INNER,
+                                p.values(new PlanNodeId("valuesA"), p.symbol("A1", BIGINT)),
+                                p.values(new PlanNodeId("valuesB"), p.symbol("B1", BIGINT)),
+                                ImmutableList.of(new JoinNode.EquiJoinClause(p.symbol("A1", BIGINT), p.symbol("B1", BIGINT))),
+                                ImmutableList.of(p.symbol("A1", BIGINT), p.symbol("B1", BIGINT)),
+                                Optional.empty()))
+                .setSystemProperty("join_distribution_type", "REPLICATED")
+                .withStats(ImmutableMap.of(
+                        new PlanNodeId("valuesA"), PlanNodeStatsEstimate.builder().setOutputRowCount(10000).build(),
+                        new PlanNodeId("valuesB"), PlanNodeStatsEstimate.builder().setOutputRowCount(10000).build()))
+                .matches(join(
+                        INNER,
+                        ImmutableList.of(equiJoinClause("A1", "B1")),
+                        Optional.empty(),
+                        Optional.of(REPLICATED),
+                        values(ImmutableMap.of("A1", 0)),
+                        values(ImmutableMap.of("B1", 0))
+                ));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -40,6 +40,7 @@ import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.LimitNode;
 import com.facebook.presto.sql.planner.plan.OutputNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
 import com.facebook.presto.sql.planner.plan.SampleNode;
 import com.facebook.presto.sql.planner.plan.TableFinishNode;
@@ -86,8 +87,13 @@ public class PlanBuilder
 
     public ValuesNode values(Symbol... columns)
     {
+        return values(idAllocator.getNextId(), columns);
+    }
+
+    public ValuesNode values(PlanNodeId id, Symbol... columns)
+    {
         return new ValuesNode(
-                idAllocator.getNextId(),
+                id,
                 ImmutableList.copyOf(columns),
                 ImmutableList.of());
     }
@@ -278,6 +284,11 @@ public class PlanBuilder
         ExchangeBuilder exchangeBuilder = new ExchangeBuilder();
         exchangeBuilderConsumer.accept(exchangeBuilder);
         return exchangeBuilder.build();
+    }
+
+    public JoinNode join(JoinNode.Type type, PlanNode left, PlanNode right, List<JoinNode.EquiJoinClause> criteria, List<Symbol> outputSymbols, Optional<Expression> filter)
+    {
+        return new JoinNode(idAllocator.getNextId(), type, left, right, criteria, outputSymbols, filter, Optional.empty(), Optional.empty(), Optional.empty());
     }
 
     public class ExchangeBuilder

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -38,6 +38,7 @@ import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.FilterNode;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.LimitNode;
+import com.facebook.presto.sql.planner.plan.OutputNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
 import com.facebook.presto.sql.planner.plan.SampleNode;
@@ -403,6 +404,54 @@ public class PlanBuilder
                 Optional.empty(),
                 ImmutableSet.of(),
                 0);
+    }
+
+    public OutputNode output(Consumer<OutputBuilder> outputBuilderConsumer)
+    {
+        OutputBuilder outputBuilder = new OutputBuilder();
+        outputBuilderConsumer.accept(outputBuilder);
+        return outputBuilder.build();
+    }
+
+    public OutputNode output(PlanNode source, List<String> columnNames, List<Symbol> symbols)
+    {
+        checkArgument(columnNames.size() == symbols.size(), "columnNames and outputs size do not match");
+        OutputBuilder outputBuilder = new OutputBuilder();
+        outputBuilder.source(source);
+        for (int columnIndex = 0; columnIndex < columnNames.size(); ++columnIndex) {
+            outputBuilder.column(symbols.get(columnIndex), columnNames.get(columnIndex));
+        }
+        return outputBuilder.build();
+    }
+
+    public class OutputBuilder
+    {
+        private PlanNode source;
+        private List<String> columnNames = new ArrayList<>();
+        private List<Symbol> outputs = new ArrayList<>();
+
+        public OutputBuilder source(PlanNode source)
+        {
+            this.source = source;
+            return this;
+        }
+
+        public OutputBuilder column(Symbol symbol)
+        {
+            return column(symbol, symbol.getName());
+        }
+
+        public OutputBuilder column(Symbol symbol, String columnName)
+        {
+            outputs.add(symbol);
+            columnNames.add(columnName);
+            return this;
+        }
+
+        protected OutputNode build()
+        {
+            return new OutputNode(idAllocator.getNextId(), source, columnNames, outputs);
+        }
     }
 
     public static Expression expression(String sql)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleAssert.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleAssert.java
@@ -52,7 +52,7 @@ import static org.testng.Assert.fail;
 public class RuleAssert
 {
     private final Metadata metadata;
-    private final StatsCalculator statsCalculator;
+    private StatsCalculator statsCalculator;
     private final CostCalculator costCalculator;
     private Session session;
     private final Rule rule;
@@ -93,6 +93,13 @@ public class RuleAssert
     public RuleAssert withSession(Session session)
     {
         this.session = session;
+        return this;
+    }
+
+    public RuleAssert withStatsCalculator(StatsCalculator statsCalculator)
+    {
+        checkState(lookup == null, "lookup has been set");
+        this.statsCalculator = statsCalculator;
         return this;
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestReorderJoins.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestReorderJoins.java
@@ -59,7 +59,7 @@ public class TestReorderJoins
 
     public TestReorderJoins()
     {
-        super(ImmutableMap.of(SystemSessionProperties.REORDER_JOINS, "true"));
+        super(ImmutableMap.of(SystemSessionProperties.JOIN_REORDERING_STRATEGY, "ELIMINATE_CROSS_JOINS"));
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestUnionWithReplicatedJoin.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestUnionWithReplicatedJoin.java
@@ -21,6 +21,6 @@ public class TestUnionWithReplicatedJoin
 {
     public TestUnionWithReplicatedJoin()
     {
-        super(ImmutableMap.of(SystemSessionProperties.DISTRIBUTED_JOIN, "false"));
+        super(ImmutableMap.of(SystemSessionProperties.JOIN_DISTRIBUTION_TYPE, "replicated"));
     }
 }

--- a/presto-product-tests/conf/presto/etc/config.properties
+++ b/presto-product-tests/conf/presto/etc/config.properties
@@ -41,4 +41,3 @@ presto.version=testversion
 query.max-memory-per-node=1GB
 query.max-memory=1GB
 redistribute-writes=false
-reorder-joins=true

--- a/presto-product-tests/conf/presto/etc/config.properties
+++ b/presto-product-tests/conf/presto/etc/config.properties
@@ -38,7 +38,6 @@ plugin.bundles=\
   ../../../presto-sqlserver/pom.xml
 
 presto.version=testversion
-distributed-joins-enabled=true
 query.max-memory-per-node=1GB
 query.max-memory=1GB
 redistribute-writes=false

--- a/presto-product-tests/conf/presto/etc/multinode-master.properties
+++ b/presto-product-tests/conf/presto/etc/multinode-master.properties
@@ -15,4 +15,3 @@ query.max-memory=1GB
 query.max-memory-per-node=512MB
 discovery-server.enabled=true
 discovery.uri=http://presto-master:8080
-reorder-joins=true

--- a/presto-product-tests/conf/presto/etc/singlenode.properties
+++ b/presto-product-tests/conf/presto/etc/singlenode.properties
@@ -15,4 +15,3 @@ query.max-memory=2GB
 query.max-memory-per-node=1GB
 discovery-server.enabled=true
 discovery.uri=http://presto-master:8080
-reorder-joins=true

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveTableStatistics.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveTableStatistics.java
@@ -85,33 +85,33 @@ public class TestHiveTableStatistics
         // table not analyzed
 
         assertThat(query(showStatsWholeTable)).containsOnly(
-                row("n_nationkey", null, null, null, null),
-                row("n_name", null, null, null, null),
-                row("n_regionkey", null, null, null, null),
-                row("n_comment", null, null, null, null),
-                row(null, null, null, null, anyOf(null, 0.0))); // anyOf because of different behaviour on HDP (hive 1.2) and CDH (hive 1.1)
+                row("n_nationkey", null, null, null, null, null, null),
+                row("n_name", null, null, null, null, null, null),
+                row("n_regionkey", null, null, null, null, null, null),
+                row("n_comment", null, null, null, null, null, null),
+                row(null, null, null, null, anyOf(null, 0.0), null, null)); // anyOf because of different behaviour on HDP (hive 1.2) and CDH (hive 1.1)
 
         // basic analysis
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " COMPUTE STATISTICS");
 
         assertThat(query(showStatsWholeTable)).containsOnly(
-                row("n_nationkey", null, null, null, null),
-                row("n_name", null, null, null, null),
-                row("n_regionkey", null, null, null, null),
-                row("n_comment", null, null, null, null),
-                row(null, null, null, null, 25.0));
+                row("n_nationkey", null, null, null, null, null, null),
+                row("n_name", null, null, null, null, null, null),
+                row("n_regionkey", null, null, null, null, null, null),
+                row("n_comment", null, null, null, null, null, null),
+                row(null, null, null, null, 25.0, null, null));
 
         // column analysis
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " COMPUTE STATISTICS FOR COLUMNS");
 
         assertThat(query(showStatsWholeTable)).containsOnly(
-                row("n_nationkey", null, 19.0, 0.0, null),
-                row("n_name", null, 24.0, 0.0, null),
-                row("n_regionkey", null, 5.0, 0.0, null),
-                row("n_comment", null, 31.0, 0.0, null),
-                row(null, null, null, null, 25.0));
+                row("n_nationkey", null, 19.0, 0.0, null, null, null),
+                row("n_name", null, 24.0, 0.0, null, null, null),
+                row("n_regionkey", null, 5.0, 0.0, null, null, null),
+                row("n_comment", null, 31.0, 0.0, null, null, null),
+                row(null, null, null, null, 25.0, null, null));
     }
 
     @Test(groups = {HIVE_CONNECTOR})
@@ -127,118 +127,118 @@ public class TestHiveTableStatistics
         // table not analyzed
 
         assertThat(query(showStatsWholeTable)).containsOnly(
-                row("p_nationkey", null, null, null, null),
-                row("p_name", null, null, null, null),
-                row("p_regionkey", null, 3.0, null, null),
-                row("p_comment", null, null, null, null),
-                row(null, null, null, null, null));
+                row("p_nationkey", null, null, null, null, null, null),
+                row("p_name", null, null, null, null, null, null),
+                row("p_regionkey", null, 3.0, null, null, null, null),
+                row("p_comment", null, null, null, null, null, null),
+                row(null, null, null, null, null, null, null));
 
         assertThat(query(showStatsPartitionOne)).containsOnly(
-                row("p_nationkey", null, null, null, null),
-                row("p_name", null, null, null, null),
-                row("p_regionkey", null, 1.0, null, null),
-                row("p_comment", null, null, null, null),
-                row(null, null, null, null, null));
+                row("p_nationkey", null, null, null, null, null, null),
+                row("p_name", null, null, null, null, null, null),
+                row("p_regionkey", null, 1.0, null, null, null, null),
+                row("p_comment", null, null, null, null, null, null),
+                row(null, null, null, null, null, null, null));
 
         // basic analysis for single partition
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " PARTITION (p_regionkey = \"1\") COMPUTE STATISTICS");
 
         assertThat(query(showStatsWholeTable)).containsOnly(
-                row("p_nationkey", null, null, null, null),
-                row("p_name", null, null, null, null),
-                row("p_regionkey", null, 3.0, 0.0, null),
-                row("p_comment", null, null, null, null),
-                row(null, null, null, null, 15.0));
+                row("p_nationkey", null, null, null, null, null, null),
+                row("p_name", null, null, null, null, null, null),
+                row("p_regionkey", null, 3.0, 0.0, null, null, null),
+                row("p_comment", null, null, null, null, null, null),
+                row(null, null, null, null, 15.0, null, null));
 
         assertThat(query(showStatsPartitionOne)).containsOnly(
-                row("p_nationkey", null, null, null, null),
-                row("p_name", null, null, null, null),
-                row("p_regionkey", null, 1.0, 0.0, null),
-                row("p_comment", null, null, null, null),
-                row(null, null, null, null, 5.0));
+                row("p_nationkey", null, null, null, null, null, null),
+                row("p_name", null, null, null, null, null, null),
+                row("p_regionkey", null, 1.0, 0.0, null, null, null),
+                row("p_comment", null, null, null, null, null, null),
+                row(null, null, null, null, 5.0, null, null));
 
         assertThat(query(showStatsPartitionTwo)).containsOnly(
-                row("p_nationkey", null, null, null, null),
-                row("p_name", null, null, null, null),
-                row("p_regionkey", null, 1.0, null, null),
-                row("p_comment", null, null, null, null),
-                row(null, null, null, null, null));
+                row("p_nationkey", null, null, null, null, null, null),
+                row("p_name", null, null, null, null, null, null),
+                row("p_regionkey", null, 1.0, null, null, null, null),
+                row("p_comment", null, null, null, null, null, null),
+                row(null, null, null, null, null, null, null));
 
         // basic analysis for all partitions
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " PARTITION (p_regionkey) COMPUTE STATISTICS");
 
         assertThat(query(showStatsWholeTable)).containsOnly(
-                row("p_nationkey", null, null, null, null),
-                row("p_name", null, null, null, null),
-                row("p_regionkey", null, 3.0, 0.0, null),
-                row("p_comment", null, null, null, null),
-                row(null, null, null, null, 15.0));
+                row("p_nationkey", null, null, null, null, null, null),
+                row("p_name", null, null, null, null, null, null),
+                row("p_regionkey", null, 3.0, 0.0, null, null, null),
+                row("p_comment", null, null, null, null, null, null),
+                row(null, null, null, null, 15.0, null, null));
 
         assertThat(query(showStatsPartitionOne)).containsOnly(
-                row("p_nationkey", null, null, null, null),
-                row("p_name", null, null, null, null),
-                row("p_regionkey", null, 1.0, 0.0, null),
-                row("p_comment", null, null, null, null),
-                row(null, null, null, null, 5.0));
+                row("p_nationkey", null, null, null, null, null, null),
+                row("p_name", null, null, null, null, null, null),
+                row("p_regionkey", null, 1.0, 0.0, null, null, null),
+                row("p_comment", null, null, null, null, null, null),
+                row(null, null, null, null, 5.0, null, null));
 
         assertThat(query(showStatsPartitionTwo)).containsOnly(
-                row("p_nationkey", null, null, null, null),
-                row("p_name", null, null, null, null),
-                row("p_regionkey", null, 1.0, 0.0, null),
-                row("p_comment", null, null, null, null),
-                row(null, null, null, null, 5.0));
+                row("p_nationkey", null, null, null, null, null, null),
+                row("p_name", null, null, null, null, null, null),
+                row("p_regionkey", null, 1.0, 0.0, null, null, null),
+                row("p_comment", null, null, null, null, null, null),
+                row(null, null, null, null, 5.0, null, null));
 
         // column analysis for single partition
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " PARTITION (p_regionkey = \"1\") COMPUTE STATISTICS FOR COLUMNS");
 
         assertThat(query(showStatsWholeTable)).containsOnly(
-                row("p_nationkey", null, 5.0, 0.0, null),
-                row("p_name", null, 6.0, 0.0, null),
-                row("p_regionkey", null, 3.0, 0.0, null),
-                row("p_comment", null, 1.0, 0.0, null),
-                row(null, null, null, null, 15.0));
+                row("p_nationkey", null, 5.0, 0.0, null, null, null),
+                row("p_name", null, 6.0, 0.0, null, null, null),
+                row("p_regionkey", null, 3.0, 0.0, null, null, null),
+                row("p_comment", null, 1.0, 0.0, null, null, null),
+                row(null, null, null, null, 15.0, null, null));
 
         assertThat(query(showStatsPartitionOne)).containsOnly(
-                row("p_nationkey", null, 5.0, 0.0, null),
-                row("p_name", null, 6.0, 0.0, null),
-                row("p_regionkey", null, 1.0, 0.0, null),
-                row("p_comment", null, 1.0, 0.0, null),
-                row(null, null, null, null, 5.0));
+                row("p_nationkey", null, 5.0, 0.0, null, null, null),
+                row("p_name", null, 6.0, 0.0, null, null, null),
+                row("p_regionkey", null, 1.0, 0.0, null, null, null),
+                row("p_comment", null, 1.0, 0.0, null, null, null),
+                row(null, null, null, null, 5.0, null, null));
 
         assertThat(query(showStatsPartitionTwo)).containsOnly(
-                row("p_nationkey", null, null, null, null),
-                row("p_name", null, null, null, null),
-                row("p_regionkey", null, 1.0, 0.0, null),
-                row("p_comment", null, null, null, null),
-                row(null, null, null, null, 5.0));
+                row("p_nationkey", null, null, null, null, null, null),
+                row("p_name", null, null, null, null, null, null),
+                row("p_regionkey", null, 1.0, 0.0, null, null, null),
+                row("p_comment", null, null, null, null, null, null),
+                row(null, null, null, null, 5.0, null, null));
 
         // column analysis for all partitions
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " PARTITION (p_regionkey) COMPUTE STATISTICS FOR COLUMNS");
 
         assertThat(query(showStatsWholeTable)).containsOnly(
-                row("p_nationkey", null, 5.0, 0.0, null),
-                row("p_name", null, 6.0, 0.0, null),
-                row("p_regionkey", null, 3.0, 0.0, null),
-                row("p_comment", null, 1.0, 0.0, null),
-                row(null, null, null, null, 15.0));
+                row("p_nationkey", null, 5.0, 0.0, null, null, null),
+                row("p_name", null, 6.0, 0.0, null, null, null),
+                row("p_regionkey", null, 3.0, 0.0, null, null, null),
+                row("p_comment", null, 1.0, 0.0, null, null, null),
+                row(null, null, null, null, 15.0, null, null));
 
         assertThat(query(showStatsPartitionOne)).containsOnly(
-                row("p_nationkey", null, 5.0, 0.0, null),
-                row("p_name", null, 6.0, 0.0, null),
-                row("p_regionkey", null, 1.0, 0.0, null),
-                row("p_comment", null, 1.0, 0.0, null),
-                row(null, null, null, null, 5.0));
+                row("p_nationkey", null, 5.0, 0.0, null, null, null),
+                row("p_name", null, 6.0, 0.0, null, null, null),
+                row("p_regionkey", null, 1.0, 0.0, null, null, null),
+                row("p_comment", null, 1.0, 0.0, null, null, null),
+                row(null, null, null, null, 5.0, null, null));
 
         assertThat(query(showStatsPartitionTwo)).containsOnly(
-                row("p_nationkey", null, 4.0, 0.0, null),
-                row("p_name", null, 6.0, 0.0, null),
-                row("p_regionkey", null, 1.0, 0.0, null),
-                row("p_comment", null, 1.0, 0.0, null),
-                row(null, null, null, null, 5.0));
+                row("p_nationkey", null, 4.0, 0.0, null, null, null),
+                row("p_name", null, 6.0, 0.0, null, null, null),
+                row("p_regionkey", null, 1.0, 0.0, null, null, null),
+                row("p_comment", null, 1.0, 0.0, null, null, null),
+                row(null, null, null, null, 5.0, null, null));
     }
 
     @Test(groups = {HIVE_CONNECTOR, SKIP_ON_CDH}) // skip on cdh due to no support for date column and stats
@@ -249,42 +249,42 @@ public class TestHiveTableStatistics
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " COMPUTE STATISTICS");
 
         assertThat(query("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
-                row("c_tinyint", null, null, null, null),
-                row("c_smallint", null, null, null, null),
-                row("c_int", null, null, null, null),
-                row("c_bigint", null, null, null, null),
-                row("c_float", null, null, null, null),
-                row("c_double", null, null, null, null),
-                row("c_decimal", null, null, null, null),
-                row("c_decimal_w_params", null, null, null, null),
-                row("c_timestamp", null, null, null, null),
-                row("c_date", null, null, null, null),
-                row("c_string", null, null, null, null),
-                row("c_varchar", null, null, null, null),
-                row("c_char", null, null, null, null),
-                row("c_boolean", null, null, null, null),
-                row("c_binary", null, null, null, null),
-                row(null, null, null, null, 1.0));
+        row("c_tinyint", null, null, null, null, null, null),
+                row("c_smallint", null, null, null, null, null, null),
+                row("c_int", null, null, null, null, null, null),
+                row("c_bigint", null, null, null, null, null, null),
+                row("c_float", null, null, null, null, null, null),
+                row("c_double", null, null, null, null, null, null),
+                row("c_decimal", null, null, null, null, null, null),
+                row("c_decimal_w_params", null, null, null, null, null, null),
+                row("c_timestamp", null, null, null, null, null, null),
+                row("c_date", null, null, null, null, null, null),
+                row("c_string", null, null, null, null, null, null),
+                row("c_varchar", null, null, null, null, null, null),
+                row("c_char", null, null, null, null, null, null),
+                row("c_boolean", null, null, null, null, null, null),
+                row("c_binary", null, null, null, null, null, null),
+                row(null, null, null, null, 1.0, null, null));
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " COMPUTE STATISTICS FOR COLUMNS");
 
         assertThat(query("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
-                row("c_tinyint", null, 1.0, 0.0, null),
-                row("c_smallint", null, 1.0, 0.0, null),
-                row("c_int", null, 2.0, 0.0, null),
-                row("c_bigint", null, 1.0, 0.0, null),
-                row("c_float", null, 1.0, 0.0, null),
-                row("c_double", null, 1.0, 0.0, null),
-                row("c_decimal", null, 1.0, 0.0, null),
-                row("c_decimal_w_params", null, 1.0, 0.0, null),
-                row("c_timestamp", null, 1.0, 0.0, null),
-                row("c_date", null, 2.0, 0.0, null),
-                row("c_string", null, 1.0, 0.0, null),
-                row("c_varchar", null, 1.0, 0.0, null),
-                row("c_char", null, 1.0, 0.0, null),
-                row("c_boolean", null, 1.0, 0.0, null),
-                row("c_binary", null, null, 0.0, null),
-                row(null, null, null, null, 1.0));
+        row("c_tinyint", null, 1.0, 0.0, null, null, null),
+                row("c_smallint", null, 1.0, 0.0, null, null, null),
+                row("c_int", null, 2.0, 0.0, null, null, null),
+                row("c_bigint", null, 1.0, 0.0, null, null, null),
+                row("c_float", null, 1.0, 0.0, null, null, null),
+                row("c_double", null, 1.0, 0.0, null, null, null),
+                row("c_decimal", null, 1.0, 0.0, null, null, null),
+                row("c_decimal_w_params", null, 1.0, 0.0, null, null, null),
+                row("c_timestamp", null, 1.0, 0.0, null, null, null),
+                row("c_date", null, 2.0, 0.0, null, null, null),
+                row("c_string", null, 1.0, 0.0, null, null, null),
+                row("c_varchar", null, 1.0, 0.0, null, null, null),
+                row("c_char", null, 1.0, 0.0, null, null, null),
+                row("c_boolean", null, 1.0, 0.0, null, null, null),
+                row("c_binary", null, null, 0.0, null, null, null),
+                row(null, null, null, null, 1.0, null, null));
     }
 
     @Test(groups = {HIVE_CONNECTOR, SKIP_ON_CDH}) // skip on cdh due to no support for date column and stats
@@ -295,42 +295,42 @@ public class TestHiveTableStatistics
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " COMPUTE STATISTICS");
 
         assertThat(query("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
-                row("c_tinyint", null, null, null, null),
-                row("c_smallint", null, null, null, null),
-                row("c_int", null, null, null, null),
-                row("c_bigint", null, null, null, null),
-                row("c_float", null, null, null, null),
-                row("c_double", null, null, null, null),
-                row("c_decimal", null, null, null, null),
-                row("c_decimal_w_params", null, null, null, null),
-                row("c_timestamp", null, null, null, null),
-                row("c_date", null, null, null, null),
-                row("c_string", null, null, null, null),
-                row("c_varchar", null, null, null, null),
-                row("c_char", null, null, null, null),
-                row("c_boolean", null, null, null, null),
-                row("c_binary", null, null, null, null),
-                row(null, null, null, null, 0.0));
+                row("c_tinyint", null, null, null, null, null, null),
+                row("c_smallint", null, null, null, null, null, null),
+                row("c_int", null, null, null, null, null, null),
+                row("c_bigint", null, null, null, null, null, null),
+                row("c_float", null, null, null, null, null, null),
+                row("c_double", null, null, null, null, null, null),
+                row("c_decimal", null, null, null, null, null, null),
+                row("c_decimal_w_params", null, null, null, null, null, null),
+                row("c_timestamp", null, null, null, null, null, null),
+                row("c_date", null, null, null, null, null, null),
+                row("c_string", null, null, null, null, null, null),
+                row("c_varchar", null, null, null, null, null, null),
+                row("c_char", null, null, null, null, null, null),
+                row("c_boolean", null, null, null, null, null, null),
+                row("c_binary", null, null, null, null, null, null),
+                row(null, null, null, null, 0.0, null, null));
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " COMPUTE STATISTICS FOR COLUMNS");
 
         assertThat(query("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
-                row("c_tinyint", null, 0.0, 0.0, null),
-                row("c_smallint", null, 0.0, 0.0, null),
-                row("c_int", null, 0.0, 0.0, null),
-                row("c_bigint", null, 0.0, 0.0, null),
-                row("c_float", null, 0.0, 0.0, null),
-                row("c_double", null, 0.0, 0.0, null),
-                row("c_decimal", null, 0.0, 0.0, null),
-                row("c_decimal_w_params", null, 0.0, 0.0, null),
-                row("c_timestamp", null, 0.0, 0.0, null),
-                row("c_date", null, 0.0, 0.0, null),
-                row("c_string", null, 0.0, 0.0, null),
-                row("c_varchar", null, 0.0, 0.0, null),
-                row("c_char", null, 0.0, 0.0, null),
-                row("c_boolean", null, 0.0, 0.0, null),
-                row("c_binary", null, null, 0.0, null),
-                row(null, null, null, null, 0.0));
+                row("c_tinyint", null, 0.0, 0.0, null, null, null),
+                row("c_smallint", null, 0.0, 0.0, null, null, null),
+                row("c_int", null, 0.0, 0.0, null, null, null),
+                row("c_bigint", null, 0.0, 0.0, null, null, null),
+                row("c_float", null, 0.0, 0.0, null, null, null),
+                row("c_double", null, 0.0, 0.0, null, null, null),
+                row("c_decimal", null, 0.0, 0.0, null, null, null),
+                row("c_decimal_w_params", null, 0.0, 0.0, null, null, null),
+                row("c_timestamp", null, 0.0, 0.0, null, null, null),
+                row("c_date", null, 0.0, 0.0, null, null, null),
+                row("c_string", null, 0.0, 0.0, null, null, null),
+                row("c_varchar", null, 0.0, 0.0, null, null, null),
+                row("c_char", null, 0.0, 0.0, null, null, null),
+                row("c_boolean", null, 0.0, 0.0, null, null, null),
+                row("c_binary", null, null, 0.0, null, null, null),
+                row(null, null, null, null, 0.0, null, null));
     }
 
     @Test(groups = {HIVE_CONNECTOR, SKIP_ON_CDH}) // skip on cdh due to no support for date column and stats
@@ -343,42 +343,42 @@ public class TestHiveTableStatistics
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " COMPUTE STATISTICS");
 
         assertThat(query("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
-                row("c_tinyint", null, null, null, null),
-                row("c_smallint", null, null, null, null),
-                row("c_int", null, null, null, null),
-                row("c_bigint", null, null, null, null),
-                row("c_float", null, null, null, null),
-                row("c_double", null, null, null, null),
-                row("c_decimal", null, null, null, null),
-                row("c_decimal_w_params", null, null, null, null),
-                row("c_timestamp", null, null, null, null),
-                row("c_date", null, null, null, null),
-                row("c_string", null, null, null, null),
-                row("c_varchar", null, null, null, null),
-                row("c_char", null, null, null, null),
-                row("c_boolean", null, null, null, null),
-                row("c_binary", null, null, null, null),
-                row(null, null, null, null, 1.0));
+                row("c_tinyint", null, null, null, null, null, null),
+                row("c_smallint", null, null, null, null, null, null),
+                row("c_int", null, null, null, null, null, null),
+                row("c_bigint", null, null, null, null, null, null),
+                row("c_float", null, null, null, null, null, null),
+                row("c_double", null, null, null, null, null, null),
+                row("c_decimal", null, null, null, null, null, null),
+                row("c_decimal_w_params", null, null, null, null, null, null),
+                row("c_timestamp", null, null, null, null, null, null),
+                row("c_date", null, null, null, null, null, null),
+                row("c_string", null, null, null, null, null, null),
+                row("c_varchar", null, null, null, null, null, null),
+                row("c_char", null, null, null, null, null, null),
+                row("c_boolean", null, null, null, null, null, null),
+                row("c_binary", null, null, null, null, null, null),
+                row(null, null, null, null, 1.0, null, null));
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " COMPUTE STATISTICS FOR COLUMNS");
 
         assertThat(query("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
-                row("c_tinyint", null, 1.0, 1.0, null),
-                row("c_smallint", null, 1.0, 1.0, null),
-                row("c_int", null, 1.0, 1.0, null),
-                row("c_bigint", null, 1.0, 1.0, null),
-                row("c_float", null, 1.0, 1.0, null),
-                row("c_double", null, 1.0, 1.0, null),
-                row("c_decimal", null, 1.0, 1.0, null),
-                row("c_decimal_w_params", null, 1.0, 1.0, null),
-                row("c_timestamp", null, 1.0, 1.0, null),
-                row("c_date", null, 1.0, 1.0, null),
-                row("c_string", null, 1.0, 1.0, null),
-                row("c_varchar", null, 1.0, 1.0, null),
-                row("c_char", null, 1.0, 1.0, null),
-                row("c_boolean", null, 0.0, 1.0, null),
-                row("c_binary", null, null, 1.0, null),
-                row(null, null, null, null, 1.0));
+                row("c_tinyint", null, 1.0, 1.0, null, null, null),
+                row("c_smallint", null, 1.0, 1.0, null, null, null),
+                row("c_int", null, 1.0, 1.0, null, null, null),
+                row("c_bigint", null, 1.0, 1.0, null, null, null),
+                row("c_float", null, 1.0, 1.0, null, null, null),
+                row("c_double", null, 1.0, 1.0, null, null, null),
+                row("c_decimal", null, 1.0, 1.0, null, null, null),
+                row("c_decimal_w_params", null, 1.0, 1.0, null, null, null),
+                row("c_timestamp", null, 1.0, 1.0, null, null, null),
+                row("c_date", null, 1.0, 1.0, null, null, null),
+                row("c_string", null, 1.0, 1.0, null, null, null),
+                row("c_varchar", null, 1.0, 1.0, null, null, null),
+                row("c_char", null, 1.0, 1.0, null, null, null),
+                row("c_boolean", null, 0.0, 1.0, null, null, null),
+                row("c_binary", null, null, 1.0, null, null, null),
+                row(null, null, null, null, 1.0, null, null));
     }
 
     private static QueryExecutor onHive()

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveTableStatistics.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveTableStatistics.java
@@ -20,6 +20,8 @@ import com.teradata.tempto.RequirementsProvider;
 import com.teradata.tempto.Requires;
 import com.teradata.tempto.configuration.Configuration;
 import com.teradata.tempto.fulfillment.table.MutableTableRequirement;
+import com.teradata.tempto.fulfillment.table.hive.HiveTableDefinition;
+import com.teradata.tempto.fulfillment.table.hive.InlineDataSource;
 import com.teradata.tempto.query.QueryExecutor;
 import org.testng.annotations.Test;
 
@@ -62,6 +64,14 @@ public class TestHiveTableStatistics
     private static final String ALL_TYPES_TABLE_NAME = "all_types";
     private static final String EMPTY_ALL_TYPES_TABLE_NAME = "empty_all_types";
 
+    private static final HiveTableDefinition ALL_TYPES_TABLE = HiveTableDefinition.like(ALL_HIVE_SIMPLE_TYPES_TEXTFILE)
+            .setDataSource(InlineDataSource.createStringDataSource(
+                    "all_analyzable_types",
+                    "",
+                    "121|32761|2147483641|9223372036854775801|123.341|234.561|344.671|345.671|2015-05-10 12:15:31.123456|2015-05-09|ela ma kota|ela ma kot|ela ma    |false|cGllcyBiaW5hcm55|\n" +
+                            "127|32767|2147483647|9223372036854775807|123.345|234.567|345.678|345.678|2015-05-10 12:15:35.123456|2015-05-10|ala ma kota|ala ma kot|ala ma    |true|a290IGJpbmFybnk=|\n"))
+            .build();
+
     private static final class AllTypesTable
             implements RequirementsProvider
     {
@@ -69,8 +79,8 @@ public class TestHiveTableStatistics
         public Requirement getRequirements(Configuration configuration)
         {
             return Requirements.compose(
-                    mutableTable(ALL_HIVE_SIMPLE_TYPES_TEXTFILE, ALL_TYPES_TABLE_NAME, MutableTableRequirement.State.LOADED),
-                    mutableTable(ALL_HIVE_SIMPLE_TYPES_TEXTFILE, EMPTY_ALL_TYPES_TABLE_NAME, MutableTableRequirement.State.CREATED));
+                    mutableTable(ALL_TYPES_TABLE, ALL_TYPES_TABLE_NAME, MutableTableRequirement.State.LOADED),
+                    mutableTable(ALL_TYPES_TABLE, EMPTY_ALL_TYPES_TABLE_NAME, MutableTableRequirement.State.CREATED));
         }
     }
 
@@ -107,9 +117,9 @@ public class TestHiveTableStatistics
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " COMPUTE STATISTICS FOR COLUMNS");
 
         assertThat(query(showStatsWholeTable)).containsOnly(
-                row("n_nationkey", null, 19.0, 0.0, null, null, null),
+                row("n_nationkey", null, 19.0, 0.0, null, "0", "24"),
                 row("n_name", null, 24.0, 0.0, null, null, null),
-                row("n_regionkey", null, 5.0, 0.0, null, null, null),
+                row("n_regionkey", null, 5.0, 0.0, null, "0", "4"),
                 row("n_comment", null, 31.0, 0.0, null, null, null),
                 row(null, null, null, null, 25.0, null, null));
     }
@@ -129,14 +139,14 @@ public class TestHiveTableStatistics
         assertThat(query(showStatsWholeTable)).containsOnly(
                 row("p_nationkey", null, null, null, null, null, null),
                 row("p_name", null, null, null, null, null, null),
-                row("p_regionkey", null, 3.0, null, null, null, null),
+                row("p_regionkey", null, 3.0, null, null, "1", "3"),
                 row("p_comment", null, null, null, null, null, null),
                 row(null, null, null, null, null, null, null));
 
         assertThat(query(showStatsPartitionOne)).containsOnly(
                 row("p_nationkey", null, null, null, null, null, null),
                 row("p_name", null, null, null, null, null, null),
-                row("p_regionkey", null, 1.0, null, null, null, null),
+                row("p_regionkey", null, 1.0, null, null, "1", "1"),
                 row("p_comment", null, null, null, null, null, null),
                 row(null, null, null, null, null, null, null));
 
@@ -147,21 +157,21 @@ public class TestHiveTableStatistics
         assertThat(query(showStatsWholeTable)).containsOnly(
                 row("p_nationkey", null, null, null, null, null, null),
                 row("p_name", null, null, null, null, null, null),
-                row("p_regionkey", null, 3.0, 0.0, null, null, null),
+                row("p_regionkey", null, 3.0, 0.0, null, "1", "3"),
                 row("p_comment", null, null, null, null, null, null),
                 row(null, null, null, null, 15.0, null, null));
 
         assertThat(query(showStatsPartitionOne)).containsOnly(
                 row("p_nationkey", null, null, null, null, null, null),
                 row("p_name", null, null, null, null, null, null),
-                row("p_regionkey", null, 1.0, 0.0, null, null, null),
+                row("p_regionkey", null, 1.0, 0.0, null, "1", "1"),
                 row("p_comment", null, null, null, null, null, null),
                 row(null, null, null, null, 5.0, null, null));
 
         assertThat(query(showStatsPartitionTwo)).containsOnly(
                 row("p_nationkey", null, null, null, null, null, null),
                 row("p_name", null, null, null, null, null, null),
-                row("p_regionkey", null, 1.0, null, null, null, null),
+                row("p_regionkey", null, 1.0, null, null, "2", "2"),
                 row("p_comment", null, null, null, null, null, null),
                 row(null, null, null, null, null, null, null));
 
@@ -172,21 +182,21 @@ public class TestHiveTableStatistics
         assertThat(query(showStatsWholeTable)).containsOnly(
                 row("p_nationkey", null, null, null, null, null, null),
                 row("p_name", null, null, null, null, null, null),
-                row("p_regionkey", null, 3.0, 0.0, null, null, null),
+                row("p_regionkey", null, 3.0, 0.0, null, "1", "3"),
                 row("p_comment", null, null, null, null, null, null),
                 row(null, null, null, null, 15.0, null, null));
 
         assertThat(query(showStatsPartitionOne)).containsOnly(
                 row("p_nationkey", null, null, null, null, null, null),
                 row("p_name", null, null, null, null, null, null),
-                row("p_regionkey", null, 1.0, 0.0, null, null, null),
+                row("p_regionkey", null, 1.0, 0.0, null, "1", "1"),
                 row("p_comment", null, null, null, null, null, null),
                 row(null, null, null, null, 5.0, null, null));
 
         assertThat(query(showStatsPartitionTwo)).containsOnly(
                 row("p_nationkey", null, null, null, null, null, null),
                 row("p_name", null, null, null, null, null, null),
-                row("p_regionkey", null, 1.0, 0.0, null, null, null),
+                row("p_regionkey", null, 1.0, 0.0, null, "2", "2"),
                 row("p_comment", null, null, null, null, null, null),
                 row(null, null, null, null, 5.0, null, null));
 
@@ -195,23 +205,23 @@ public class TestHiveTableStatistics
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " PARTITION (p_regionkey = \"1\") COMPUTE STATISTICS FOR COLUMNS");
 
         assertThat(query(showStatsWholeTable)).containsOnly(
-                row("p_nationkey", null, 5.0, 0.0, null, null, null),
+                row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
                 row("p_name", null, 6.0, 0.0, null, null, null),
-                row("p_regionkey", null, 3.0, 0.0, null, null, null),
+                row("p_regionkey", null, 3.0, 0.0, null, "1", "3"),
                 row("p_comment", null, 1.0, 0.0, null, null, null),
                 row(null, null, null, null, 15.0, null, null));
 
         assertThat(query(showStatsPartitionOne)).containsOnly(
-                row("p_nationkey", null, 5.0, 0.0, null, null, null),
+                row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
                 row("p_name", null, 6.0, 0.0, null, null, null),
-                row("p_regionkey", null, 1.0, 0.0, null, null, null),
+                row("p_regionkey", null, 1.0, 0.0, null, "1", "1"),
                 row("p_comment", null, 1.0, 0.0, null, null, null),
                 row(null, null, null, null, 5.0, null, null));
 
         assertThat(query(showStatsPartitionTwo)).containsOnly(
                 row("p_nationkey", null, null, null, null, null, null),
                 row("p_name", null, null, null, null, null, null),
-                row("p_regionkey", null, 1.0, 0.0, null, null, null),
+                row("p_regionkey", null, 1.0, 0.0, null, "2", "2"),
                 row("p_comment", null, null, null, null, null, null),
                 row(null, null, null, null, 5.0, null, null));
 
@@ -220,23 +230,23 @@ public class TestHiveTableStatistics
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " PARTITION (p_regionkey) COMPUTE STATISTICS FOR COLUMNS");
 
         assertThat(query(showStatsWholeTable)).containsOnly(
-                row("p_nationkey", null, 5.0, 0.0, null, null, null),
+                row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
                 row("p_name", null, 6.0, 0.0, null, null, null),
-                row("p_regionkey", null, 3.0, 0.0, null, null, null),
+                row("p_regionkey", null, 3.0, 0.0, null, "1", "3"),
                 row("p_comment", null, 1.0, 0.0, null, null, null),
                 row(null, null, null, null, 15.0, null, null));
 
         assertThat(query(showStatsPartitionOne)).containsOnly(
-                row("p_nationkey", null, 5.0, 0.0, null, null, null),
+                row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
                 row("p_name", null, 6.0, 0.0, null, null, null),
-                row("p_regionkey", null, 1.0, 0.0, null, null, null),
+                row("p_regionkey", null, 1.0, 0.0, null, "1", "1"),
                 row("p_comment", null, 1.0, 0.0, null, null, null),
                 row(null, null, null, null, 5.0, null, null));
 
         assertThat(query(showStatsPartitionTwo)).containsOnly(
-                row("p_nationkey", null, 4.0, 0.0, null, null, null),
+                row("p_nationkey", null, 4.0, 0.0, null, "8", "21"),
                 row("p_name", null, 6.0, 0.0, null, null, null),
-                row("p_regionkey", null, 1.0, 0.0, null, null, null),
+                row("p_regionkey", null, 1.0, 0.0, null, "2", "2"),
                 row("p_comment", null, 1.0, 0.0, null, null, null),
                 row(null, null, null, null, 5.0, null, null));
     }
@@ -264,27 +274,27 @@ public class TestHiveTableStatistics
                 row("c_char", null, null, null, null, null, null),
                 row("c_boolean", null, null, null, null, null, null),
                 row("c_binary", null, null, null, null, null, null),
-                row(null, null, null, null, 1.0, null, null));
+                row(null, null, null, null, 2.0, null, null));
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " COMPUTE STATISTICS FOR COLUMNS");
 
         assertThat(query("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
-        row("c_tinyint", null, 1.0, 0.0, null, null, null),
-                row("c_smallint", null, 1.0, 0.0, null, null, null),
-                row("c_int", null, 2.0, 0.0, null, null, null),
-                row("c_bigint", null, 1.0, 0.0, null, null, null),
-                row("c_float", null, 1.0, 0.0, null, null, null),
-                row("c_double", null, 1.0, 0.0, null, null, null),
-                row("c_decimal", null, 1.0, 0.0, null, null, null),
-                row("c_decimal_w_params", null, 1.0, 0.0, null, null, null),
-                row("c_timestamp", null, 1.0, 0.0, null, null, null),
-                row("c_date", null, 2.0, 0.0, null, null, null),
-                row("c_string", null, 1.0, 0.0, null, null, null),
-                row("c_varchar", null, 1.0, 0.0, null, null, null),
-                row("c_char", null, 1.0, 0.0, null, null, null),
-                row("c_boolean", null, 1.0, 0.0, null, null, null),
+                row("c_tinyint", null, 2.0, 0.0, null, "121", "127"),
+                row("c_smallint", null, 2.0, 0.0, null, "32761", "32767"),
+                row("c_int", null, 2.0, 0.0, null, "2147483641", "2147483647"),
+                row("c_bigint", null, 2.0, 0.0, null, "9223372036854775801", "9223372036854775807"),
+                row("c_float", null, 2.0, 0.0, null, "123.341", "123.345"),
+                row("c_double", null, 1.0, 0.0, null, "234.561", "234.567"),
+                row("c_decimal", null, 2.0, 0.0, null, "345", "346"),
+                row("c_decimal_w_params", null, 2.0, 0.0, null, "345.67100", "345.67800"),
+                row("c_timestamp", null, 2.0, 0.0, null, "2015-05-10 12:15:31.000", "2015-05-10 12:15:35.000"),
+                row("c_date", null, 3.0, 0.0, null, "2015-05-09", "2015-05-10"),
+                row("c_string", null, 2.0, 0.0, null, null, null),
+                row("c_varchar", null, 2.0, 0.0, null, null, null),
+                row("c_char", null, 2.0, 0.0, null, null, null),
+                row("c_boolean", null, 2.0, 0.0, null, null, null),
                 row("c_binary", null, null, 0.0, null, null, null),
-                row(null, null, null, null, 1.0, null, null));
+                row(null, null, null, null, 2.0, null, null));
     }
 
     @Test(groups = {HIVE_CONNECTOR, SKIP_ON_CDH}) // skip on cdh due to no support for date column and stats

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/jdbc/JdbcTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/jdbc/JdbcTests.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.tests.jdbc;
 
 import com.facebook.presto.jdbc.PrestoConnection;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.teradata.tempto.BeforeTestWithContext;
 import com.teradata.tempto.ProductTest;
 import com.teradata.tempto.Requirement;
@@ -52,8 +53,6 @@ import static com.teradata.tempto.fulfillment.table.hive.tpch.TpchTableDefinitio
 import static com.teradata.tempto.internal.convention.SqlResultDescriptor.sqlResultDescriptorForResource;
 import static com.teradata.tempto.query.QueryExecutor.defaultQueryExecutor;
 import static com.teradata.tempto.query.QueryExecutor.query;
-import static java.lang.Boolean.FALSE;
-import static java.lang.Boolean.TRUE;
 import static java.util.Locale.CHINESE;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -247,13 +246,14 @@ public class JdbcTests
     public void testSessionProperties()
             throws SQLException
     {
-        final String distributedJoin = "distributed_join";
+        final String joinDistributionType = "join_distribution_type";
+        final String defaultValue = new FeaturesConfig().getJoinDistributionType().name();
 
-        assertThat(getSessionProperty(connection, distributedJoin)).isEqualTo(TRUE.toString());
-        setSessionProperty(connection, distributedJoin, FALSE.toString());
-        assertThat(getSessionProperty(connection, distributedJoin)).isEqualTo(FALSE.toString());
-        resetSessionProperty(connection, distributedJoin);
-        assertThat(getSessionProperty(connection, distributedJoin)).isEqualTo(TRUE.toString());
+        assertThat(getSessionProperty(connection, joinDistributionType)).isEqualTo(defaultValue);
+        setSessionProperty(connection, joinDistributionType, "REPLICATED");
+        assertThat(getSessionProperty(connection, joinDistributionType)).isEqualTo("REPLICATED");
+        resetSessionProperty(connection, joinDistributionType);
+        assertThat(getSessionProperty(connection, joinDistributionType)).isEqualTo(defaultValue);
     }
 
     private QueryResult queryResult(Statement statement, String query)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/Constraint.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/Constraint.java
@@ -31,6 +31,11 @@ public class Constraint<T>
         return new Constraint<>(TupleDomain.<V>all(), bindings -> true);
     }
 
+    public static <V> Constraint<V> alwaysFalse()
+    {
+        return new Constraint<>(TupleDomain.<V>none(), bindings -> false);
+    }
+
     public Constraint(TupleDomain<T> summary, Predicate<Map<T, NullableValue>> predicate)
     {
         requireNonNull(summary, "summary is null");

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/ColumnStatistics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/ColumnStatistics.java
@@ -26,6 +26,7 @@ import static java.util.Objects.requireNonNull;
 public final class ColumnStatistics
 {
     private static final List<RangeColumnStatistics> SINGLE_UNKNOWN_RANGE_STATISTICS = singletonList(RangeColumnStatistics.builder().build());
+    public static final ColumnStatistics UNKNOWN_COLUMN_STATISTICS = ColumnStatistics.builder().build();
 
     private final List<RangeColumnStatistics> rangeColumnStatistics;
     private final Estimate nullsFraction;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/ColumnStatistics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/ColumnStatistics.java
@@ -59,6 +59,14 @@ public final class ColumnStatistics
         return nullsFraction;
     }
 
+    public Builder asBuilder()
+    {
+        Builder builder = builder()
+                .setNullsFraction(nullsFraction);
+        rangeColumnStatistics.forEach(builder::addRange);
+        return builder;
+    }
+
     public static Builder builder()
     {
         return new Builder();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/ColumnStatistics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/ColumnStatistics.java
@@ -107,6 +107,12 @@ public final class ColumnStatistics
             return this;
         }
 
+        public Builder clearRanges()
+        {
+            rangeColumnStatistics.clear();
+            return this;
+        }
+
         public ColumnStatistics build()
         {
             return new ColumnStatistics(nullsFraction, rangeColumnStatistics);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/Estimate.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/Estimate.java
@@ -39,6 +39,11 @@ public final class Estimate
         return new Estimate(0);
     }
 
+    public static final Estimate of(double value)
+    {
+        return new Estimate(value);
+    }
+
     public Estimate(double value)
     {
         this.value = value;
@@ -52,6 +57,11 @@ public final class Estimate
     public double getValue()
     {
         return value;
+    }
+
+    public double valueOrDefault(double defaultValue)
+    {
+        return isValueUnknown() ? defaultValue : value;
     }
 
     public Estimate map(Function<Double, Double> mappingFunction)
@@ -70,6 +80,46 @@ public final class Estimate
             return unknownValue();
         }
         return new Estimate(value + other.getValue());
+    }
+
+    public Estimate subtract(Estimate other)
+    {
+        if (isValueUnknown() || other.isValueUnknown()) {
+            return unknownValue();
+        }
+        return new Estimate(value - other.getValue());
+    }
+
+    public Estimate divide(Estimate other)
+    {
+        if (isValueUnknown() || other.isValueUnknown()) {
+            return unknownValue();
+        }
+        return new Estimate(value / other.getValue());
+    }
+
+    public Estimate multiply(Estimate other)
+    {
+        if (isValueUnknown() || other.isValueUnknown()) {
+            return unknownValue();
+        }
+        return new Estimate(value * other.getValue());
+    }
+
+    public static Estimate max(Estimate left, Estimate right)
+    {
+        if (left.isValueUnknown() || right.isValueUnknown()) {
+            return unknownValue();
+        }
+        return Estimate.of(Math.max(left.getValue(), right.getValue()));
+    }
+
+    public static Estimate min(Estimate left, Estimate right)
+    {
+        if (left.isValueUnknown() || right.isValueUnknown()) {
+            return unknownValue();
+        }
+        return Estimate.of(Math.min(left.getValue(), right.getValue()));
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/RangeColumnStatistics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/RangeColumnStatistics.java
@@ -88,6 +88,15 @@ public class RangeColumnStatistics
         return statistics;
     }
 
+    public Builder asBuilder()
+    {
+        return builder()
+                .setDataSize(getDataSize())
+                .setDistinctValuesCount(getDistinctValuesCount())
+                .setHighValue(getHighValue())
+                .setLowValue(getLowValue());
+    }
+
     public static Builder builder()
     {
         return new Builder();

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -19,6 +19,7 @@ import com.facebook.presto.cost.CostCalculatorUsingExchanges;
 import com.facebook.presto.cost.CostCalculatorWithEstimatedExchanges;
 import com.facebook.presto.cost.CostComparator;
 import com.facebook.presto.cost.FilterStatsCalculator;
+import com.facebook.presto.cost.ScalarStatsCalculator;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.server.ServerMainModule;
 import com.facebook.presto.spi.security.AccessDeniedException;
@@ -305,7 +306,7 @@ public abstract class AbstractTestQueryFramework
                 forceSingleNode,
                 new MBeanExporter(new TestingMBeanServer()),
                 new CostComparator(featuresConfig),
-                ServerMainModule.createStatsCalculator(metadata, new FilterStatsCalculator(metadata)),
+                ServerMainModule.createStatsCalculator(metadata, new FilterStatsCalculator(metadata), new ScalarStatsCalculator(metadata)),
                 costCalculator,
                 new CostCalculatorWithEstimatedExchanges(costCalculator, queryRunner.getNodeCount())).get();
         return new QueryExplainer(

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -14,12 +14,12 @@
 package com.facebook.presto.tests;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.cost.CoefficientBasedStatsCalculator;
 import com.facebook.presto.cost.CostCalculator;
 import com.facebook.presto.cost.CostCalculatorUsingExchanges;
 import com.facebook.presto.cost.CostCalculatorWithEstimatedExchanges;
 import com.facebook.presto.cost.CostComparator;
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.server.ServerMainModule;
 import com.facebook.presto.spi.security.AccessDeniedException;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
@@ -304,7 +304,7 @@ public abstract class AbstractTestQueryFramework
                 forceSingleNode,
                 new MBeanExporter(new TestingMBeanServer()),
                 new CostComparator(featuresConfig),
-                new CoefficientBasedStatsCalculator(metadata),
+                ServerMainModule.createStatsCalculator(metadata),
                 costCalculator,
                 new CostCalculatorWithEstimatedExchanges(costCalculator, queryRunner.getNodeCount())).get();
         return new QueryExplainer(

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -18,6 +18,7 @@ import com.facebook.presto.cost.CostCalculator;
 import com.facebook.presto.cost.CostCalculatorUsingExchanges;
 import com.facebook.presto.cost.CostCalculatorWithEstimatedExchanges;
 import com.facebook.presto.cost.CostComparator;
+import com.facebook.presto.cost.FilterStatsCalculator;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.server.ServerMainModule;
 import com.facebook.presto.spi.security.AccessDeniedException;
@@ -304,7 +305,7 @@ public abstract class AbstractTestQueryFramework
                 forceSingleNode,
                 new MBeanExporter(new TestingMBeanServer()),
                 new CostComparator(featuresConfig),
-                ServerMainModule.createStatsCalculator(metadata),
+                ServerMainModule.createStatsCalculator(metadata, new FilterStatsCalculator(metadata)),
                 costCalculator,
                 new CostCalculatorWithEstimatedExchanges(costCalculator, queryRunner.getNodeCount())).get();
         return new QueryExplainer(

--- a/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
@@ -171,11 +171,10 @@ public class DistributedQueryRunner
                 .put("compiler.interpreter-enabled", "false")
                 .put("task.max-index-memory", "16kB") // causes index joins to fault load
                 .put("datasources", "system")
-                .put("distributed-index-joins-enabled", "true")
                 .put("optimizer.optimize-mixed-distinct-aggregations", "true");
         if (coordinator) {
             propertiesBuilder.put("node-scheduler.include-coordinator", "true");
-            propertiesBuilder.put("distributed-joins-enabled", "true");
+            propertiesBuilder.put("join-distribution-type", "REPARTITIONED");
         }
         HashMap<String, String> properties = new HashMap<>(propertiesBuilder.build());
         properties.putAll(extraProperties);

--- a/presto-tests/src/main/java/com/facebook/presto/tests/statistics/Metric.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/statistics/Metric.java
@@ -14,23 +14,44 @@
 package com.facebook.presto.tests.statistics;
 
 import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.testing.MaterializedRow;
 
-import java.util.function.Function;
+import java.util.Objects;
+import java.util.Optional;
 
-public enum Metric
+public abstract class Metric<T>
 {
-    OUTPUT_ROW_COUNT(PlanNodeStatsEstimate::getOutputRowCount),
-    OUTPUT_SIZE_BYTES(PlanNodeStatsEstimate::getOutputSizeInBytes);
+    public abstract Optional<T> getValueFromPlanNodeEstimate(PlanNodeStatsEstimate planNodeStatsEstimate, StatsContext statsContext);
 
-    private final Function<PlanNodeStatsEstimate, Double> extractor;
+    public abstract Optional<T> getValueFromAggregationQuery(MaterializedRow aggregationQueryResult, int fieldId, StatsContext statsContext);
 
-    Metric(Function<PlanNodeStatsEstimate, Double> extractor)
+    public abstract String getComputingAggregationSql();
+
+    public abstract String getName();
+
+    // name based equality
+    @Override
+    public boolean equals(Object o)
     {
-        this.extractor = extractor;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Metric<?> metric = (Metric<?>) o;
+        return Objects.equals(getName(), metric.getName());
     }
 
-    Double getValue(PlanNodeStatsEstimate planNodeStatsEstimate)
+    @Override
+    public int hashCode()
     {
-        return extractor.apply(planNodeStatsEstimate);
+        return Objects.hash(getName());
+    }
+
+    @Override
+    public String toString()
+    {
+        return getName();
     }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/statistics/MetricComparator.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/statistics/MetricComparator.java
@@ -83,8 +83,10 @@ public class MetricComparator
     {
         return PlanNodeStatsEstimate.builder()
                 .setOutputRowCount(operatorStats.getPlanNodeOutputPositions())
-                .setOutputSizeInBytes(operatorStats.getPlanNodeOutputDataSize().toBytes())
                 .build();
+        // TODO think if we want to compare estimated data size with actual data size
+        //      hacky way to do it is to have single symbol with single range with data_size set to
+        //      new Estimate(operatorStats.getPlanNodeOutputDataSize().toBytes())
     }
 
     private MetricComparison createMetricComparison(Metric metric, PlanNode node, PlanNodeStatsEstimate estimate, Optional<PlanNodeStatsEstimate> execution)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/statistics/MetricComparator.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/statistics/MetricComparator.java
@@ -13,13 +13,16 @@
  */
 package com.facebook.presto.tests.statistics;
 
+import com.facebook.presto.Session;
 import com.facebook.presto.cost.PlanNodeStatsEstimate;
 import com.facebook.presto.execution.StageInfo;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.sql.planner.Plan;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.plan.OutputNode;
+import com.facebook.presto.testing.LocalQueryRunner;
 import com.facebook.presto.testing.MaterializedRow;
+import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.DistributedQueryRunner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -28,30 +31,68 @@ import com.google.common.collect.ImmutableSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 
+import static com.facebook.presto.transaction.TransactionBuilder.transaction;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 
 public class MetricComparator
 {
-    public Set<MetricComparison<?>> getMetricComparisons(String query, DistributedQueryRunner runner, Set<Metric<?>> metrics)
+    public Set<MetricComparison<?>> getMetricComparisons(String query, QueryRunner runner, Set<Metric<?>> metrics)
+    {
+        if (runner instanceof DistributedQueryRunner) {
+            return getMetricComparisonsDistributed(query, (DistributedQueryRunner) runner, metrics);
+        }
+        else if (runner instanceof LocalQueryRunner) {
+            return getMetricComparisonsLocal(query, (LocalQueryRunner) runner, metrics);
+        }
+        else {
+            throw new IllegalArgumentException("only local and distributed runner supported");
+        }
+    }
+
+    private Set<MetricComparison<?>> getMetricComparisonsDistributed(String query, DistributedQueryRunner runner, Set<Metric<?>> metrics)
     {
         String queryId = runner.executeWithQueryId(runner.getDefaultSession(), query).getQueryId();
         Plan queryPlan = runner.getQueryPlan(new QueryId(queryId));
         StageInfo stageInfo = runner.getQueryInfo(new QueryId(queryId)).getOutputStage().get();
         OutputNode outputNode = (OutputNode) stageInfo.getPlan().getRoot();
 
+        return getMetricComparisons(query, runner, queryPlan, outputNode, metrics);
+    }
+
+    private Set<MetricComparison<?>> getMetricComparisonsLocal(String query, LocalQueryRunner runner, Set<Metric<?>> metrics)
+    {
+        Plan queryPlan = inTransaction(runner, (session) -> runner.createPlan(session, query));
+        OutputNode outputNode = (OutputNode) queryPlan.getRoot();
+        return getMetricComparisons(query, runner, queryPlan, outputNode, metrics);
+    }
+
+    private <T> T inTransaction(QueryRunner runner, Function<Session, T> transactionSessionConsumer)
+    {
+        return transaction(runner.getTransactionManager(), runner.getAccessControl())
+                .singleStatement()
+                .execute(runner.getDefaultSession(), session -> {
+                    // metadata.getCatalogHandle() registers the catalog for the transaction
+                    session.getCatalog().ifPresent(catalog -> runner.getMetadata().getCatalogHandle(session, catalog));
+                    return transactionSessionConsumer.apply(session);
+                });
+    }
+
+    private Set<MetricComparison<?>> getMetricComparisons(String query, QueryRunner runner, Plan queryPlan, OutputNode outputNode, Set<Metric<?>> metrics)
+    {
         StatsContext statsContext = buildStatsContext(queryPlan, outputNode);
-        List<Metric<?>> metricsLists = ImmutableList.copyOf(metrics);
-        List<Optional<?>> actualValues = getActualValues(metricsLists, query, runner, statsContext);
-        List<Optional<?>> estimatedValues = getEstimatedValues(metricsLists, queryPlan.getPlanNodeStatsEstimates().get(outputNode.getId()), statsContext);
+        List<Metric<?>> metricsList = ImmutableList.copyOf(metrics);
+        List<Optional<?>> actualValues = getActualValues(metricsList, query, runner, statsContext);
+        List<Optional<?>> estimatedValues = getEstimatedValues(metricsList, queryPlan.getPlanNodeStatsEstimates().get(outputNode.getId()), statsContext);
 
         ImmutableSet.Builder<MetricComparison<?>> metricComparisons = ImmutableSet.builder();
-        for (int i = 0; i < metricsLists.size(); ++i) {
+        for (int i = 0; i < metricsList.size(); ++i) {
             metricComparisons.add(new MetricComparison(
                     outputNode,
-                    metricsLists.get(i),
+                    metricsList.get(i),
                     estimatedValues.get(i),
                     actualValues.get(i)));
         }
@@ -67,7 +108,7 @@ public class MetricComparator
         return new StatsContext(columnSymbols.build(), queryPlan.getTypes());
     }
 
-    private List<Optional<?>> getActualValues(List<Metric<?>> metrics, String query, DistributedQueryRunner runner, StatsContext statsContext)
+    private List<Optional<?>> getActualValues(List<Metric<?>> metrics, String query, QueryRunner runner, StatsContext statsContext)
     {
         String statsQuery = "SELECT "
                 + metrics.stream().map(Metric::getComputingAggregationSql).collect(joining(","))

--- a/presto-tests/src/main/java/com/facebook/presto/tests/statistics/MetricComparator.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/statistics/MetricComparator.java
@@ -15,89 +15,77 @@ package com.facebook.presto.tests.statistics;
 
 import com.facebook.presto.cost.PlanNodeStatsEstimate;
 import com.facebook.presto.execution.StageInfo;
+import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.sql.planner.Plan;
-import com.facebook.presto.sql.planner.plan.PlanNode;
-import com.facebook.presto.sql.planner.plan.PlanNodeId;
-import com.facebook.presto.sql.planner.planPrinter.PlanNodeStats;
-import com.facebook.presto.sql.planner.planPrinter.PlanNodeStatsSummarizer;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.plan.OutputNode;
+import com.facebook.presto.testing.MaterializedRow;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.function.BinaryOperator;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import java.util.Set;
 
-import static com.facebook.presto.execution.StageInfo.getAllStages;
-import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
-import static com.facebook.presto.util.MoreMaps.mergeMaps;
-import static com.google.common.collect.Maps.transformValues;
-import static java.util.Arrays.asList;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
 
 public class MetricComparator
 {
-    private final List<Metric> metrics = asList(Metric.values());
-    private final double tolerance = 0.1;
-
-    public List<MetricComparison> getMetricComparisons(Plan queryPlan, StageInfo outputStageInfo)
+    public Set<MetricComparison<?>> getMetricComparisons(String query, DistributedQueryRunner runner, Set<Metric<?>> metrics)
     {
-        return metrics.stream().flatMap(metric -> {
-            Map<PlanNodeId, PlanNodeStatsEstimate> estimates = queryPlan.getPlanNodeStatsEstimates();
-            Map<PlanNodeId, PlanNodeStatsEstimate> actuals = extractActualCosts(outputStageInfo);
-            return estimates.entrySet().stream().map(entry -> {
-                // todo refactor to stay in PlanNodeId domain ????
-                PlanNode node = planNodeForId(queryPlan, entry.getKey());
-                PlanNodeStatsEstimate estimate = entry.getValue();
-                Optional<PlanNodeStatsEstimate> execution = Optional.ofNullable(actuals.get(node.getId()));
-                return createMetricComparison(metric, node, estimate, execution);
-            });
-        }).collect(Collectors.toList());
+        String queryId = runner.executeWithQueryId(runner.getDefaultSession(), query).getQueryId();
+        Plan queryPlan = runner.getQueryPlan(new QueryId(queryId));
+        StageInfo stageInfo = runner.getQueryInfo(new QueryId(queryId)).getOutputStage().get();
+        OutputNode outputNode = (OutputNode) stageInfo.getPlan().getRoot();
+
+        StatsContext statsContext = buildStatsContext(queryPlan, outputNode);
+        List<Metric<?>> metricsLists = ImmutableList.copyOf(metrics);
+        List<Optional<?>> actualValues = getActualValues(metricsLists, query, runner, statsContext);
+        List<Optional<?>> estimatedValues = getEstimatedValues(metricsLists, queryPlan.getPlanNodeStatsEstimates().get(outputNode.getId()), statsContext);
+
+        ImmutableSet.Builder<MetricComparison<?>> metricComparisons = ImmutableSet.builder();
+        for (int i = 0; i < metricsLists.size(); ++i) {
+            metricComparisons.add(new MetricComparison(
+                    outputNode,
+                    metricsLists.get(i),
+                    estimatedValues.get(i),
+                    actualValues.get(i)));
+        }
+        return metricComparisons.build();
     }
 
-    private PlanNode planNodeForId(Plan queryPlan, PlanNodeId id)
+    private StatsContext buildStatsContext(Plan queryPlan, OutputNode outputNode)
     {
-        return searchFrom(queryPlan.getRoot())
-                .where(node -> node.getId().equals(id))
-                .findOnlyElement();
+        ImmutableMap.Builder<String, Symbol> columnSymbols = ImmutableMap.builder();
+        for (int columnId = 0; columnId < outputNode.getColumnNames().size(); ++columnId) {
+            columnSymbols.put(outputNode.getColumnNames().get(columnId), outputNode.getOutputSymbols().get(columnId));
+        }
+        return new StatsContext(columnSymbols.build(), queryPlan.getTypes());
     }
 
-    private Map<PlanNodeId, PlanNodeStatsEstimate> extractActualCosts(StageInfo outputStageInfo)
+    private List<Optional<?>> getActualValues(List<Metric<?>> metrics, String query, DistributedQueryRunner runner, StatsContext statsContext)
     {
-        Stream<Map<PlanNodeId, PlanNodeStats>> stagesStatsStream =
-                getAllStages(Optional.of(outputStageInfo)).stream()
-                        .map(PlanNodeStatsSummarizer::aggregatePlanNodeStats);
+        String statsQuery = "SELECT "
+                + metrics.stream().map(Metric::getComputingAggregationSql).collect(joining(","))
+                + " FROM (" + query + ")";
 
-        Map<PlanNodeId, PlanNodeStats> mergedStats = mergeStats(stagesStatsStream);
-        return transformValues(mergedStats, this::toPlanNodeStatsEstimate);
+        MaterializedRow actualValuesRow = getOnlyElement(runner.execute(statsQuery).getMaterializedRows());
+
+        ImmutableList.Builder<Optional<?>> actualValues = ImmutableList.builder();
+        for (int i = 0; i < metrics.size(); ++i) {
+            actualValues.add(metrics.get(i).getValueFromAggregationQuery(actualValuesRow, i, statsContext));
+        }
+        return actualValues.build();
     }
 
-    private Map<PlanNodeId, PlanNodeStats> mergeStats(Stream<Map<PlanNodeId, PlanNodeStats>> stagesStatsStream)
+    private List<Optional<?>> getEstimatedValues(List<Metric<?>> metrics, PlanNodeStatsEstimate outputNodeStatisticsEstimates, StatsContext statsContext)
     {
-        BinaryOperator<PlanNodeStats> allowNoDuplicates = (a, b) -> {
-            throw new IllegalArgumentException("PlanNodeIds must be unique");
-        };
-        return mergeMaps(stagesStatsStream, allowNoDuplicates);
-    }
-
-    private PlanNodeStatsEstimate toPlanNodeStatsEstimate(PlanNodeStats operatorStats)
-    {
-        return PlanNodeStatsEstimate.builder()
-                .setOutputRowCount(operatorStats.getPlanNodeOutputPositions())
-                .build();
-        // TODO think if we want to compare estimated data size with actual data size
-        //      hacky way to do it is to have single symbol with single range with data_size set to
-        //      new Estimate(operatorStats.getPlanNodeOutputDataSize().toBytes())
-    }
-
-    private MetricComparison createMetricComparison(Metric metric, PlanNode node, PlanNodeStatsEstimate estimate, Optional<PlanNodeStatsEstimate> execution)
-    {
-        Optional<Double> estimatedCost = asOptional(metric.getValue(estimate));
-        Optional<Double> executionCost = execution.flatMap(e -> asOptional(metric.getValue(e)));
-        return new MetricComparison(node, metric, estimatedCost, executionCost);
-    }
-
-    private Optional<Double> asOptional(double value)
-    {
-        return Double.isNaN(value) ? Optional.empty() : Optional.of(value);
+        return metrics.stream()
+                .map(metric -> metric.getValueFromPlanNodeEstimate(outputNodeStatisticsEstimates, statsContext))
+                .collect(toList());
     }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/statistics/MetricComparison.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/statistics/MetricComparison.java
@@ -23,19 +23,19 @@ import static com.facebook.presto.tests.statistics.MetricComparison.Result.NO_BA
 import static com.facebook.presto.tests.statistics.MetricComparison.Result.NO_ESTIMATE;
 import static java.lang.String.format;
 
-public class MetricComparison
+public class MetricComparison<T>
 {
     private final PlanNode planNode;
     private final Metric metric;
-    private final Optional<Double> estimatedCost;
-    private final Optional<Double> executionCost;
+    private final Optional<T> estimatedValue;
+    private final Optional<T> actualValue;
 
-    public MetricComparison(PlanNode planNode, Metric metric, Optional<Double> estimatedCost, Optional<Double> executionCost)
+    public MetricComparison(PlanNode planNode, Metric metric, Optional<T> estimatedValue, Optional<T> actualValue)
     {
         this.planNode = planNode;
         this.metric = metric;
-        this.estimatedCost = estimatedCost;
-        this.executionCost = executionCost;
+        this.estimatedValue = estimatedValue;
+        this.actualValue = actualValue;
     }
 
     public Metric getMetric()
@@ -52,19 +52,19 @@ public class MetricComparison
     public String toString()
     {
         return format("Metric [%s] - estimated: [%s], real: [%s] - plan node: [%s]",
-                metric, print(estimatedCost), print(executionCost), planNode);
+                metric, print(estimatedValue), print(actualValue), planNode);
     }
 
-    public Result result(MetricComparisonStrategy metricComparisonStrategy)
+    public Result result(MetricComparisonStrategy<T> metricComparisonStrategy)
     {
-        return estimatedCost
-                .map(estimate -> executionCost
+        return estimatedValue
+                .map(estimate -> actualValue
                         .map(execution -> metricComparisonStrategy.matches(execution, estimate) ? MATCH : DIFFER)
                         .orElse(NO_BASELINE))
                 .orElse(NO_ESTIMATE);
     }
 
-    private String print(Optional<Double> cost)
+    private String print(Optional<T> cost)
     {
         return cost.map(Object::toString).orElse("UNKNOWN");
     }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/statistics/MetricComparison.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/statistics/MetricComparison.java
@@ -57,6 +57,9 @@ public class MetricComparison<T>
 
     public Result result(MetricComparisonStrategy<T> metricComparisonStrategy)
     {
+        if (!estimatedValue.isPresent() && !actualValue.isPresent()) {
+            return MATCH;
+        }
         return estimatedValue
                 .map(estimate -> actualValue
                         .map(execution -> metricComparisonStrategy.matches(execution, estimate) ? MATCH : DIFFER)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/statistics/MetricComparisonStrategies.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/statistics/MetricComparisonStrategies.java
@@ -24,33 +24,33 @@ public class MetricComparisonStrategies
 {
     private MetricComparisonStrategies() {}
 
-    public static MetricComparisonStrategy noError()
+    public static MetricComparisonStrategy<Double> noError()
     {
         return absoluteError(0);
     }
 
-    public static MetricComparisonStrategy absoluteError(double error)
+    public static MetricComparisonStrategy<Double> absoluteError(double error)
     {
         return absoluteError(Range.closed(-error, error));
     }
 
-    public static MetricComparisonStrategy absoluteError(Range<Double> errorRange)
+    public static MetricComparisonStrategy<Double> absoluteError(Range<Double> errorRange)
     {
         return (actual, estimate) -> mapRange(errorRange, endpoint -> endpoint + actual)
                 .contains(estimate);
     }
 
-    public static MetricComparisonStrategy defaultTolerance()
+    public static MetricComparisonStrategy<Double> defaultTolerance()
     {
         return relativeError(.1);
     }
 
-    public static MetricComparisonStrategy relativeError(double error)
+    public static MetricComparisonStrategy<Double> relativeError(double error)
     {
         return relativeError(Range.closed(-error, error));
     }
 
-    public static MetricComparisonStrategy relativeError(Range<Double> errorRange)
+    public static MetricComparisonStrategy<Double> relativeError(Range<Double> errorRange)
     {
         return (actual, estimate) -> mapRange(errorRange, endpoint -> (endpoint + 1) * actual)
                 .contains(estimate);

--- a/presto-tests/src/main/java/com/facebook/presto/tests/statistics/MetricComparisonStrategies.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/statistics/MetricComparisonStrategies.java
@@ -56,6 +56,11 @@ public class MetricComparisonStrategies
                 .contains(estimate);
     }
 
+    public static MetricComparisonStrategy<Object> isEqual()
+    {
+        return Object::equals;
+    }
+
     private static Range<Double> mapRange(Range<Double> range, Function<Double, Double> mappingFunction)
     {
         checkArgument(range.hasLowerBound() && range.hasUpperBound(), "Expected error range to have lower and upper bound");

--- a/presto-tests/src/main/java/com/facebook/presto/tests/statistics/MetricComparisonStrategy.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/statistics/MetricComparisonStrategy.java
@@ -14,7 +14,7 @@
 
 package com.facebook.presto.tests.statistics;
 
-public interface MetricComparisonStrategy
+public interface MetricComparisonStrategy<T>
 {
-    boolean matches(double actual, double estimate);
+    boolean matches(T actual, T estimate);
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/statistics/Metrics.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/statistics/Metrics.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests.statistics;
+
+import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.cost.SymbolStatsEstimate;
+import com.facebook.presto.testing.MaterializedRow;
+
+import java.util.Optional;
+
+import static java.lang.Double.isNaN;
+
+public final class Metrics
+{
+    private Metrics() {}
+
+    public static final Metric<Double> OUTPUT_ROW_COUNT = new Metric<Double>()
+    {
+        @Override
+        public Optional<Double> getValueFromPlanNodeEstimate(PlanNodeStatsEstimate planNodeStatsEstimate, StatsContext statsContext)
+        {
+            return asOptional(planNodeStatsEstimate.getOutputRowCount());
+        }
+
+        @Override
+        public Optional<Double> getValueFromAggregationQuery(MaterializedRow aggregationQueryResult, int fieldId, StatsContext statsContext)
+        {
+            return Optional.of(((Number) aggregationQueryResult.getField(fieldId)).doubleValue());
+        }
+
+        @Override
+        public String getComputingAggregationSql()
+        {
+            return "count(*)";
+        }
+
+        @Override
+        public String getName()
+        {
+            return "OUTPUT_ROW_COUNT";
+        }
+    };
+
+    public static Metric<Double> nullsFraction(String columnName)
+    {
+        return new Metric<Double>()
+        {
+            @Override
+            public Optional<Double> getValueFromPlanNodeEstimate(PlanNodeStatsEstimate planNodeStatsEstimate, StatsContext statsContext)
+            {
+                return asOptional(getSymbolStatistics(planNodeStatsEstimate, columnName, statsContext).getNullsFraction());
+            }
+
+            @Override
+            public Optional<Double> getValueFromAggregationQuery(MaterializedRow aggregationQueryResult, int fieldId, StatsContext statsContext)
+            {
+                return Optional.of(((Number) aggregationQueryResult.getField(fieldId)).doubleValue());
+            }
+
+            @Override
+            public String getComputingAggregationSql()
+            {
+                return "(count(*) filter(where " + columnName + " is null)) / cast(count(*) as double)";
+            }
+
+            @Override
+            public String getName()
+            {
+                return "NULLS_FRACTION(" + columnName + ")";
+            }
+        };
+    }
+
+    public static Metric<Double> distinctValuesCount(String columnName)
+    {
+        return new Metric<Double>()
+        {
+            @Override
+            public Optional<Double> getValueFromPlanNodeEstimate(PlanNodeStatsEstimate planNodeStatsEstimate, StatsContext statsContext)
+            {
+                return asOptional(getSymbolStatistics(planNodeStatsEstimate, columnName, statsContext).getDistinctValuesCount());
+            }
+
+            @Override
+            public Optional getValueFromAggregationQuery(MaterializedRow aggregationQueryResult, int fieldId, StatsContext statsContext)
+            {
+                return Optional.of(((Number) aggregationQueryResult.getField(fieldId)).doubleValue());
+            }
+
+            @Override
+            public String getComputingAggregationSql()
+            {
+                return "count(distinct " + columnName + ")";
+            }
+
+            @Override
+            public String getName()
+            {
+                return "DISTINCT_VALUES_COUNT(" + columnName + ")";
+            }
+        };
+    }
+
+    private static SymbolStatsEstimate getSymbolStatistics(PlanNodeStatsEstimate planNodeStatsEstimate, String columnName, StatsContext statsContext)
+    {
+        return planNodeStatsEstimate.getSymbolStatistics(statsContext.getSymbolForColumn(columnName));
+    }
+
+    private static Optional<Double> asOptional(double value)
+    {
+        return isNaN(value) ? Optional.empty() : Optional.of(value);
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/statistics/Metrics.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/statistics/Metrics.java
@@ -19,6 +19,7 @@ import com.facebook.presto.testing.MaterializedRow;
 
 import java.util.Optional;
 
+import static java.lang.Double.isInfinite;
 import static java.lang.Double.isNaN;
 
 public final class Metrics
@@ -108,6 +109,78 @@ public final class Metrics
             public String getName()
             {
                 return "DISTINCT_VALUES_COUNT(" + columnName + ")";
+            }
+        };
+    }
+
+    public static Metric<Object> lowValue(String columnName)
+    {
+        return new Metric<Object>()
+        {
+            @Override
+            public Optional<Object> getValueFromPlanNodeEstimate(PlanNodeStatsEstimate planNodeStatsEstimate, StatsContext statsContext)
+            {
+                double lowValue = getSymbolStatistics(planNodeStatsEstimate, columnName, statsContext).getLowValue();
+                if (isInfinite(lowValue)) {
+                    return Optional.empty();
+                }
+                else {
+                    return Optional.of(lowValue);
+                }
+            }
+
+            @Override
+            public Optional<Object> getValueFromAggregationQuery(MaterializedRow aggregationQueryResult, int fieldId, StatsContext statsContext)
+            {
+                return Optional.ofNullable(aggregationQueryResult.getField(fieldId)).map(value -> ((Number) value).doubleValue());
+            }
+
+            @Override
+            public String getComputingAggregationSql()
+            {
+                return "try_cast(min(" + columnName + ") as double)";
+            }
+
+            @Override
+            public String getName()
+            {
+                return "LOW_VALUE(" + columnName + ")";
+            }
+        };
+    }
+
+    public static Metric<Object> highValue(String columnName)
+    {
+        return new Metric<Object>()
+        {
+            @Override
+            public Optional<Object> getValueFromPlanNodeEstimate(PlanNodeStatsEstimate planNodeStatsEstimate, StatsContext statsContext)
+            {
+                double highValue = getSymbolStatistics(planNodeStatsEstimate, columnName, statsContext).getHighValue();
+                if (isInfinite(highValue)) {
+                    return Optional.empty();
+                }
+                else {
+                    return Optional.of(highValue);
+                }
+            }
+
+            @Override
+            public Optional<Object> getValueFromAggregationQuery(MaterializedRow aggregationQueryResult, int fieldId, StatsContext statsContext)
+            {
+                return Optional.ofNullable(aggregationQueryResult.getField(fieldId)).map(value -> ((Number) value).doubleValue());
+            }
+
+            @Override
+            public String getComputingAggregationSql()
+            {
+                return "max(try_cast(" + columnName + " as double))";
+            }
+
+            @Override
+            public String getName()
+            {
+                return "HIGH_VALUE(" + columnName + ")";
             }
         };
     }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/statistics/StatisticsAssertion.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/statistics/StatisticsAssertion.java
@@ -14,7 +14,7 @@
 
 package com.facebook.presto.tests.statistics;
 
-import com.facebook.presto.tests.DistributedQueryRunner;
+import com.facebook.presto.testing.QueryRunner;
 import org.intellij.lang.annotations.Language;
 
 import java.util.ArrayList;
@@ -33,9 +33,9 @@ import static org.testng.Assert.assertTrue;
 
 public class StatisticsAssertion
 {
-    private final DistributedQueryRunner runner;
+    private final QueryRunner runner;
 
-    public StatisticsAssertion(DistributedQueryRunner runner)
+    public StatisticsAssertion(QueryRunner runner)
     {
         this.runner = requireNonNull(runner, "runner is null");
     }
@@ -83,7 +83,7 @@ public class StatisticsAssertion
             return this;
         }
 
-        void run(@Language("SQL") String query, DistributedQueryRunner runner)
+        void run(@Language("SQL") String query, QueryRunner runner)
         {
             Set<Metric<?>> metrics = checks.stream()
                     .map(check -> check.metric)
@@ -94,7 +94,7 @@ public class StatisticsAssertion
             }
         }
 
-        private Set<MetricComparison<?>> metricComparisons(@Language("SQL") String query, DistributedQueryRunner queryRunner, Set<Metric<?>> metrics)
+        private Set<MetricComparison<?>> metricComparisons(@Language("SQL") String query, QueryRunner queryRunner, Set<Metric<?>> metrics)
         {
             return new MetricComparator().getMetricComparisons(query, queryRunner, metrics);
         }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/statistics/StatisticsAssertion.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/statistics/StatisticsAssertion.java
@@ -14,23 +14,19 @@
 
 package com.facebook.presto.tests.statistics;
 
-import com.facebook.presto.execution.StageInfo;
-import com.facebook.presto.spi.QueryId;
-import com.facebook.presto.sql.planner.Plan;
-import com.facebook.presto.sql.planner.plan.OutputNode;
-import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.tests.DistributedQueryRunner;
-import com.google.common.collect.ImmutableList;
 import org.intellij.lang.annotations.Language;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 import static com.facebook.presto.tests.statistics.MetricComparison.Result.MATCH;
 import static com.facebook.presto.tests.statistics.MetricComparison.Result.NO_BASELINE;
 import static com.facebook.presto.tests.statistics.MetricComparison.Result.NO_ESTIMATE;
-import static com.facebook.presto.tests.statistics.MetricComparisonStrategies.defaultTolerance;
-import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static org.testng.Assert.assertTrue;
@@ -44,55 +40,73 @@ public class StatisticsAssertion
         this.runner = requireNonNull(runner, "runner is null");
     }
 
-    public Result check(@Language("SQL") String query)
+    public void check(@Language("SQL") String query, Consumer<Checks> checksBuilderConsumer)
     {
-        return new Result(metricComparisons(query));
+        Checks checks = new Checks();
+        checksBuilderConsumer.accept(checks);
+        checks.run(query, runner);
     }
 
-    public List<MetricComparison> metricComparisons(@Language("SQL") String query)
+    private static class MetricsCheck<T>
     {
-        String queryId = runner.executeWithQueryId(runner.getDefaultSession(), query).getQueryId();
-        Plan queryPlan = runner.getQueryPlan(new QueryId(queryId));
-        StageInfo stageInfo = runner.getQueryInfo(new QueryId(queryId)).getOutputStage().get();
-        return new MetricComparator().getMetricComparisons(queryPlan, stageInfo);
+        public final Metric<T> metric;
+        public final MetricComparisonStrategy<T> strategy;
+        public final MetricComparison.Result expectedComparisonResult;
+
+        public MetricsCheck(Metric<T> metric, MetricComparisonStrategy<T> strategy, MetricComparison.Result expectedComparisonResult)
+        {
+            this.metric = metric;
+            this.strategy = strategy;
+            this.expectedComparisonResult = expectedComparisonResult;
+        }
     }
 
-    public static class Result
+    public static class Checks
     {
-        private static final Predicate<PlanNode> IS_OUTPUT_NODE = OutputNode.class::isInstance;
+        private final List<MetricsCheck<?>> checks = new ArrayList<>();
 
-        private final List<MetricComparison> metricComparisons;
-
-        public Result(List<MetricComparison> metricComparisons)
+        public <T> Checks estimate(Metric<T> metric, MetricComparisonStrategy<T> strategy)
         {
-            checkArgument(!metricComparisons.isEmpty(), "No metric comparisons given");
-            this.metricComparisons = ImmutableList.copyOf(metricComparisons);
+            checks.add(new MetricsCheck<>(metric, strategy, MATCH));
+            return this;
         }
 
-        public Result estimate(Metric metric, MetricComparisonStrategy strategy)
+        public <T> Checks noEstimate(Metric<T> metric)
         {
-            return testMetrics(metric, metricComparison -> metricComparison.result(strategy) == MATCH);
+            checks.add(new MetricsCheck<>(metric, (actual, estimate) -> true, NO_ESTIMATE));
+            return this;
         }
 
-        private Result testMetrics(Metric metric, Predicate<MetricComparison> assertCondition)
+        public <T> Checks noBaseline(Metric<T> metric)
+        {
+            checks.add(new MetricsCheck<>(metric, (actual, estimate) -> true, NO_BASELINE));
+            return this;
+        }
+
+        void run(@Language("SQL") String query, DistributedQueryRunner runner)
+        {
+            Set<Metric<?>> metrics = checks.stream()
+                    .map(check -> check.metric)
+                    .collect(toImmutableSet());
+            Set<MetricComparison<?>> metricComparisons = metricComparisons(query, runner, metrics);
+            for (MetricsCheck check : checks) {
+                testMetrics(check.metric, metricComparison -> metricComparison.result(check.strategy) == check.expectedComparisonResult, metricComparisons);
+            }
+        }
+
+        private Set<MetricComparison<?>> metricComparisons(@Language("SQL") String query, DistributedQueryRunner queryRunner, Set<Metric<?>> metrics)
+        {
+            return new MetricComparator().getMetricComparisons(query, queryRunner, metrics);
+        }
+
+        private Checks testMetrics(Metric metric, Predicate<MetricComparison> assertCondition, Set<MetricComparison<?>> metricComparisons)
         {
             List<MetricComparison> testMetrics = metricComparisons.stream()
-                    .filter(metricComparison -> metricComparison.getMetric() == metric)
-                    .filter(metricComparison -> IS_OUTPUT_NODE.test(metricComparison.getPlanNode()))
+                    .filter(metricComparison -> metricComparison.getMetric().equals(metric))
                     .collect(toList());
             assertTrue(testMetrics.size() > 0, "No metric found for: " + metric);
             assertTrue(testMetrics.stream().allMatch(assertCondition), "Following metrics do not match: " + testMetrics);
             return this;
-        }
-
-        public Result noEstimate(Metric metric)
-        {
-            return testMetrics(metric, metricComparison -> metricComparison.result(defaultTolerance()) == NO_ESTIMATE);
-        }
-
-        public Result noBaseline(Metric metric)
-        {
-            return testMetrics(metric, metricComparison -> metricComparison.result(defaultTolerance()) == NO_BASELINE);
         }
     }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/statistics/StatisticsAssertion.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/statistics/StatisticsAssertion.java
@@ -26,6 +26,12 @@ import java.util.function.Predicate;
 import static com.facebook.presto.tests.statistics.MetricComparison.Result.MATCH;
 import static com.facebook.presto.tests.statistics.MetricComparison.Result.NO_BASELINE;
 import static com.facebook.presto.tests.statistics.MetricComparison.Result.NO_ESTIMATE;
+import static com.facebook.presto.tests.statistics.MetricComparisonStrategies.isEqual;
+import static com.facebook.presto.tests.statistics.MetricComparisonStrategies.noError;
+import static com.facebook.presto.tests.statistics.Metrics.distinctValuesCount;
+import static com.facebook.presto.tests.statistics.Metrics.highValue;
+import static com.facebook.presto.tests.statistics.Metrics.lowValue;
+import static com.facebook.presto.tests.statistics.Metrics.nullsFraction;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
@@ -64,6 +70,15 @@ public class StatisticsAssertion
     public static class Checks
     {
         private final List<MetricsCheck<?>> checks = new ArrayList<>();
+
+        public Checks verifyExactColumnStatistics(String columnName)
+        {
+            estimate(nullsFraction(columnName), noError());
+            estimate(distinctValuesCount(columnName), noError());
+            estimate(lowValue(columnName), isEqual());
+            estimate(highValue(columnName), isEqual());
+            return this;
+        }
 
         public <T> Checks estimate(Metric<T> metric, MetricComparisonStrategy<T> strategy)
         {

--- a/presto-tests/src/main/java/com/facebook/presto/tests/statistics/StatsContext.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/statistics/StatsContext.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests.statistics;
+
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.Symbol;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class StatsContext
+{
+    private final Map<String, Symbol> columnSymbols;
+    private final Map<Symbol, Type> symbolTypes;
+
+    public StatsContext(Map<String, Symbol> columnSymbols, Map<Symbol, Type> symbolTypes)
+    {
+        this.columnSymbols = ImmutableMap.copyOf(columnSymbols);
+        this.symbolTypes = ImmutableMap.copyOf(symbolTypes);
+    }
+
+    public Symbol getSymbolForColumn(String columnName)
+    {
+        checkArgument(columnSymbols.containsKey(columnName), "no symbol found for column '" + columnName + "'");
+        return columnSymbols.get(columnName);
+    }
+
+    public Type getTypeForSymbol(Symbol symbol)
+    {
+        checkArgument(symbolTypes.containsKey(symbol), "no type found found for symbol '" + symbol + "'");
+        return symbolTypes.get(symbol);
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueries.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueries.java
@@ -72,8 +72,8 @@ public class TestLocalQueries
         // FIXME Add tests for more complex scenario with more stats
         MaterializedResult result = computeActual("SHOW STATS FOR nation");
 
-        MaterializedResult expectedStatistics = resultBuilder(getSession(), VARCHAR, DOUBLE)
-                .row(null, 25.0)
+        MaterializedResult expectedStatistics = resultBuilder(getSession(), VARCHAR, DOUBLE, VARCHAR, VARCHAR)
+                .row(null, 25.0, null, null)
                 .build();
 
         assertEquals(result, expectedStatistics);

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueries.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueries.java
@@ -72,8 +72,15 @@ public class TestLocalQueries
         // FIXME Add tests for more complex scenario with more stats
         MaterializedResult result = computeActual("SHOW STATS FOR nation");
 
-        MaterializedResult expectedStatistics = resultBuilder(getSession(), VARCHAR, DOUBLE, VARCHAR, VARCHAR)
-                .row(null, 25.0, null, null)
+        MaterializedResult expectedStatistics =
+                resultBuilder(getSession(), VARCHAR, DOUBLE, DOUBLE, DOUBLE, DOUBLE, VARCHAR, VARCHAR)
+                .row("regionkey", null, 5.0, null, null, "0", "4")
+                .row("name", null, 25.0, null, null, "ALGERIA", "VIETNAM")
+                .row("comment", null, 25.0, null, null,
+                        " haggle. carefully final deposits detect slyly agai",
+                        "y final packages. slow foxes cajole quickly. quickly silent platelets breach ironic accounts. unusual pinto be")
+                .row("nationkey", null, 25.0, null, null, "0", "24")
+                .row(null, null, null, null, 25.0, null, null)
                 .build();
 
         assertEquals(result, expectedStatistics);

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchDistributedStats.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchDistributedStats.java
@@ -20,11 +20,11 @@ import com.google.common.collect.Range;
 import io.airlift.tpch.TpchTable;
 import org.testng.annotations.Test;
 
-import static com.facebook.presto.tests.statistics.Metric.OUTPUT_ROW_COUNT;
 import static com.facebook.presto.tests.statistics.MetricComparisonStrategies.absoluteError;
 import static com.facebook.presto.tests.statistics.MetricComparisonStrategies.defaultTolerance;
 import static com.facebook.presto.tests.statistics.MetricComparisonStrategies.noError;
 import static com.facebook.presto.tests.statistics.MetricComparisonStrategies.relativeError;
+import static com.facebook.presto.tests.statistics.Metrics.OUTPUT_ROW_COUNT;
 import static com.facebook.presto.tests.tpch.TpchQueryRunner.createQueryRunnerWithoutCatalogs;
 import static java.util.Collections.emptyMap;
 
@@ -46,9 +46,10 @@ public class TestTpchDistributedStats
     void testTableScanStats()
     {
         TpchTable.getTables()
-                .forEach(table -> statisticsAssertion.check("SELECT * FROM " + table.getTableName())
-                        // TODO use noError
-                        .estimate(OUTPUT_ROW_COUNT, defaultTolerance()));
+                .forEach(table -> statisticsAssertion.check("SELECT * FROM " + table.getTableName(),
+                        checks -> checks
+                                // TODO use noError
+                                .estimate(OUTPUT_ROW_COUNT, defaultTolerance())));
     }
 
     @Test
@@ -58,63 +59,70 @@ public class TestTpchDistributedStats
                 "SELECT * " +
                 "FROM lineitem " +
                 "WHERE l_shipdate <= DATE '1998-12-01' - INTERVAL '90' DAY";
-        statisticsAssertion.check(query)
-                .estimate(OUTPUT_ROW_COUNT, relativeError(Range.closed(-.55, -.45)));
+        statisticsAssertion.check(query,
+                checks -> checks
+                        .estimate(OUTPUT_ROW_COUNT, relativeError(Range.closed(-.55, -.45))));
     }
 
     @Test
     void testJoin()
     {
-        statisticsAssertion.check("SELECT * FROM  part, partsupp WHERE p_partkey = ps_partkey")
-                .estimate(OUTPUT_ROW_COUNT, relativeError(Range.closed(.95, 1.05)));
+        statisticsAssertion.check("SELECT * FROM  part, partsupp WHERE p_partkey = ps_partkey",
+                checks -> checks
+                        .estimate(OUTPUT_ROW_COUNT, relativeError(Range.closed(.95, 1.05))));
     }
 
     @Test
     void testSetOperations()
     {
-        statisticsAssertion.check("SELECT * FROM nation UNION SELECT * FROM nation")
-                .noEstimate(OUTPUT_ROW_COUNT);
+        statisticsAssertion.check("SELECT * FROM nation UNION SELECT * FROM nation",
+                checks -> checks
+                        .noEstimate(OUTPUT_ROW_COUNT));
 
-        statisticsAssertion.check("SELECT * FROM nation INTERSECT SELECT * FROM nation")
-                .noEstimate(OUTPUT_ROW_COUNT);
+        statisticsAssertion.check("SELECT * FROM nation INTERSECT SELECT * FROM nation",
+                checks -> checks
+                        .noEstimate(OUTPUT_ROW_COUNT));
 
-        statisticsAssertion.check("SELECT * FROM nation EXCEPT SELECT * FROM nation")
-                .noEstimate(OUTPUT_ROW_COUNT);
+        statisticsAssertion.check("SELECT * FROM nation EXCEPT SELECT * FROM nation",
+                checks -> checks
+                        .noEstimate(OUTPUT_ROW_COUNT));
     }
 
     @Test
     void testEnforceSingleRow()
     {
         String query = "SELECT (SELECT n_regionkey FROM nation WHERE n_name = 'Germany')";
-        statisticsAssertion.check(query)
-                .estimate(OUTPUT_ROW_COUNT, noError());
+        statisticsAssertion.check(query,
+                checks -> checks
+                        .estimate(OUTPUT_ROW_COUNT, noError()));
     }
 
     @Test
     void testValues()
     {
         String query = "VALUES 1";
-        statisticsAssertion.check(query)
-                .estimate(OUTPUT_ROW_COUNT, noError());
+        statisticsAssertion.check(query,
+                checks -> checks
+                        .estimate(OUTPUT_ROW_COUNT, noError()));
     }
 
     @Test
     void testSemiJoin()
     {
-        statisticsAssertion.check("SELECT * FROM nation WHERE n_regionkey IN (SELECT r_regionkey FROM region)")
-                .estimate(OUTPUT_ROW_COUNT, noError());
-        statisticsAssertion.check("SELECT * FROM nation WHERE n_regionkey IN (SELECT r_regionkey FROM region WHERE r_regionkey % 3 = 0)")
-                .estimate(OUTPUT_ROW_COUNT, absoluteError(Range.singleton(15.)));
+        statisticsAssertion.check("SELECT * FROM nation WHERE n_regionkey IN (SELECT r_regionkey FROM region)",
+                checks -> checks
+                        .estimate(OUTPUT_ROW_COUNT, noError()));
+        statisticsAssertion.check("SELECT * FROM nation WHERE n_regionkey IN (SELECT r_regionkey FROM region WHERE r_regionkey % 3 = 0)",
+                checks -> checks
+                        .estimate(OUTPUT_ROW_COUNT, absoluteError(Range.singleton(15.))));
     }
 
     @Test
     void testLimit()
     {
-        statisticsAssertion.check("SELECT * FROM nation LIMIT 10")
-                .estimate(OUTPUT_ROW_COUNT, noError());
-
-        statisticsAssertion.check("SELECT * FROM nation LIMIT 30")
-                .estimate(OUTPUT_ROW_COUNT, noError());
+        statisticsAssertion.check("SELECT * FROM nation LIMIT 10",
+                checks -> checks
+                        .estimate(OUTPUT_ROW_COUNT, noError()));
     }
 
     @Test
@@ -124,7 +132,8 @@ public class TestTpchDistributedStats
                 "SELECT l_returnflag, l_linestatus " +
                 "FROM lineitem " +
                 "GROUP BY l_returnflag, l_linestatus";
-        statisticsAssertion.check(query)
-                .noEstimate(OUTPUT_ROW_COUNT);
+        statisticsAssertion.check(query,
+                checks -> checks
+                        .noEstimate(OUTPUT_ROW_COUNT));
     }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchDistributedStats.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchDistributedStats.java
@@ -42,7 +42,7 @@ public class TestTpchDistributedStats
         statisticsAssertion = new StatisticsAssertion(runner);
     }
 
-    @Test
+    @Test(enabled = false)
     void testTableScanStats()
     {
         TpchTable.getTables()
@@ -52,7 +52,7 @@ public class TestTpchDistributedStats
                                 .estimate(OUTPUT_ROW_COUNT, defaultTolerance())));
     }
 
-    @Test
+    @Test(enabled = false)
     void testFilter()
     {
         String query = "" +
@@ -64,7 +64,7 @@ public class TestTpchDistributedStats
                         .estimate(OUTPUT_ROW_COUNT, relativeError(Range.closed(-.55, -.45))));
     }
 
-    @Test
+    @Test(enabled = false)
     void testJoin()
     {
         statisticsAssertion.check("SELECT * FROM  part, partsupp WHERE p_partkey = ps_partkey",
@@ -72,7 +72,7 @@ public class TestTpchDistributedStats
                         .estimate(OUTPUT_ROW_COUNT, relativeError(Range.closed(.95, 1.05))));
     }
 
-    @Test
+    @Test(enabled = false)
     void testSetOperations()
     {
         statisticsAssertion.check("SELECT * FROM nation UNION SELECT * FROM nation",
@@ -88,7 +88,7 @@ public class TestTpchDistributedStats
                         .noEstimate(OUTPUT_ROW_COUNT));
     }
 
-    @Test
+    @Test(enabled = false)
     void testEnforceSingleRow()
     {
         String query = "SELECT (SELECT n_regionkey FROM nation WHERE n_name = 'Germany')";
@@ -97,7 +97,7 @@ public class TestTpchDistributedStats
                         .estimate(OUTPUT_ROW_COUNT, noError()));
     }
 
-    @Test
+    @Test(enabled = false)
     void testValues()
     {
         String query = "VALUES 1";
@@ -106,7 +106,7 @@ public class TestTpchDistributedStats
                         .estimate(OUTPUT_ROW_COUNT, noError()));
     }
 
-    @Test
+    @Test(enabled = false)
     void testSemiJoin()
     {
         statisticsAssertion.check("SELECT * FROM nation WHERE n_regionkey IN (SELECT r_regionkey FROM region)",
@@ -117,7 +117,7 @@ public class TestTpchDistributedStats
                         .estimate(OUTPUT_ROW_COUNT, absoluteError(Range.singleton(15.))));
     }
 
-    @Test
+    @Test(enabled = false)
     void testLimit()
     {
         statisticsAssertion.check("SELECT * FROM nation LIMIT 10",
@@ -125,7 +125,7 @@ public class TestTpchDistributedStats
                         .estimate(OUTPUT_ROW_COUNT, noError()));
     }
 
-    @Test
+    @Test(enabled = false)
     void testGroupBy()
     {
         String query = "" +

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchLocalStats.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchLocalStats.java
@@ -19,9 +19,18 @@ import com.facebook.presto.tests.statistics.StatisticsAssertion;
 import com.facebook.presto.tpch.ColumnNaming;
 import com.facebook.presto.tpch.TpchConnectorFactory;
 import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
 
 import static com.facebook.presto.SystemSessionProperties.PUSH_PARTIAL_AGGREGATION_THROUGH_JOIN;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.facebook.presto.tests.statistics.MetricComparisonStrategies.defaultTolerance;
+import static com.facebook.presto.tests.statistics.MetricComparisonStrategies.isEqual;
+import static com.facebook.presto.tests.statistics.MetricComparisonStrategies.noError;
+import static com.facebook.presto.tests.statistics.Metrics.OUTPUT_ROW_COUNT;
+import static com.facebook.presto.tests.statistics.Metrics.distinctValuesCount;
+import static com.facebook.presto.tests.statistics.Metrics.highValue;
+import static com.facebook.presto.tests.statistics.Metrics.lowValue;
+import static com.facebook.presto.tests.statistics.Metrics.nullsFraction;
 import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 
 public class TestTpchLocalStats
@@ -40,7 +49,31 @@ public class TestTpchLocalStats
         LocalQueryRunner runner = new LocalQueryRunner(defaultSession);
         runner.createCatalog("tpch", new TpchConnectorFactory(1),
                 ImmutableMap.of("tpch.column-naming", ColumnNaming.STANDARD.name()
-        ));
+                ));
         statisticsAssertion = new StatisticsAssertion(runner);
+    }
+
+    @Test
+    void testTableScanStats()
+    {
+        statisticsAssertion.check("SELECT * FROM nation",
+                checks -> checks
+                        .estimate(OUTPUT_ROW_COUNT, defaultTolerance())
+
+                        .estimate(nullsFraction("n_nationkey"), noError())
+                        .estimate(distinctValuesCount("n_nationkey"), noError())
+                        .estimate(lowValue("n_nationkey"), isEqual())
+                        .estimate(highValue("n_nationkey"), isEqual())
+
+                        .estimate(distinctValuesCount("n_regionkey"), noError())
+                        .estimate(nullsFraction("n_regionkey"), noError())
+                        .estimate(lowValue("n_regionkey"), isEqual())
+                        .estimate(highValue("n_regionkey"), isEqual())
+
+                        .estimate(distinctValuesCount("n_name"), noError())
+                        .estimate(nullsFraction("n_name"), noError())
+                        .estimate(lowValue("n_name"), isEqual())
+                        .estimate(highValue("n_name"), isEqual())
+        );
     }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchLocalStats.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchLocalStats.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.facebook.presto.tests.statistics.StatisticsAssertion;
+import com.facebook.presto.tpch.ColumnNaming;
+import com.facebook.presto.tpch.TpchConnectorFactory;
+import com.google.common.collect.ImmutableMap;
+
+import static com.facebook.presto.SystemSessionProperties.PUSH_PARTIAL_AGGREGATION_THROUGH_JOIN;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+
+public class TestTpchLocalStats
+{
+    private final StatisticsAssertion statisticsAssertion;
+
+    public TestTpchLocalStats()
+            throws Exception
+    {
+        Session defaultSession = testSessionBuilder()
+                .setCatalog("tpch")
+                .setSchema(TINY_SCHEMA_NAME)
+                .setSystemProperty(PUSH_PARTIAL_AGGREGATION_THROUGH_JOIN, "true")
+                .build();
+
+        LocalQueryRunner runner = new LocalQueryRunner(defaultSession);
+        runner.createCatalog("tpch", new TpchConnectorFactory(1),
+                ImmutableMap.of("tpch.column-naming", ColumnNaming.STANDARD.name()
+        ));
+        statisticsAssertion = new StatisticsAssertion(runner);
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchLocalStats.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchLocalStats.java
@@ -24,13 +24,7 @@ import org.testng.annotations.Test;
 import static com.facebook.presto.SystemSessionProperties.PUSH_PARTIAL_AGGREGATION_THROUGH_JOIN;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.tests.statistics.MetricComparisonStrategies.defaultTolerance;
-import static com.facebook.presto.tests.statistics.MetricComparisonStrategies.isEqual;
-import static com.facebook.presto.tests.statistics.MetricComparisonStrategies.noError;
 import static com.facebook.presto.tests.statistics.Metrics.OUTPUT_ROW_COUNT;
-import static com.facebook.presto.tests.statistics.Metrics.distinctValuesCount;
-import static com.facebook.presto.tests.statistics.Metrics.highValue;
-import static com.facebook.presto.tests.statistics.Metrics.lowValue;
-import static com.facebook.presto.tests.statistics.Metrics.nullsFraction;
 import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 
 public class TestTpchLocalStats
@@ -59,21 +53,9 @@ public class TestTpchLocalStats
         statisticsAssertion.check("SELECT * FROM nation",
                 checks -> checks
                         .estimate(OUTPUT_ROW_COUNT, defaultTolerance())
-
-                        .estimate(nullsFraction("n_nationkey"), noError())
-                        .estimate(distinctValuesCount("n_nationkey"), noError())
-                        .estimate(lowValue("n_nationkey"), isEqual())
-                        .estimate(highValue("n_nationkey"), isEqual())
-
-                        .estimate(distinctValuesCount("n_regionkey"), noError())
-                        .estimate(nullsFraction("n_regionkey"), noError())
-                        .estimate(lowValue("n_regionkey"), isEqual())
-                        .estimate(highValue("n_regionkey"), isEqual())
-
-                        .estimate(distinctValuesCount("n_name"), noError())
-                        .estimate(nullsFraction("n_name"), noError())
-                        .estimate(lowValue("n_name"), isEqual())
-                        .estimate(highValue("n_name"), isEqual())
+                        .verifyExactColumnStatistics("n_nationkey")
+                        .verifyExactColumnStatistics("n_regionkey")
+                        .verifyExactColumnStatistics("n_name")
         );
     }
 

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchLocalStats.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchLocalStats.java
@@ -76,4 +76,46 @@ public class TestTpchLocalStats
                         .estimate(highValue("n_name"), isEqual())
         );
     }
+
+    @Test
+    void testSimpleJoinStats()
+    {
+        statisticsAssertion.check("SELECT * FROM supplier s, nation n",
+                checks -> checks
+                        .estimate(OUTPUT_ROW_COUNT, defaultTolerance())
+                        .verifyExactColumnStatistics("s_nationkey"));
+
+        statisticsAssertion.check("SELECT * FROM supplier s, nation n WHERE s_nationkey = n_nationkey",
+                checks -> checks
+                        .estimate(OUTPUT_ROW_COUNT, defaultTolerance())
+                        .verifyExactColumnStatistics("s_nationkey")
+                        .verifyExactColumnStatistics("n_nationkey"));
+
+        statisticsAssertion.check("SELECT * FROM customer c, nation s WHERE c_nationkey = n_nationkey",
+                checks -> checks
+                        .estimate(OUTPUT_ROW_COUNT, defaultTolerance())
+                        .verifyExactColumnStatistics("c_nationkey")
+                        .verifyExactColumnStatistics("n_nationkey"));
+
+        statisticsAssertion.check("SELECT * FROM nation n, region r WHERE n_regionkey = r_regionkey",
+                checks -> checks
+                        .estimate(OUTPUT_ROW_COUNT, defaultTolerance())
+                        .verifyExactColumnStatistics("n_regionkey")
+                        .verifyExactColumnStatistics("r_regionkey"));
+
+        statisticsAssertion.check("SELECT * FROM part p, partsupp ps WHERE p_partkey = ps_partkey",
+                checks -> checks
+                        .estimate(OUTPUT_ROW_COUNT, defaultTolerance())
+                        .verifyExactColumnStatistics("p_partkey")
+                        .verifyExactColumnStatistics("ps_partkey"));
+
+        // two join on different keys
+        statisticsAssertion.check("SELECT * FROM nation n, supplier s, partsupp ps WHERE n_nationkey = s_nationkey AND s_suppkey = ps_suppkey",
+                checks -> checks
+                        .estimate(OUTPUT_ROW_COUNT, defaultTolerance())
+                        .verifyExactColumnStatistics("ps_partkey")
+                        .verifyExactColumnStatistics("n_nationkey")
+                        .verifyExactColumnStatistics("s_nationkey")
+                        .verifyExactColumnStatistics("n_name"));
+    }
 }

--- a/presto-tpch/pom.xml
+++ b/presto-tpch/pom.xml
@@ -41,6 +41,16 @@
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchMetadata.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchMetadata.java
@@ -32,13 +32,18 @@ import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.predicate.Domain;
 import com.facebook.presto.spi.predicate.NullableValue;
 import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.statistics.ColumnStatistics;
 import com.facebook.presto.spi.statistics.Estimate;
 import com.facebook.presto.spi.statistics.TableStatistics;
 import com.facebook.presto.spi.type.BigintType;
-import com.facebook.presto.spi.type.DateType;
-import com.facebook.presto.spi.type.DoubleType;
-import com.facebook.presto.spi.type.IntegerType;
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.VarcharType;
+import com.facebook.presto.tpch.statistics.ColumnStatisticsData;
+import com.facebook.presto.tpch.statistics.StatisticsEstimator;
+import com.facebook.presto.tpch.statistics.TableStatisticsData;
+import com.facebook.presto.tpch.statistics.TableStatisticsDataRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -60,9 +65,19 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import static com.facebook.presto.spi.statistics.Estimate.unknownValue;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.VarcharType.createVarcharType;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.collect.Maps.asMap;
+import static io.airlift.tpch.OrderColumn.ORDER_STATUS;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
 public class TpchMetadata
@@ -77,14 +92,18 @@ public class TpchMetadata
     public static final String ROW_NUMBER_COLUMN_NAME = "row_number";
 
     private static final Set<String> ORDER_STATUS_VALUES = ImmutableSet.of("F", "O", "P");
+    private static final Set<Slice> ORDER_STATUS_VALUES_SLICES = ORDER_STATUS_VALUES.stream()
+            .map(Slices::utf8Slice)
+            .collect(toImmutableSet());
     private static final Set<NullableValue> ORDER_STATUS_NULLABLE_VALUES = ORDER_STATUS_VALUES.stream()
-            .map(value -> new NullableValue(getPrestoType(OrderColumn.ORDER_STATUS), Slices.utf8Slice(value)))
+            .map(value -> new NullableValue(getPrestoType(ORDER_STATUS), Slices.utf8Slice(value)))
             .collect(toSet());
 
     private final String connectorId;
     private final Set<String> tableNames;
     private final boolean predicatePushdownEnabled;
     private final ColumnNaming columnNaming;
+    private final StatisticsEstimator statisticsEstimator;
 
     public TpchMetadata(String connectorId)
     {
@@ -101,6 +120,15 @@ public class TpchMetadata
         this.connectorId = connectorId;
         this.predicatePushdownEnabled = predicatePushdownEnabled;
         this.columnNaming = columnNaming;
+        this.statisticsEstimator = createStatisticsEstimator();
+    }
+
+    private static StatisticsEstimator createStatisticsEstimator()
+    {
+        ObjectMapper objectMapper = new ObjectMapper()
+                .registerModule(new Jdk8Module());
+        TableStatisticsDataRepository tableStatisticsDataRepository = new TableStatisticsDataRepository(objectMapper);
+        return new StatisticsEstimator(tableStatisticsDataRepository);
     }
 
     @Override
@@ -248,57 +276,92 @@ public class TpchMetadata
     @Override
     public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle, Constraint<ColumnHandle> constraint)
     {
-        TpchTableHandle table = (TpchTableHandle) tableHandle;
-        return new TableStatistics(new Estimate(getRowCount(table, Optional.of(constraint.getSummary()))), ImmutableMap.of());
+        TpchTableHandle tpchTableHandle = (TpchTableHandle) tableHandle;
+        String tableName = tpchTableHandle.getTableName();
+        TpchTable<?> tpchTable = TpchTable.getTable(tableName);
+        Map<TpchColumn<?>, List<Object>> columnValuesRestrictions = getColumnValuesRestrictions(tpchTable, constraint);
+        TableStatisticsData tableStatisticsData = statisticsEstimator.estimateStats(tpchTable, columnValuesRestrictions, tpchTableHandle.getScaleFactor());
+        return toTableStatistics(tableStatisticsData, tpchTableHandle, getColumnHandles(session, tpchTableHandle));
     }
 
-    private long getRowCount(TpchTableHandle tpchTableHandle, Optional<TupleDomain<ColumnHandle>> predicate)
+    private Map<TpchColumn<?>, List<Object>> getColumnValuesRestrictions(TpchTable<?> tpchTable, Constraint<ColumnHandle> constraint)
     {
-        // todo expose row counts from airlift-tpch instead of hardcoding it here
-        // todo add stats for columns
-        String tableName = tpchTableHandle.getTableName();
-        double scaleFactor = tpchTableHandle.getScaleFactor();
-        switch (tableName.toLowerCase()) {
-            case "customer":
-                return (long) (150_000 * scaleFactor);
-            case "orders":
-                Set<String> orderStatusValues = predicate.map(tupleDomain ->
-                        ORDER_STATUS_NULLABLE_VALUES.stream()
-                                .filter(convertToPredicate(tupleDomain, OrderColumn.ORDER_STATUS))
-                                .map(nullableValue -> ((Slice) nullableValue.getValue()).toStringUtf8())
-                                .collect(toSet()))
-                        .orElse(ORDER_STATUS_VALUES);
-
-                long totalRows = 0L;
-                if (orderStatusValues.contains("F")) {
-                    totalRows = 729_413;
-                }
-                if (orderStatusValues.contains("O")) {
-                    totalRows += 732_044;
-                }
-                if (orderStatusValues.contains("P")) {
-                    totalRows += 38_543;
-                }
-                return (long) (totalRows * scaleFactor);
-            case "lineitem":
-                return (long) (6_000_000 * scaleFactor);
-            case "part":
-                return (long) (200_000 * scaleFactor);
-            case "partsupp":
-                return (long) (800_000 * scaleFactor);
-            case "supplier":
-                return (long) (10_000 * scaleFactor);
-            case "nation":
-                return 25;
-            case "region":
-                return 5;
-            default:
-                throw new IllegalArgumentException("unknown tpch table name '" + tableName + "'");
+        TupleDomain<ColumnHandle> constraintSummary = constraint.getSummary();
+        if (constraintSummary.isAll()) {
+            return emptyMap();
+        }
+        else if (constraintSummary.isNone()) {
+            Set<TpchColumn<?>> columns = ImmutableSet.copyOf(tpchTable.getColumns());
+            return asMap(columns, key -> emptyList());
+        }
+        else {
+            Map<ColumnHandle, Domain> domains = constraintSummary.getDomains().get();
+            Optional<Domain> orderStatusDomain = Optional.ofNullable(domains.get(toColumnHandle(ORDER_STATUS)));
+            Optional<Map<TpchColumn<?>, List<Object>>> allowedColumnValues = orderStatusDomain.map(domain -> {
+                List<Object> allowedValues = ORDER_STATUS_VALUES_SLICES.stream()
+                        .filter(domain::includesNullableValue)
+                        .collect(toList());
+                return avoidTrivialOrderStatusRestriction(allowedValues);
+            });
+            return allowedColumnValues.orElse(emptyMap());
         }
     }
 
+    private Map<TpchColumn<?>, List<Object>> avoidTrivialOrderStatusRestriction(List<Object> allowedValues)
+    {
+        if (allowedValues.containsAll(ORDER_STATUS_VALUES_SLICES)) {
+            return emptyMap();
+        }
+        else {
+            return ImmutableMap.of(ORDER_STATUS, allowedValues);
+        }
+    }
+
+    private TableStatistics toTableStatistics(TableStatisticsData tableStatisticsData, TpchTableHandle tpchTableHandle, Map<String, ColumnHandle> columnHandles)
+    {
+        TableStatistics.Builder builder = TableStatistics.builder()
+                .setRowCount(new Estimate(tableStatisticsData.getRowCount()));
+        tableStatisticsData.getColumns().forEach((columnName, stats) -> {
+            TpchColumnHandle columnHandle = (TpchColumnHandle) getColumnHandle(tpchTableHandle, columnHandles, columnName);
+            builder.setColumnStatistics(columnHandle, toColumnStatistics(stats, columnHandle.getType()));
+        });
+        return builder.build();
+    }
+
+    private ColumnHandle getColumnHandle(TpchTableHandle tpchTableHandle, Map<String, ColumnHandle> columnHandles, String columnName)
+    {
+        TpchTable<?> table = TpchTable.getTable(tpchTableHandle.getTableName());
+        return columnHandles.get(columnNaming.getName(table.getColumn(columnName)));
+    }
+
+    private ColumnStatistics toColumnStatistics(ColumnStatisticsData stats, Type columnType)
+    {
+        return ColumnStatistics.builder()
+                .addRange(rangeBuilder -> rangeBuilder
+                        .setDistinctValuesCount(stats.getDistinctValuesCount().map(Estimate::new).orElse(unknownValue()))
+                        .setLowValue(stats.getMin().map(value -> toPrestoValue(value, columnType)))
+                        .setHighValue(stats.getMax().map(value -> toPrestoValue(value, columnType)))
+                        .setFraction(new Estimate(1.0)))
+                .setNullsFraction(Estimate.zeroValue())
+                .build();
+    }
+
+    private Object toPrestoValue(Object tpchValue, Type columnType)
+    {
+        if (columnType instanceof VarcharType) {
+            return Slices.utf8Slice((String) tpchValue);
+        }
+        if (columnType.equals(BIGINT) || columnType.equals(INTEGER) || columnType.equals(DATE)) {
+            return ((Number) tpchValue).longValue();
+        }
+        if (columnType.equals(DOUBLE)) {
+            return ((Number) tpchValue).doubleValue();
+        }
+        throw new IllegalArgumentException("unsupported column type " + columnType);
+    }
+
     @VisibleForTesting
-    TpchColumnHandle toColumnHandle(TpchColumn column)
+    TpchColumnHandle toColumnHandle(TpchColumn<?> column)
     {
         return new TpchColumnHandle(columnNaming.getName(column), getPrestoType(column));
     }
@@ -408,11 +471,11 @@ public class TpchMetadata
             case IDENTIFIER:
                 return BigintType.BIGINT;
             case INTEGER:
-                return IntegerType.INTEGER;
+                return INTEGER;
             case DATE:
-                return DateType.DATE;
+                return DATE;
             case DOUBLE:
-                return DoubleType.DOUBLE;
+                return DOUBLE;
             case VARCHAR:
                 return createVarcharType((int) (long) tpchType.getPrecision().get());
         }

--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchMetadata.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchMetadata.java
@@ -77,7 +77,7 @@ public class TpchMetadata
 
     private static final Set<String> ORDER_STATUS_VALUES = ImmutableSet.of("F", "O", "P");
     private static final Set<NullableValue> ORDER_STATUS_NULLABLE_VALUES = ORDER_STATUS_VALUES.stream()
-            .map(value -> new NullableValue(getPrestoType(OrderColumn.ORDER_STATUS.getType()), Slices.utf8Slice(value)))
+            .map(value -> new NullableValue(getPrestoType(OrderColumn.ORDER_STATUS), Slices.utf8Slice(value)))
             .collect(toSet());
 
     private final String connectorId;
@@ -211,7 +211,7 @@ public class TpchMetadata
     {
         ImmutableList.Builder<ColumnMetadata> columns = ImmutableList.builder();
         for (TpchColumn<? extends TpchEntity> column : tpchTable.getColumns()) {
-            columns.add(new ColumnMetadata(columnNaming.getName(column), getPrestoType(column.getType())));
+            columns.add(new ColumnMetadata(columnNaming.getName(column), getPrestoType(column)));
         }
         columns.add(new ColumnMetadata(ROW_NUMBER_COLUMN_NAME, BIGINT, null, true));
 
@@ -298,7 +298,7 @@ public class TpchMetadata
 
     private TpchColumnHandle toColumnHandle(TpchColumn column)
     {
-        return new TpchColumnHandle(columnNaming.getName(column), getPrestoType(column.getType()));
+        return new TpchColumnHandle(columnNaming.getName(column), getPrestoType(column));
     }
 
     @Override
@@ -399,8 +399,9 @@ public class TpchMetadata
         }
     }
 
-    public static Type getPrestoType(TpchColumnType tpchType)
+    public static Type getPrestoType(TpchColumn<?> column)
     {
+        TpchColumnType tpchType = column.getType();
         switch (tpchType.getBase()) {
             case IDENTIFIER:
                 return BigintType.BIGINT;

--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchMetadata.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchMetadata.java
@@ -383,8 +383,7 @@ public class TpchMetadata
         return "sf" + scaleFactor;
     }
 
-    @VisibleForTesting
-    static double schemaNameToScaleFactor(String schemaName)
+    public static double schemaNameToScaleFactor(String schemaName)
     {
         if (TINY_SCHEMA_NAME.equals(schemaName)) {
             return TINY_SCALE_FACTOR;

--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchMetadata.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchMetadata.java
@@ -39,6 +39,7 @@ import com.facebook.presto.spi.type.DateType;
 import com.facebook.presto.spi.type.DoubleType;
 import com.facebook.presto.spi.type.IntegerType;
 import com.facebook.presto.spi.type.Type;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -296,7 +297,8 @@ public class TpchMetadata
         }
     }
 
-    private TpchColumnHandle toColumnHandle(TpchColumn column)
+    @VisibleForTesting
+    TpchColumnHandle toColumnHandle(TpchColumn column)
     {
         return new TpchColumnHandle(columnNaming.getName(column), getPrestoType(column));
     }
@@ -381,7 +383,8 @@ public class TpchMetadata
         return "sf" + scaleFactor;
     }
 
-    private static double schemaNameToScaleFactor(String schemaName)
+    @VisibleForTesting
+    static double schemaNameToScaleFactor(String schemaName)
     {
         if (TINY_SCHEMA_NAME.equals(schemaName)) {
             return TINY_SCALE_FACTOR;

--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchRecordSet.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchRecordSet.java
@@ -75,10 +75,10 @@ public class TpchRecordSet<E extends TpchEntity>
         this.table = table;
         this.columns = ImmutableList.copyOf(columns);
 
-        this.columnTypes = ImmutableList.copyOf(transform(columns, column -> getPrestoType(column.getType())));
+        this.columnTypes = ImmutableList.copyOf(transform(columns, TpchMetadata::getPrestoType));
 
         columnHandles = this.columns.stream()
-                .map(column -> new TpchColumnHandle(column.getColumnName(), getPrestoType(column.getType())))
+                .map(column -> new TpchColumnHandle(column.getColumnName(), getPrestoType(column)))
                 .collect(toList());
         this.predicate = predicate.map(TpchRecordSet::convertToPredicate);
     }
@@ -135,7 +135,7 @@ public class TpchRecordSet<E extends TpchEntity>
         @Override
         public Type getType(int field)
         {
-            return getPrestoType(getTpchColumn(field).getType());
+            return getPrestoType(getTpchColumn(field));
         }
 
         @Override

--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/statistics/ColumnStatisticsData.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/statistics/ColumnStatisticsData.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tpch.statistics;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class ColumnStatisticsData
+{
+    private final Optional<Long> distinctValuesCount;
+    private final Optional<Long> nullsCount;
+    private final Optional<Object> min;
+    private final Optional<Object> max;
+
+    @JsonCreator
+    public ColumnStatisticsData(
+            @JsonProperty("distinctValuesCount") Optional<Long> distinctValuesCount,
+            @JsonProperty("nullsCount") Optional<Long> nullsCount,
+            @JsonProperty("min") Optional<Object> min,
+            @JsonProperty("max") Optional<Object> max)
+    {
+        this.distinctValuesCount = requireNonNull(distinctValuesCount);
+        this.nullsCount = requireNonNull(nullsCount);
+        this.min = requireNonNull(min);
+        this.max = requireNonNull(max);
+    }
+
+    public static ColumnStatisticsData empty()
+    {
+        return new ColumnStatisticsData(
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty()
+        );
+    }
+
+    public static ColumnStatisticsData zero()
+    {
+        return new ColumnStatisticsData(
+                Optional.of(0L),
+                Optional.of(0L),
+                Optional.empty(),
+                Optional.empty()
+        );
+    }
+
+    public Optional<Long> getDistinctValuesCount()
+    {
+        return distinctValuesCount;
+    }
+
+    public Optional<Long> getNullsCount()
+    {
+        return nullsCount;
+    }
+
+    public Optional<Object> getMin()
+    {
+        return min;
+    }
+
+    public Optional<Object> getMax()
+    {
+        return max;
+    }
+}

--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/statistics/ColumnStatisticsRecorder.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/statistics/ColumnStatisticsRecorder.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tpch.statistics;
+
+import java.util.Optional;
+import java.util.TreeSet;
+
+class ColumnStatisticsRecorder
+{
+    private final TreeSet<Object> nonNullValues = new TreeSet<>();
+    private long nullsCount = 0;
+
+    public void record(Comparable<?> value)
+    {
+        if (value != null) {
+            nonNullValues.add(value);
+        }
+        else {
+            nullsCount++;
+        }
+    }
+
+    public ColumnStatisticsData getRecording()
+    {
+        return new ColumnStatisticsData(
+                Optional.of(getUniqueValuesCount()),
+                Optional.of(getNullsCount()),
+                getLowestValue(),
+                getHighestValue()
+        );
+    }
+
+    private long getUniqueValuesCount()
+    {
+        return nonNullValues.size();
+    }
+
+    private long getNullsCount()
+    {
+        return nullsCount;
+    }
+
+    private Optional<Object> getLowestValue()
+    {
+        return nonNullValues.size() > 0 ? Optional.of(nonNullValues.first()) : Optional.empty();
+    }
+
+    private Optional<Object> getHighestValue()
+    {
+        return nonNullValues.size() > 0 ? Optional.of(nonNullValues.last()) : Optional.empty();
+    }
+}

--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/statistics/StatisticsEstimator.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/statistics/StatisticsEstimator.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tpch.statistics;
+
+import com.facebook.presto.util.Types;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.slice.Slice;
+import io.airlift.tpch.CustomerColumn;
+import io.airlift.tpch.LineItemColumn;
+import io.airlift.tpch.OrderColumn;
+import io.airlift.tpch.PartColumn;
+import io.airlift.tpch.PartSupplierColumn;
+import io.airlift.tpch.SupplierColumn;
+import io.airlift.tpch.TpchColumn;
+import io.airlift.tpch.TpchTable;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+import static com.facebook.presto.tpch.util.Optionals.checkPresent;
+import static com.facebook.presto.tpch.util.Optionals.combine;
+import static com.facebook.presto.tpch.util.Optionals.withBoth;
+import static com.facebook.presto.util.Types.checkSameType;
+import static com.facebook.presto.util.Types.checkType;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static java.lang.Math.abs;
+import static java.lang.String.format;
+import static java.util.Optional.empty;
+
+public class StatisticsEstimator
+{
+    //These columns are unsupported because scaling them would require sophisticated logic
+    private static final Set<TpchColumn<?>> UNSUPPORTED_COLUMNS = ImmutableSet.of(
+            CustomerColumn.ACCOUNT_BALANCE,
+            LineItemColumn.EXTENDED_PRICE,
+            OrderColumn.TOTAL_PRICE,
+            PartColumn.RETAIL_PRICE,
+            PartSupplierColumn.AVAILABLE_QUANTITY,
+            SupplierColumn.ACCOUNT_BALANCE
+    );
+
+    private final TableStatisticsDataRepository tableStatisticsDataRepository;
+
+    public StatisticsEstimator(TableStatisticsDataRepository tableStatisticsDataRepository)
+    {
+        this.tableStatisticsDataRepository = tableStatisticsDataRepository;
+    }
+
+    public TableStatisticsData estimateStats(TpchTable<?> tpchTable, Map<TpchColumn<?>, List<Object>> columnValuesRestrictions, double scaleFactor)
+    {
+        TableStatisticsData bigStatistics = readStatistics(tpchTable, columnValuesRestrictions, "sf1");
+        TableStatisticsData smallStatistics = readStatistics(tpchTable, columnValuesRestrictions, "tiny");
+        double rescalingFactor = smallStatistics.getRowCount() == bigStatistics.getRowCount() ? 1 : scaleFactor;
+        return new TableStatisticsData(
+                (long) (bigStatistics.getRowCount() * rescalingFactor),
+                rescale(tpchTable, bigStatistics, smallStatistics, scaleFactor)
+        );
+    }
+
+    private Map<String, ColumnStatisticsData> rescale(TpchTable<?> table, TableStatisticsData bigStatistics, TableStatisticsData smallStatistics, double scaleFactor)
+    {
+        return bigStatistics.getColumns().entrySet().stream().collect(toImmutableMap(
+                Map.Entry::getKey,
+                entry -> {
+                    String columnName = entry.getKey();
+                    TpchColumn<?> column = table.getColumn(columnName);
+                    ColumnStatisticsData bigColumnStatistics = entry.getValue();
+                    ColumnStatisticsData smallColumnStatistics = smallStatistics.getColumns().get(columnName);
+                    return rescale(column, bigColumnStatistics, smallColumnStatistics, scaleFactor);
+                }
+        ));
+    }
+
+    private ColumnStatisticsData rescale(TpchColumn<?> column, ColumnStatisticsData big, ColumnStatisticsData small, double scaleFactor)
+    {
+        if (UNSUPPORTED_COLUMNS.contains(column)) {
+            return ColumnStatisticsData.empty();
+        }
+        else {
+            return rescale(big, small, scaleFactor);
+        }
+    }
+
+    private ColumnStatisticsData rescale(ColumnStatisticsData big, ColumnStatisticsData small, double scaleFactor)
+    {
+        if (columnDoesNotScale(big, small)) {
+            return new ColumnStatisticsData(
+                    big.getDistinctValuesCount(),
+                    big.getNullsCount(),
+                    checkPresent(withBoth(big.getMin(), small.getMin(), this::checkClose)),
+                    checkPresent(withBoth(big.getMax(), small.getMax(), this::checkClose))
+            );
+        }
+        else {
+            Function<Number, Double> rescale = value -> value.doubleValue() * scaleFactor;
+            return new ColumnStatisticsData(
+                    big.getDistinctValuesCount().map(rescale).map(Number::longValue),
+                    big.getNullsCount().map(rescale).map(Number::longValue),
+                    Types.tryCast(big.getMin(), Number.class),
+                    Types.tryCast(big.getMax(), Number.class).map(rescale));
+        }
+    }
+
+    private boolean columnDoesNotScale(ColumnStatisticsData big, ColumnStatisticsData small)
+    {
+        return withBoth(small.getMin(), big.getMin(), this::areClose)
+                .flatMap(lowerBoundsClose ->
+                        withBoth(small.getMax(), big.getMax(), this::areClose)
+                                .map(upperBoundsClose -> lowerBoundsClose && upperBoundsClose))
+                .orElse(false);
+    }
+
+    private Object checkClose(Object leftValue, Object rightValue)
+    {
+        checkArgument(
+                areClose(leftValue, rightValue),
+                format("Values must be close to each other, got [%s] and [%s]", leftValue, rightValue));
+        return leftValue;
+    }
+
+    private boolean areClose(Object leftValue, Object rightValue)
+    {
+        checkSameType(leftValue, rightValue);
+        if (leftValue instanceof String) {
+            return leftValue.equals(rightValue);
+        }
+        else {
+            Number left = checkType(leftValue, Number.class);
+            Number right = checkType(rightValue, Number.class);
+            return areClose(left.doubleValue(), right.doubleValue());
+        }
+    }
+
+    private boolean areClose(double left, double right)
+    {
+        return abs(right - left) <= abs(left) * 0.01;
+    }
+
+    private TableStatisticsData readStatistics(TpchTable<?> table, Map<TpchColumn<?>, List<Object>> columnValuesRestrictions, String schemaName)
+    {
+        if (columnValuesRestrictions.isEmpty()) {
+            return tableStatisticsDataRepository.load(schemaName, table, empty(), empty());
+        }
+        else if (columnValuesRestrictions.values().stream().allMatch(List::isEmpty)) {
+            return zeroStatistics(table);
+        }
+        else {
+            checkArgument(columnValuesRestrictions.size() <= 1, "Can only estimate stats when at most one column has value restrictions");
+            TpchColumn<?> partitionColumn = getOnlyElement(columnValuesRestrictions.keySet());
+            List<Object> partitionValues = columnValuesRestrictions.get(partitionColumn);
+            TableStatisticsData result = zeroStatistics(table);
+            for (Object partitionValue : partitionValues) {
+                Slice value = checkType(partitionValue, Slice.class, "Only string (Slice) partition values supported for now");
+                TableStatisticsData tableStatisticsData = tableStatisticsDataRepository
+                        .load(schemaName, table, Optional.of(partitionColumn), Optional.of(value.toStringUtf8()));
+                result = addPartitionStats(result, tableStatisticsData, partitionColumn);
+            }
+            return result;
+        }
+    }
+
+    private TableStatisticsData addPartitionStats(TableStatisticsData left, TableStatisticsData right, TpchColumn<?> partitionColumn)
+    {
+        return new TableStatisticsData(
+                left.getRowCount() + right.getRowCount(),
+                addPartitionStats(left.getColumns(), right.getColumns(), partitionColumn)
+        );
+    }
+
+    private Map<String, ColumnStatisticsData> addPartitionStats(Map<String, ColumnStatisticsData> leftColumns, Map<String, ColumnStatisticsData> rightColumns, TpchColumn<?> partitionColumn)
+    {
+        return leftColumns.entrySet().stream().collect(toImmutableMap(
+                Map.Entry::getKey,
+                entry -> {
+                    String columnName = entry.getKey();
+                    ColumnStatisticsData leftStats = entry.getValue();
+                    ColumnStatisticsData rightStats = rightColumns.get(columnName);
+                    return new ColumnStatisticsData(
+                            combineUniqueValuesCount(partitionColumn, columnName, leftStats, rightStats),
+                            combine(leftStats.getNullsCount(), rightStats.getNullsCount(), (a, b) -> a + b),
+                            combine(leftStats.getMin(), rightStats.getMin(), this::min),
+                            combine(leftStats.getMax(), rightStats.getMax(), this::max)
+                    );
+                }));
+    }
+
+    private Optional<Long> combineUniqueValuesCount(TpchColumn<?> partitionColumn, String columnName, ColumnStatisticsData leftStats, ColumnStatisticsData rightStats)
+    {
+        //unique values count can't be added between different partitions
+        //for columns other than the partition column (because almost certainly there are duplicates)
+        return combine(leftStats.getDistinctValuesCount(), rightStats.getDistinctValuesCount(), (a, b) -> a + b)
+                .filter(v -> columnName.equals(partitionColumn.getColumnName()));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Object min(Object l, Object r)
+    {
+        checkSameType(l, r);
+        Comparable left = checkType(l, Comparable.class);
+        Comparable right = checkType(r, Comparable.class);
+        return left.compareTo(right) < 0 ? left : right;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Object max(Object l, Object r)
+    {
+        checkSameType(l, r);
+        Comparable left = checkType(l, Comparable.class);
+        Comparable right = checkType(r, Comparable.class);
+        return left.compareTo(right) > 0 ? left : right;
+    }
+
+    private TableStatisticsData zeroStatistics(TpchTable<?> table)
+    {
+        return new TableStatisticsData(0, table.getColumns().stream().collect(toImmutableMap(
+                TpchColumn::getColumnName,
+                column -> ColumnStatisticsData.zero()
+        )));
+    }
+}

--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/statistics/TableStatisticsData.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/statistics/TableStatisticsData.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tpch.statistics;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+public class TableStatisticsData
+{
+    private final long rowCount;
+    private final Map<String, ColumnStatisticsData> columns;
+
+    @JsonCreator
+    public TableStatisticsData(
+            @JsonProperty("rowCount") long rowCount,
+            @JsonProperty("columns") Map<String, ColumnStatisticsData> columns)
+    {
+        this.rowCount = rowCount;
+        this.columns = ImmutableMap.copyOf(columns);
+    }
+
+    public long getRowCount()
+    {
+        return rowCount;
+    }
+
+    public Map<String, ColumnStatisticsData> getColumns()
+    {
+        return columns;
+    }
+}

--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/statistics/TableStatisticsDataRepository.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/statistics/TableStatisticsDataRepository.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tpch.statistics;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.airlift.tpch.TpchColumn;
+import io.airlift.tpch.TpchTable;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+
+import static com.facebook.presto.tpch.util.Optionals.withBoth;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.String.format;
+
+public class TableStatisticsDataRepository
+{
+    private final ObjectMapper objectMapper;
+
+    public TableStatisticsDataRepository(ObjectMapper objectMapper)
+    {
+        this.objectMapper = objectMapper;
+    }
+
+    public void save(
+            String schemaName,
+            TpchTable<?> table,
+            Optional<TpchColumn<?>> partitionColumn,
+            Optional<String> partitionValue,
+            TableStatisticsData statisticsData)
+    {
+        String filename = tableStatisticsDataFilename(table, partitionColumn, partitionValue);
+        Path path = Paths.get("presto-tpch", "src", "main", "resources", "tpch", "statistics", schemaName, filename + ".json");
+        writeStatistics(path, statisticsData);
+    }
+
+    private void writeStatistics(Path path, TableStatisticsData tableStatisticsData)
+    {
+        File file = path.toFile();
+        file.getParentFile().mkdirs();
+        try {
+            objectMapper
+                    .writerWithDefaultPrettyPrinter()
+                    .writeValue(file, tableStatisticsData);
+            try (FileWriter fileWriter = new FileWriter(file, true)) {
+                fileWriter.append('\n');
+            }
+        }
+        catch (IOException e) {
+            throw new RuntimeException("Could not save table statistics data", e);
+        }
+    }
+
+    public TableStatisticsData load(String schemaName, TpchTable<?> table, Optional<TpchColumn<?>> partitionColumn, Optional<String> partitionValue)
+    {
+        String filename = tableStatisticsDataFilename(table, partitionColumn, partitionValue);
+        String resourcePath = "/tpch/statistics/" + schemaName + "/" + filename + ".json";
+        return readStatistics(resourcePath);
+    }
+
+    private TableStatisticsData readStatistics(String resourcePath)
+    {
+        URL resource = getClass().getResource(resourcePath);
+        try {
+            return objectMapper.readValue(resource, TableStatisticsData.class);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(format("Failed to parse stats from resource [%s]", resourcePath), e);
+        }
+    }
+
+    private String tableStatisticsDataFilename(TpchTable<?> table, Optional<TpchColumn<?>> partitionColumn, Optional<String> partitionValue)
+    {
+        Optional<String> partitionDescription = getPartitionDescription(partitionColumn, partitionValue);
+        return table.getTableName() + partitionDescription.map(value -> "." + value).orElse("");
+    }
+
+    private Optional<String> getPartitionDescription(Optional<TpchColumn<?>> partitionColumn, Optional<String> partitionValue)
+    {
+        checkArgument(partitionColumn.isPresent() == partitionValue.isPresent());
+        return withBoth(partitionColumn, partitionValue, (column, value) -> column.getColumnName() + "." + value);
+    }
+}

--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/statistics/TableStatisticsRecorder.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/statistics/TableStatisticsRecorder.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tpch.statistics;
+
+import io.airlift.tpch.TpchColumn;
+import io.airlift.tpch.TpchColumnType;
+import io.airlift.tpch.TpchEntity;
+import io.airlift.tpch.TpchTable;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.lang.String.format;
+import static java.util.function.Function.identity;
+
+class TableStatisticsRecorder
+{
+    public <E extends TpchEntity> TableStatisticsData recordStatistics(TpchTable<E> tpchTable, Predicate<E> constraint, double scaleFactor)
+    {
+        Iterable<E> rows = tpchTable.createGenerator(scaleFactor, 1, 1);
+        return recordStatistics(rows, tpchTable.getColumns(), constraint);
+    }
+
+    private <E extends TpchEntity> TableStatisticsData recordStatistics(Iterable<E> rows, List<TpchColumn<E>> columns, Predicate<E> constraint)
+    {
+        Map<TpchColumn<E>, ColumnStatisticsRecorder> statisticsRecorders = createStatisticsRecorders(columns);
+        long rowCount = 0;
+
+        for (E row : rows) {
+            if (constraint.test(row)) {
+                rowCount++;
+                for (TpchColumn<E> column : columns) {
+                    Comparable<?> value = getTpchValue(row, column);
+                    statisticsRecorders.get(column).record(value);
+                }
+            }
+        }
+
+        Map<String, ColumnStatisticsData> columnSampleStatistics = statisticsRecorders.entrySet().stream()
+                .collect(toImmutableMap(
+                        e -> e.getKey().getColumnName(),
+                        e -> e.getValue().getRecording()
+                ));
+        return new TableStatisticsData(rowCount, columnSampleStatistics);
+    }
+
+    private <E extends TpchEntity> Map<TpchColumn<E>, ColumnStatisticsRecorder> createStatisticsRecorders(List<TpchColumn<E>> columns)
+    {
+        return columns.stream()
+                .collect(toImmutableMap(identity(), (column) -> new ColumnStatisticsRecorder()));
+    }
+
+    private <E extends TpchEntity> Comparable<?> getTpchValue(E row, TpchColumn<E> column)
+    {
+        TpchColumnType.Base baseType = column.getType().getBase();
+        switch (baseType) {
+            case IDENTIFIER:
+                return column.getIdentifier(row);
+            case INTEGER:
+                return column.getInteger(row);
+            case DATE:
+                return column.getDate(row);
+            case DOUBLE:
+                return column.getDouble(row);
+            case VARCHAR:
+                return column.getString(row);
+        }
+        throw new UnsupportedOperationException(format("Unsupported TPCH base type [%s]", baseType));
+    }
+}

--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/util/Optionals.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/util/Optionals.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tpch.util;
+
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class Optionals
+{
+    private Optionals() {}
+
+    public static <T> Optional<T> checkPresent(Optional<T> optional)
+    {
+        checkArgument(optional.isPresent(), "Expected a present optional, got empty()");
+        return optional;
+    }
+
+    public static <S, T, R> Optional<R> withBoth(Optional<? extends S> left, Optional<? extends T> right, BiFunction<S, T, R> binaryFunction)
+    {
+        return left.flatMap(l -> right.map(r -> binaryFunction.apply(l, r)));
+    }
+
+    public static <T> Optional<T> combine(Optional<T> left, Optional<T> right, BinaryOperator<T> combiner)
+    {
+        if (left.isPresent() && right.isPresent()) {
+            return Optional.of(combiner.apply(left.get(), right.get()));
+        }
+        else if (left.isPresent()) {
+            return left;
+        }
+        else {
+            return right;
+        }
+    }
+}

--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/util/Types.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/util/Types.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.util;
+
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class Types
+{
+    private Types() {}
+
+    public static <T> T checkType(Object object, Class<T> expectedClass)
+    {
+        return checkType(object, expectedClass, "Expected an object of type [%s]", expectedClass.getCanonicalName());
+    }
+
+    public static <T> T checkType(Object object, Class<T> expectedClass, String messageTemplate, Object... arguments)
+    {
+        checkArgument(expectedClass.isInstance(object), messageTemplate, arguments);
+        return expectedClass.cast(object);
+    }
+
+    public static void checkSameType(Object left, Object right)
+    {
+        Class<?> leftClass = left.getClass();
+        Class<?> rightClass = right.getClass();
+        String message = "Values must be of same type, got [%s : %s] and [%s : %s]";
+        checkArgument(leftClass.equals(rightClass), message, left, leftClass, right, rightClass);
+    }
+
+    public static <R, T extends R> Optional<R> tryCast(Optional<?> optional, Class<T> targetClass)
+    {
+        return optional
+                .filter(targetClass::isInstance)
+                .map(targetClass::cast);
+    }
+}

--- a/presto-tpch/src/main/resources/tpch/statistics/sf1/customer.json
+++ b/presto-tpch/src/main/resources/tpch/statistics/sf1/customer.json
@@ -1,0 +1,53 @@
+{
+  "rowCount" : 150000,
+  "columns" : {
+    "c_custkey" : {
+      "distinctValuesCount" : 150000,
+      "nullsCount" : 0,
+      "min" : 1,
+      "max" : 150000
+    },
+    "c_name" : {
+      "distinctValuesCount" : 150000,
+      "nullsCount" : 0,
+      "min" : "Customer#000000001",
+      "max" : "Customer#000150000"
+    },
+    "c_address" : {
+      "distinctValuesCount" : 150000,
+      "nullsCount" : 0,
+      "min" : "   2uZwVhQvwA",
+      "max" : "zzxGktzXTMKS1BxZlgQ9nqQ"
+    },
+    "c_nationkey" : {
+      "distinctValuesCount" : 25,
+      "nullsCount" : 0,
+      "min" : 0,
+      "max" : 24
+    },
+    "c_phone" : {
+      "distinctValuesCount" : 150000,
+      "nullsCount" : 0,
+      "min" : "10-100-106-1617",
+      "max" : "34-999-618-6881"
+    },
+    "c_acctbal" : {
+      "distinctValuesCount" : 140187,
+      "nullsCount" : 0,
+      "min" : -999.99,
+      "max" : 9999.99
+    },
+    "c_mktsegment" : {
+      "distinctValuesCount" : 5,
+      "nullsCount" : 0,
+      "min" : "AUTOMOBILE",
+      "max" : "MACHINERY"
+    },
+    "c_comment" : {
+      "distinctValuesCount" : 149968,
+      "nullsCount" : 0,
+      "min" : " Tiresias according to the slyly blithe instructions detect quickly at the slyly express courts. express dinos wake ",
+      "max" : "zzle. blithely regular instructions cajol"
+    }
+  }
+}

--- a/presto-tpch/src/main/resources/tpch/statistics/sf1/lineitem.json
+++ b/presto-tpch/src/main/resources/tpch/statistics/sf1/lineitem.json
@@ -1,0 +1,101 @@
+{
+  "rowCount" : 6001215,
+  "columns" : {
+    "l_orderkey" : {
+      "distinctValuesCount" : 1500000,
+      "nullsCount" : 0,
+      "min" : 1,
+      "max" : 6000000
+    },
+    "l_partkey" : {
+      "distinctValuesCount" : 200000,
+      "nullsCount" : 0,
+      "min" : 1,
+      "max" : 200000
+    },
+    "l_suppkey" : {
+      "distinctValuesCount" : 10000,
+      "nullsCount" : 0,
+      "min" : 1,
+      "max" : 10000
+    },
+    "l_linenumber" : {
+      "distinctValuesCount" : 7,
+      "nullsCount" : 0,
+      "min" : 1,
+      "max" : 7
+    },
+    "l_quantity" : {
+      "distinctValuesCount" : 50,
+      "nullsCount" : 0,
+      "min" : 1.0,
+      "max" : 50.0
+    },
+    "l_extendedprice" : {
+      "distinctValuesCount" : 933900,
+      "nullsCount" : 0,
+      "min" : 901.0,
+      "max" : 104949.5
+    },
+    "l_discount" : {
+      "distinctValuesCount" : 11,
+      "nullsCount" : 0,
+      "min" : 0.0,
+      "max" : 0.1
+    },
+    "l_tax" : {
+      "distinctValuesCount" : 9,
+      "nullsCount" : 0,
+      "min" : 0.0,
+      "max" : 0.08
+    },
+    "l_returnflag" : {
+      "distinctValuesCount" : 3,
+      "nullsCount" : 0,
+      "min" : "A",
+      "max" : "R"
+    },
+    "l_linestatus" : {
+      "distinctValuesCount" : 2,
+      "nullsCount" : 0,
+      "min" : "F",
+      "max" : "O"
+    },
+    "l_shipdate" : {
+      "distinctValuesCount" : 2526,
+      "nullsCount" : 0,
+      "min" : 8036,
+      "max" : 10561
+    },
+    "l_commitdate" : {
+      "distinctValuesCount" : 2466,
+      "nullsCount" : 0,
+      "min" : 8065,
+      "max" : 10530
+    },
+    "l_receiptdate" : {
+      "distinctValuesCount" : 2554,
+      "nullsCount" : 0,
+      "min" : 8038,
+      "max" : 10591
+    },
+    "l_shipinstruct" : {
+      "distinctValuesCount" : 4,
+      "nullsCount" : 0,
+      "min" : "COLLECT COD",
+      "max" : "TAKE BACK RETURN"
+    },
+    "l_shipmode" : {
+      "distinctValuesCount" : 7,
+      "nullsCount" : 0,
+      "min" : "AIR",
+      "max" : "TRUCK"
+    },
+    "l_comment" : {
+      "distinctValuesCount" : 4580667,
+      "nullsCount" : 0,
+      "min" : " Tiresias ",
+      "max" : "zzle? slyly final platelets sleep quickly. "
+    }
+  }
+}

--- a/presto-tpch/src/main/resources/tpch/statistics/sf1/nation.json
+++ b/presto-tpch/src/main/resources/tpch/statistics/sf1/nation.json
@@ -1,0 +1,29 @@
+{
+  "rowCount" : 25,
+  "columns" : {
+    "n_nationkey" : {
+      "distinctValuesCount" : 25,
+      "nullsCount" : 0,
+      "min" : 0,
+      "max" : 24
+    },
+    "n_name" : {
+      "distinctValuesCount" : 25,
+      "nullsCount" : 0,
+      "min" : "ALGERIA",
+      "max" : "VIETNAM"
+    },
+    "n_regionkey" : {
+      "distinctValuesCount" : 5,
+      "nullsCount" : 0,
+      "min" : 0,
+      "max" : 4
+    },
+    "n_comment" : {
+      "distinctValuesCount" : 25,
+      "nullsCount" : 0,
+      "min" : " haggle. carefully final deposits detect slyly agai",
+      "max" : "y final packages. slow foxes cajole quickly. quickly silent platelets breach ironic accounts. unusual pinto be"
+    }
+  }
+}

--- a/presto-tpch/src/main/resources/tpch/statistics/sf1/orders.json
+++ b/presto-tpch/src/main/resources/tpch/statistics/sf1/orders.json
@@ -1,0 +1,59 @@
+{
+  "rowCount" : 1500000,
+  "columns" : {
+    "o_orderkey" : {
+      "distinctValuesCount" : 1500000,
+      "nullsCount" : 0,
+      "min" : 1,
+      "max" : 6000000
+    },
+    "o_custkey" : {
+      "distinctValuesCount" : 99996,
+      "nullsCount" : 0,
+      "min" : 1,
+      "max" : 149999
+    },
+    "o_orderstatus" : {
+      "distinctValuesCount" : 3,
+      "nullsCount" : 0,
+      "min" : "F",
+      "max" : "P"
+    },
+    "o_totalprice" : {
+      "distinctValuesCount" : 1464556,
+      "nullsCount" : 0,
+      "min" : 857.71,
+      "max" : 555285.16
+    },
+    "o_orderdate" : {
+      "distinctValuesCount" : 2406,
+      "nullsCount" : 0,
+      "min" : 8035,
+      "max" : 10440
+    },
+    "o_orderpriority" : {
+      "distinctValuesCount" : 5,
+      "nullsCount" : 0,
+      "min" : "1-URGENT",
+      "max" : "5-LOW"
+    },
+    "o_clerk" : {
+      "distinctValuesCount" : 1000,
+      "nullsCount" : 0,
+      "min" : "Clerk#000000001",
+      "max" : "Clerk#000001000"
+    },
+    "o_shippriority" : {
+      "distinctValuesCount" : 1,
+      "nullsCount" : 0,
+      "min" : 0,
+      "max" : 0
+    },
+    "o_comment" : {
+      "distinctValuesCount" : 1482071,
+      "nullsCount" : 0,
+      "min" : " Tiresias about the blithely ironic a",
+      "max" : "zzle? furiously ironic instructions among the unusual t"
+    }
+  }
+}

--- a/presto-tpch/src/main/resources/tpch/statistics/sf1/orders.o_orderstatus.F.json
+++ b/presto-tpch/src/main/resources/tpch/statistics/sf1/orders.o_orderstatus.F.json
@@ -1,0 +1,59 @@
+{
+  "rowCount" : 729413,
+  "columns" : {
+    "o_orderkey" : {
+      "distinctValuesCount" : 729413,
+      "nullsCount" : 0,
+      "min" : 3,
+      "max" : 5999975
+    },
+    "o_custkey" : {
+      "distinctValuesCount" : 99609,
+      "nullsCount" : 0,
+      "min" : 1,
+      "max" : 149999
+    },
+    "o_orderstatus" : {
+      "distinctValuesCount" : 1,
+      "nullsCount" : 0,
+      "min" : "F",
+      "max" : "F"
+    },
+    "o_totalprice" : {
+      "distinctValuesCount" : 720822,
+      "nullsCount" : 0,
+      "min" : 866.9,
+      "max" : 555285.16
+    },
+    "o_orderdate" : {
+      "distinctValuesCount" : 1261,
+      "nullsCount" : 0,
+      "min" : 8035,
+      "max" : 9296
+    },
+    "o_orderpriority" : {
+      "distinctValuesCount" : 5,
+      "nullsCount" : 0,
+      "min" : "1-URGENT",
+      "max" : "5-LOW"
+    },
+    "o_clerk" : {
+      "distinctValuesCount" : 1000,
+      "nullsCount" : 0,
+      "min" : "Clerk#000000001",
+      "max" : "Clerk#000001000"
+    },
+    "o_shippriority" : {
+      "distinctValuesCount" : 1,
+      "nullsCount" : 0,
+      "min" : 0,
+      "max" : 0
+    },
+    "o_comment" : {
+      "distinctValuesCount" : 724600,
+      "nullsCount" : 0,
+      "min" : " Tiresias above the carefully ironic packages nag about the pend",
+      "max" : "zzle; ironic accounts affix slyly regular pinto b"
+    }
+  }
+}

--- a/presto-tpch/src/main/resources/tpch/statistics/sf1/orders.o_orderstatus.O.json
+++ b/presto-tpch/src/main/resources/tpch/statistics/sf1/orders.o_orderstatus.O.json
@@ -1,0 +1,59 @@
+{
+  "rowCount" : 732044,
+  "columns" : {
+    "o_orderkey" : {
+      "distinctValuesCount" : 732044,
+      "nullsCount" : 0,
+      "min" : 1,
+      "max" : 6000000
+    },
+    "o_custkey" : {
+      "distinctValuesCount" : 99621,
+      "nullsCount" : 0,
+      "min" : 1,
+      "max" : 149999
+    },
+    "o_orderstatus" : {
+      "distinctValuesCount" : 1,
+      "nullsCount" : 0,
+      "min" : "O",
+      "max" : "O"
+    },
+    "o_totalprice" : {
+      "distinctValuesCount" : 723368,
+      "nullsCount" : 0,
+      "min" : 857.71,
+      "max" : 530604.44
+    },
+    "o_orderdate" : {
+      "distinctValuesCount" : 1262,
+      "nullsCount" : 0,
+      "min" : 9178,
+      "max" : 10440
+    },
+    "o_orderpriority" : {
+      "distinctValuesCount" : 5,
+      "nullsCount" : 0,
+      "min" : "1-URGENT",
+      "max" : "5-LOW"
+    },
+    "o_clerk" : {
+      "distinctValuesCount" : 1000,
+      "nullsCount" : 0,
+      "min" : "Clerk#000000001",
+      "max" : "Clerk#000001000"
+    },
+    "o_shippriority" : {
+      "distinctValuesCount" : 1,
+      "nullsCount" : 0,
+      "min" : 0,
+      "max" : 0
+    },
+    "o_comment" : {
+      "distinctValuesCount" : 727175,
+      "nullsCount" : 0,
+      "min" : " Tiresias about the blithely ironic a",
+      "max" : "zzle? furiously ironic instructions among the unusual t"
+    }
+  }
+}

--- a/presto-tpch/src/main/resources/tpch/statistics/sf1/orders.o_orderstatus.P.json
+++ b/presto-tpch/src/main/resources/tpch/statistics/sf1/orders.o_orderstatus.P.json
@@ -1,0 +1,59 @@
+{
+  "rowCount" : 38543,
+  "columns" : {
+    "o_orderkey" : {
+      "distinctValuesCount" : 38543,
+      "nullsCount" : 0,
+      "min" : 65,
+      "max" : 5999875
+    },
+    "o_custkey" : {
+      "distinctValuesCount" : 31310,
+      "nullsCount" : 0,
+      "min" : 2,
+      "max" : 149998
+    },
+    "o_orderstatus" : {
+      "distinctValuesCount" : 1,
+      "nullsCount" : 0,
+      "min" : "P",
+      "max" : "P"
+    },
+    "o_totalprice" : {
+      "distinctValuesCount" : 38515,
+      "nullsCount" : 0,
+      "min" : 2933.43,
+      "max" : 491549.57
+    },
+    "o_orderdate" : {
+      "distinctValuesCount" : 120,
+      "nullsCount" : 0,
+      "min" : 9178,
+      "max" : 9297
+    },
+    "o_orderpriority" : {
+      "distinctValuesCount" : 5,
+      "nullsCount" : 0,
+      "min" : "1-URGENT",
+      "max" : "5-LOW"
+    },
+    "o_clerk" : {
+      "distinctValuesCount" : 1000,
+      "nullsCount" : 0,
+      "min" : "Clerk#000000001",
+      "max" : "Clerk#000001000"
+    },
+    "o_shippriority" : {
+      "distinctValuesCount" : 1,
+      "nullsCount" : 0,
+      "min" : 0,
+      "max" : 0
+    },
+    "o_comment" : {
+      "distinctValuesCount" : 38531,
+      "nullsCount" : 0,
+      "min" : " Tiresias haggle slyly bli",
+      "max" : "zzle furiously. bold packa"
+    }
+  }
+}

--- a/presto-tpch/src/main/resources/tpch/statistics/sf1/part.json
+++ b/presto-tpch/src/main/resources/tpch/statistics/sf1/part.json
@@ -1,0 +1,59 @@
+{
+  "rowCount" : 200000,
+  "columns" : {
+    "p_partkey" : {
+      "distinctValuesCount" : 200000,
+      "nullsCount" : 0,
+      "min" : 1,
+      "max" : 200000
+    },
+    "p_name" : {
+      "distinctValuesCount" : 199997,
+      "nullsCount" : 0,
+      "min" : "almond antique blue royal burnished",
+      "max" : "yellow white seashell lavender black"
+    },
+    "p_mfgr" : {
+      "distinctValuesCount" : 5,
+      "nullsCount" : 0,
+      "min" : "Manufacturer#1",
+      "max" : "Manufacturer#5"
+    },
+    "p_brand" : {
+      "distinctValuesCount" : 25,
+      "nullsCount" : 0,
+      "min" : "Brand#11",
+      "max" : "Brand#55"
+    },
+    "p_type" : {
+      "distinctValuesCount" : 150,
+      "nullsCount" : 0,
+      "min" : "ECONOMY ANODIZED BRASS",
+      "max" : "STANDARD POLISHED TIN"
+    },
+    "p_size" : {
+      "distinctValuesCount" : 50,
+      "nullsCount" : 0,
+      "min" : 1,
+      "max" : 50
+    },
+    "p_container" : {
+      "distinctValuesCount" : 40,
+      "nullsCount" : 0,
+      "min" : "JUMBO BAG",
+      "max" : "WRAP PKG"
+    },
+    "p_retailprice" : {
+      "distinctValuesCount" : 20899,
+      "nullsCount" : 0,
+      "min" : 901.0,
+      "max" : 2098.99
+    },
+    "p_comment" : {
+      "distinctValuesCount" : 131753,
+      "nullsCount" : 0,
+      "min" : " Tire",
+      "max" : "zzle. quickly si"
+    }
+  }
+}

--- a/presto-tpch/src/main/resources/tpch/statistics/sf1/partsupp.json
+++ b/presto-tpch/src/main/resources/tpch/statistics/sf1/partsupp.json
@@ -1,0 +1,35 @@
+{
+  "rowCount" : 800000,
+  "columns" : {
+    "ps_partkey" : {
+      "distinctValuesCount" : 200000,
+      "nullsCount" : 0,
+      "min" : 1,
+      "max" : 200000
+    },
+    "ps_suppkey" : {
+      "distinctValuesCount" : 10000,
+      "nullsCount" : 0,
+      "min" : 1,
+      "max" : 10000
+    },
+    "ps_availqty" : {
+      "distinctValuesCount" : 9999,
+      "nullsCount" : 0,
+      "min" : 1,
+      "max" : 9999
+    },
+    "ps_supplycost" : {
+      "distinctValuesCount" : 99865,
+      "nullsCount" : 0,
+      "min" : 1.0,
+      "max" : 1000.0
+    },
+    "ps_comment" : {
+      "distinctValuesCount" : 799124,
+      "nullsCount" : 0,
+      "min" : " Tiresias according to the quiet courts sleep against the ironic, final requests. carefully unusual requests affix fluffily quickly ironic packages. regular ",
+      "max" : "zzle. unusual decoys detect slyly blithely express frays. furiously ironic packages about the bold accounts are close requests. slowly silent reque"
+    }
+  }
+}

--- a/presto-tpch/src/main/resources/tpch/statistics/sf1/region.json
+++ b/presto-tpch/src/main/resources/tpch/statistics/sf1/region.json
@@ -1,0 +1,23 @@
+{
+  "rowCount" : 5,
+  "columns" : {
+    "r_regionkey" : {
+      "distinctValuesCount" : 5,
+      "nullsCount" : 0,
+      "min" : 0,
+      "max" : 4
+    },
+    "r_name" : {
+      "distinctValuesCount" : 5,
+      "nullsCount" : 0,
+      "min" : "AFRICA",
+      "max" : "MIDDLE EAST"
+    },
+    "r_comment" : {
+      "distinctValuesCount" : 5,
+      "nullsCount" : 0,
+      "min" : "ges. thinly even pinto beans ca",
+      "max" : "uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl"
+    }
+  }
+}

--- a/presto-tpch/src/main/resources/tpch/statistics/sf1/supplier.json
+++ b/presto-tpch/src/main/resources/tpch/statistics/sf1/supplier.json
@@ -1,0 +1,47 @@
+{
+  "rowCount" : 10000,
+  "columns" : {
+    "s_suppkey" : {
+      "distinctValuesCount" : 10000,
+      "nullsCount" : 0,
+      "min" : 1,
+      "max" : 10000
+    },
+    "s_name" : {
+      "distinctValuesCount" : 10000,
+      "nullsCount" : 0,
+      "min" : "Supplier#000000001",
+      "max" : "Supplier#000010000"
+    },
+    "s_address" : {
+      "distinctValuesCount" : 10000,
+      "nullsCount" : 0,
+      "min" : "  9aW1wwnBJJPnCx,nox0MA48Y0zpI1IeVfYZ",
+      "max" : "zzfDhdtZcvmVzA8rNFU,Yctj1zBN"
+    },
+    "s_nationkey" : {
+      "distinctValuesCount" : 25,
+      "nullsCount" : 0,
+      "min" : 0,
+      "max" : 24
+    },
+    "s_phone" : {
+      "distinctValuesCount" : 10000,
+      "nullsCount" : 0,
+      "min" : "10-102-116-6785",
+      "max" : "34-998-900-4911"
+    },
+    "s_acctbal" : {
+      "distinctValuesCount" : 9955,
+      "nullsCount" : 0,
+      "min" : -998.22,
+      "max" : 9999.72
+    },
+    "s_comment" : {
+      "distinctValuesCount" : 10000,
+      "nullsCount" : 0,
+      "min" : " about the blithely express foxes. bli",
+      "max" : "zzle furiously. bold accounts haggle furiously ironic excuses. fur"
+    }
+  }
+}

--- a/presto-tpch/src/main/resources/tpch/statistics/tiny/customer.json
+++ b/presto-tpch/src/main/resources/tpch/statistics/tiny/customer.json
@@ -1,0 +1,53 @@
+{
+  "rowCount" : 1500,
+  "columns" : {
+    "c_custkey" : {
+      "distinctValuesCount" : 1500,
+      "nullsCount" : 0,
+      "min" : 1,
+      "max" : 1500
+    },
+    "c_name" : {
+      "distinctValuesCount" : 1500,
+      "nullsCount" : 0,
+      "min" : "Customer#000000001",
+      "max" : "Customer#000001500"
+    },
+    "c_address" : {
+      "distinctValuesCount" : 1500,
+      "nullsCount" : 0,
+      "min" : " ,cIZ,06Kg",
+      "max" : "zyWvi,SGc,tXTls"
+    },
+    "c_nationkey" : {
+      "distinctValuesCount" : 25,
+      "nullsCount" : 0,
+      "min" : 0,
+      "max" : 24
+    },
+    "c_phone" : {
+      "distinctValuesCount" : 1500,
+      "nullsCount" : 0,
+      "min" : "10-109-430-5638",
+      "max" : "34-992-529-2023"
+    },
+    "c_acctbal" : {
+      "distinctValuesCount" : 1499,
+      "nullsCount" : 0,
+      "min" : -994.79,
+      "max" : 9987.71
+    },
+    "c_mktsegment" : {
+      "distinctValuesCount" : 5,
+      "nullsCount" : 0,
+      "min" : "AUTOMOBILE",
+      "max" : "MACHINERY"
+    },
+    "c_comment" : {
+      "distinctValuesCount" : 1500,
+      "nullsCount" : 0,
+      "min" : " about the carefully ironic pinto beans. accoun",
+      "max" : "ymptotes. ironic, unusual notornis wake after the ironic, special deposits. blithely fina"
+    }
+  }
+}

--- a/presto-tpch/src/main/resources/tpch/statistics/tiny/lineitem.json
+++ b/presto-tpch/src/main/resources/tpch/statistics/tiny/lineitem.json
@@ -1,0 +1,101 @@
+{
+  "rowCount" : 60175,
+  "columns" : {
+    "l_orderkey" : {
+      "distinctValuesCount" : 15000,
+      "nullsCount" : 0,
+      "min" : 1,
+      "max" : 60000
+    },
+    "l_partkey" : {
+      "distinctValuesCount" : 2000,
+      "nullsCount" : 0,
+      "min" : 1,
+      "max" : 2000
+    },
+    "l_suppkey" : {
+      "distinctValuesCount" : 100,
+      "nullsCount" : 0,
+      "min" : 1,
+      "max" : 100
+    },
+    "l_linenumber" : {
+      "distinctValuesCount" : 7,
+      "nullsCount" : 0,
+      "min" : 1,
+      "max" : 7
+    },
+    "l_quantity" : {
+      "distinctValuesCount" : 50,
+      "nullsCount" : 0,
+      "min" : 1.0,
+      "max" : 50.0
+    },
+    "l_extendedprice" : {
+      "distinctValuesCount" : 35921,
+      "nullsCount" : 0,
+      "min" : 904.0,
+      "max" : 94949.5
+    },
+    "l_discount" : {
+      "distinctValuesCount" : 11,
+      "nullsCount" : 0,
+      "min" : 0.0,
+      "max" : 0.1
+    },
+    "l_tax" : {
+      "distinctValuesCount" : 9,
+      "nullsCount" : 0,
+      "min" : 0.0,
+      "max" : 0.08
+    },
+    "l_returnflag" : {
+      "distinctValuesCount" : 3,
+      "nullsCount" : 0,
+      "min" : "A",
+      "max" : "R"
+    },
+    "l_linestatus" : {
+      "distinctValuesCount" : 2,
+      "nullsCount" : 0,
+      "min" : "F",
+      "max" : "O"
+    },
+    "l_shipdate" : {
+      "distinctValuesCount" : 2518,
+      "nullsCount" : 0,
+      "min" : 8038,
+      "max" : 10559
+    },
+    "l_commitdate" : {
+      "distinctValuesCount" : 2460,
+      "nullsCount" : 0,
+      "min" : 8067,
+      "max" : 10527
+    },
+    "l_receiptdate" : {
+      "distinctValuesCount" : 2529,
+      "nullsCount" : 0,
+      "min" : 8043,
+      "max" : 10585
+    },
+    "l_shipinstruct" : {
+      "distinctValuesCount" : 4,
+      "nullsCount" : 0,
+      "min" : "COLLECT COD",
+      "max" : "TAKE BACK RETURN"
+    },
+    "l_shipmode" : {
+      "distinctValuesCount" : 7,
+      "nullsCount" : 0,
+      "min" : "AIR",
+      "max" : "TRUCK"
+    },
+    "l_comment" : {
+      "distinctValuesCount" : 58616,
+      "nullsCount" : 0,
+      "min" : " Tiresias ",
+      "max" : "zzle: pending i"
+    }
+  }
+}

--- a/presto-tpch/src/main/resources/tpch/statistics/tiny/nation.json
+++ b/presto-tpch/src/main/resources/tpch/statistics/tiny/nation.json
@@ -1,0 +1,29 @@
+{
+  "rowCount" : 25,
+  "columns" : {
+    "n_nationkey" : {
+      "distinctValuesCount" : 25,
+      "nullsCount" : 0,
+      "min" : 0,
+      "max" : 24
+    },
+    "n_name" : {
+      "distinctValuesCount" : 25,
+      "nullsCount" : 0,
+      "min" : "ALGERIA",
+      "max" : "VIETNAM"
+    },
+    "n_regionkey" : {
+      "distinctValuesCount" : 5,
+      "nullsCount" : 0,
+      "min" : 0,
+      "max" : 4
+    },
+    "n_comment" : {
+      "distinctValuesCount" : 25,
+      "nullsCount" : 0,
+      "min" : " haggle. carefully final deposits detect slyly agai",
+      "max" : "y final packages. slow foxes cajole quickly. quickly silent platelets breach ironic accounts. unusual pinto be"
+    }
+  }
+}

--- a/presto-tpch/src/main/resources/tpch/statistics/tiny/orders.json
+++ b/presto-tpch/src/main/resources/tpch/statistics/tiny/orders.json
@@ -1,0 +1,59 @@
+{
+  "rowCount" : 15000,
+  "columns" : {
+    "o_orderkey" : {
+      "distinctValuesCount" : 15000,
+      "nullsCount" : 0,
+      "min" : 1,
+      "max" : 60000
+    },
+    "o_custkey" : {
+      "distinctValuesCount" : 1000,
+      "nullsCount" : 0,
+      "min" : 1,
+      "max" : 1499
+    },
+    "o_orderstatus" : {
+      "distinctValuesCount" : 3,
+      "nullsCount" : 0,
+      "min" : "F",
+      "max" : "P"
+    },
+    "o_totalprice" : {
+      "distinctValuesCount" : 14996,
+      "nullsCount" : 0,
+      "min" : 874.89,
+      "max" : 466001.28
+    },
+    "o_orderdate" : {
+      "distinctValuesCount" : 2401,
+      "nullsCount" : 0,
+      "min" : 8035,
+      "max" : 10440
+    },
+    "o_orderpriority" : {
+      "distinctValuesCount" : 5,
+      "nullsCount" : 0,
+      "min" : "1-URGENT",
+      "max" : "5-LOW"
+    },
+    "o_clerk" : {
+      "distinctValuesCount" : 1000,
+      "nullsCount" : 0,
+      "min" : "Clerk#000000001",
+      "max" : "Clerk#000001000"
+    },
+    "o_shippriority" : {
+      "distinctValuesCount" : 1,
+      "nullsCount" : 0,
+      "min" : 0,
+      "max" : 0
+    },
+    "o_comment" : {
+      "distinctValuesCount" : 14995,
+      "nullsCount" : 0,
+      "min" : " about the accounts. slyly express accounts wa",
+      "max" : "zzle. carefully enticing deposits nag furio"
+    }
+  }
+}

--- a/presto-tpch/src/main/resources/tpch/statistics/tiny/orders.o_orderstatus.F.json
+++ b/presto-tpch/src/main/resources/tpch/statistics/tiny/orders.o_orderstatus.F.json
@@ -1,0 +1,59 @@
+{
+  "rowCount" : 7304,
+  "columns" : {
+    "o_orderkey" : {
+      "distinctValuesCount" : 7304,
+      "nullsCount" : 0,
+      "min" : 3,
+      "max" : 59975
+    },
+    "o_custkey" : {
+      "distinctValuesCount" : 996,
+      "nullsCount" : 0,
+      "min" : 1,
+      "max" : 1499
+    },
+    "o_orderstatus" : {
+      "distinctValuesCount" : 1,
+      "nullsCount" : 0,
+      "min" : "F",
+      "max" : "F"
+    },
+    "o_totalprice" : {
+      "distinctValuesCount" : 7303,
+      "nullsCount" : 0,
+      "min" : 874.89,
+      "max" : 408345.74
+    },
+    "o_orderdate" : {
+      "distinctValuesCount" : 1213,
+      "nullsCount" : 0,
+      "min" : 8035,
+      "max" : 9277
+    },
+    "o_orderpriority" : {
+      "distinctValuesCount" : 5,
+      "nullsCount" : 0,
+      "min" : "1-URGENT",
+      "max" : "5-LOW"
+    },
+    "o_clerk" : {
+      "distinctValuesCount" : 1000,
+      "nullsCount" : 0,
+      "min" : "Clerk#000000001",
+      "max" : "Clerk#000001000"
+    },
+    "o_shippriority" : {
+      "distinctValuesCount" : 1,
+      "nullsCount" : 0,
+      "min" : 0,
+      "max" : 0
+    },
+    "o_comment" : {
+      "distinctValuesCount" : 7303,
+      "nullsCount" : 0,
+      "min" : " about the blithely ironic requests. fluffily ironic ",
+      "max" : "zzle final, final dependencies. final, final accounts are blith"
+    }
+  }
+}

--- a/presto-tpch/src/main/resources/tpch/statistics/tiny/orders.o_orderstatus.O.json
+++ b/presto-tpch/src/main/resources/tpch/statistics/tiny/orders.o_orderstatus.O.json
@@ -1,0 +1,59 @@
+{
+  "rowCount" : 7333,
+  "columns" : {
+    "o_orderkey" : {
+      "distinctValuesCount" : 7333,
+      "nullsCount" : 0,
+      "min" : 1,
+      "max" : 59974
+    },
+    "o_custkey" : {
+      "distinctValuesCount" : 998,
+      "nullsCount" : 0,
+      "min" : 1,
+      "max" : 1499
+    },
+    "o_orderstatus" : {
+      "distinctValuesCount" : 1,
+      "nullsCount" : 0,
+      "min" : "O",
+      "max" : "O"
+    },
+    "o_totalprice" : {
+      "distinctValuesCount" : 7331,
+      "nullsCount" : 0,
+      "min" : 974.04,
+      "max" : 466001.28
+    },
+    "o_orderdate" : {
+      "distinctValuesCount" : 1213,
+      "nullsCount" : 0,
+      "min" : 9197,
+      "max" : 10440
+    },
+    "o_orderpriority" : {
+      "distinctValuesCount" : 5,
+      "nullsCount" : 0,
+      "min" : "1-URGENT",
+      "max" : "5-LOW"
+    },
+    "o_clerk" : {
+      "distinctValuesCount" : 1000,
+      "nullsCount" : 0,
+      "min" : "Clerk#000000001",
+      "max" : "Clerk#000001000"
+    },
+    "o_shippriority" : {
+      "distinctValuesCount" : 1,
+      "nullsCount" : 0,
+      "min" : 0,
+      "max" : 0
+    },
+    "o_comment" : {
+      "distinctValuesCount" : 7333,
+      "nullsCount" : 0,
+      "min" : " about the accounts. slyly express accounts wa",
+      "max" : "zzle. carefully enticing deposits nag furio"
+    }
+  }
+}

--- a/presto-tpch/src/main/resources/tpch/statistics/tiny/orders.o_orderstatus.P.json
+++ b/presto-tpch/src/main/resources/tpch/statistics/tiny/orders.o_orderstatus.P.json
@@ -1,0 +1,59 @@
+{
+  "rowCount" : 363,
+  "columns" : {
+    "o_orderkey" : {
+      "distinctValuesCount" : 363,
+      "nullsCount" : 0,
+      "min" : 65,
+      "max" : 60000
+    },
+    "o_custkey" : {
+      "distinctValuesCount" : 304,
+      "nullsCount" : 0,
+      "min" : 16,
+      "max" : 1499
+    },
+    "o_orderstatus" : {
+      "distinctValuesCount" : 1,
+      "nullsCount" : 0,
+      "min" : "P",
+      "max" : "P"
+    },
+    "o_totalprice" : {
+      "distinctValuesCount" : 363,
+      "nullsCount" : 0,
+      "min" : 16145.49,
+      "max" : 376904.18
+    },
+    "o_orderdate" : {
+      "distinctValuesCount" : 107,
+      "nullsCount" : 0,
+      "min" : 9182,
+      "max" : 9292
+    },
+    "o_orderpriority" : {
+      "distinctValuesCount" : 5,
+      "nullsCount" : 0,
+      "min" : "1-URGENT",
+      "max" : "5-LOW"
+    },
+    "o_clerk" : {
+      "distinctValuesCount" : 310,
+      "nullsCount" : 0,
+      "min" : "Clerk#000000001",
+      "max" : "Clerk#000001000"
+    },
+    "o_shippriority" : {
+      "distinctValuesCount" : 1,
+      "nullsCount" : 0,
+      "min" : 0,
+      "max" : 0
+    },
+    "o_comment" : {
+      "distinctValuesCount" : 363,
+      "nullsCount" : 0,
+      "min" : " according to the final asymptotes. carefully silent de",
+      "max" : "yly pending platelets sleep c"
+    }
+  }
+}

--- a/presto-tpch/src/main/resources/tpch/statistics/tiny/part.json
+++ b/presto-tpch/src/main/resources/tpch/statistics/tiny/part.json
@@ -1,0 +1,59 @@
+{
+  "rowCount" : 2000,
+  "columns" : {
+    "p_partkey" : {
+      "distinctValuesCount" : 2000,
+      "nullsCount" : 0,
+      "min" : 1,
+      "max" : 2000
+    },
+    "p_name" : {
+      "distinctValuesCount" : 2000,
+      "nullsCount" : 0,
+      "min" : "almond aquamarine mint misty red",
+      "max" : "yellow white puff orange rosy"
+    },
+    "p_mfgr" : {
+      "distinctValuesCount" : 5,
+      "nullsCount" : 0,
+      "min" : "Manufacturer#1",
+      "max" : "Manufacturer#5"
+    },
+    "p_brand" : {
+      "distinctValuesCount" : 25,
+      "nullsCount" : 0,
+      "min" : "Brand#11",
+      "max" : "Brand#55"
+    },
+    "p_type" : {
+      "distinctValuesCount" : 150,
+      "nullsCount" : 0,
+      "min" : "ECONOMY ANODIZED BRASS",
+      "max" : "STANDARD POLISHED TIN"
+    },
+    "p_size" : {
+      "distinctValuesCount" : 50,
+      "nullsCount" : 0,
+      "min" : 1,
+      "max" : 50
+    },
+    "p_container" : {
+      "distinctValuesCount" : 40,
+      "nullsCount" : 0,
+      "min" : "JUMBO BAG",
+      "max" : "WRAP PKG"
+    },
+    "p_retailprice" : {
+      "distinctValuesCount" : 1099,
+      "nullsCount" : 0,
+      "min" : 901.0,
+      "max" : 1900.99
+    },
+    "p_comment" : {
+      "distinctValuesCount" : 1959,
+      "nullsCount" : 0,
+      "min" : " about the furio",
+      "max" : "zzle among t"
+    }
+  }
+}

--- a/presto-tpch/src/main/resources/tpch/statistics/tiny/partsupp.json
+++ b/presto-tpch/src/main/resources/tpch/statistics/tiny/partsupp.json
@@ -1,0 +1,35 @@
+{
+  "rowCount" : 8000,
+  "columns" : {
+    "ps_partkey" : {
+      "distinctValuesCount" : 2000,
+      "nullsCount" : 0,
+      "min" : 1,
+      "max" : 2000
+    },
+    "ps_suppkey" : {
+      "distinctValuesCount" : 100,
+      "nullsCount" : 0,
+      "min" : 1,
+      "max" : 100
+    },
+    "ps_availqty" : {
+      "distinctValuesCount" : 5497,
+      "nullsCount" : 0,
+      "min" : 3,
+      "max" : 9998
+    },
+    "ps_supplycost" : {
+      "distinctValuesCount" : 7665,
+      "nullsCount" : 0,
+      "min" : 1.05,
+      "max" : 999.99
+    },
+    "ps_comment" : {
+      "distinctValuesCount" : 8000,
+      "nullsCount" : 0,
+      "min" : " about the instructions. carefully final platelets cajole carefully furiously regular requests. carefully regular theodolites along the carefully regular pinto beans haggle about ",
+      "max" : "zzle blithely about the furiously final foxes. pen"
+    }
+  }
+}

--- a/presto-tpch/src/main/resources/tpch/statistics/tiny/region.json
+++ b/presto-tpch/src/main/resources/tpch/statistics/tiny/region.json
@@ -1,0 +1,23 @@
+{
+  "rowCount" : 5,
+  "columns" : {
+    "r_regionkey" : {
+      "distinctValuesCount" : 5,
+      "nullsCount" : 0,
+      "min" : 0,
+      "max" : 4
+    },
+    "r_name" : {
+      "distinctValuesCount" : 5,
+      "nullsCount" : 0,
+      "min" : "AFRICA",
+      "max" : "MIDDLE EAST"
+    },
+    "r_comment" : {
+      "distinctValuesCount" : 5,
+      "nullsCount" : 0,
+      "min" : "ges. thinly even pinto beans ca",
+      "max" : "uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl"
+    }
+  }
+}

--- a/presto-tpch/src/main/resources/tpch/statistics/tiny/supplier.json
+++ b/presto-tpch/src/main/resources/tpch/statistics/tiny/supplier.json
@@ -1,0 +1,47 @@
+{
+  "rowCount" : 100,
+  "columns" : {
+    "s_suppkey" : {
+      "distinctValuesCount" : 100,
+      "nullsCount" : 0,
+      "min" : 1,
+      "max" : 100
+    },
+    "s_name" : {
+      "distinctValuesCount" : 100,
+      "nullsCount" : 0,
+      "min" : "Supplier#000000001",
+      "max" : "Supplier#000000100"
+    },
+    "s_address" : {
+      "distinctValuesCount" : 100,
+      "nullsCount" : 0,
+      "min" : " N kD4on9OM Ipw3,gf0JBoQDd7tgrzrddZ",
+      "max" : "zyIeWzbbpkTV37vm1nmSGBxSgd2Kp"
+    },
+    "s_nationkey" : {
+      "distinctValuesCount" : 25,
+      "nullsCount" : 0,
+      "min" : 0,
+      "max" : 24
+    },
+    "s_phone" : {
+      "distinctValuesCount" : 100,
+      "nullsCount" : 0,
+      "min" : "10-470-144-1330",
+      "max" : "34-876-912-6007"
+    },
+    "s_acctbal" : {
+      "distinctValuesCount" : 100,
+      "nullsCount" : 0,
+      "min" : -966.2,
+      "max" : 9915.24
+    },
+    "s_comment" : {
+      "distinctValuesCount" : 100,
+      "nullsCount" : 0,
+      "min" : " across the furiously regular platelets wake even deposits. quickly express she",
+      "max" : "yly final accounts could are carefully. fluffily ironic instruct"
+    }
+  }
+}

--- a/presto-tpch/src/test/java/com/facebook/presto/tpch/EstimateAssertion.java
+++ b/presto-tpch/src/test/java/com/facebook/presto/tpch/EstimateAssertion.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tpch;
+
+import com.facebook.presto.spi.statistics.Estimate;
+import io.airlift.slice.Slice;
+
+import java.util.Optional;
+
+import static java.lang.String.format;
+import static java.util.Optional.empty;
+import static org.testng.Assert.assertEquals;
+
+class EstimateAssertion
+{
+    private final double tolerance;
+
+    public EstimateAssertion(double tolerance)
+    {
+        this.tolerance = tolerance;
+    }
+
+    public void assertClose(Estimate actual, Estimate expected, String message)
+    {
+        assertClose(toOptional(actual), toOptional(expected), message);
+    }
+
+    private Optional<Double> toOptional(Estimate estimate)
+    {
+        return estimate.isValueUnknown() ? empty() : Optional.of(estimate.getValue());
+    }
+
+    public void assertClose(Optional<?> actual, Optional<?> expected, String message)
+    {
+        assertEquals(actual.isPresent(), expected.isPresent(), message);
+        if (actual.isPresent()) {
+            Object actualValue = actual.get();
+            Object expectedValue = expected.get();
+            assertClose(actualValue, expectedValue, message);
+        }
+    }
+
+    private void assertClose(Object actual, Object expected, String message)
+    {
+        if (actual instanceof Slice) {
+            assertEquals(actual.getClass(), expected.getClass(), message);
+            assertEquals(((Slice) actual).toStringUtf8(), ((Slice) expected).toStringUtf8());
+        }
+        else {
+            double actualDouble = toDouble(actual);
+            double expectedDouble = toDouble(expected);
+            assertEquals(actualDouble, expectedDouble, expectedDouble * tolerance, message);
+        }
+    }
+
+    private double toDouble(Object object)
+    {
+        if (object instanceof Number) {
+            return ((Number) object).doubleValue();
+        }
+        else {
+            String message = "Can't compare with tolerance objects of class %s. Use assertEquals.";
+            throw new UnsupportedOperationException(format(message, object.getClass()));
+        }
+    }
+}

--- a/presto-tpch/src/test/java/com/facebook/presto/tpch/TestTpchMetadata.java
+++ b/presto-tpch/src/test/java/com/facebook/presto/tpch/TestTpchMetadata.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tpch;
+
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.Constraint;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.predicate.NullableValue;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.statistics.Estimate;
+import com.facebook.presto.spi.statistics.TableStatistics;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.tpch.TpchColumn;
+import io.airlift.tpch.TpchTable;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.spi.predicate.TupleDomain.fromFixedValues;
+import static com.facebook.presto.tpch.TpchRecordSet.convertToPredicate;
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.airlift.tpch.OrderColumn.ORDER_STATUS;
+import static io.airlift.tpch.TpchTable.CUSTOMER;
+import static io.airlift.tpch.TpchTable.LINE_ITEM;
+import static io.airlift.tpch.TpchTable.NATION;
+import static io.airlift.tpch.TpchTable.ORDERS;
+import static io.airlift.tpch.TpchTable.PART;
+import static io.airlift.tpch.TpchTable.PART_SUPPLIER;
+import static io.airlift.tpch.TpchTable.REGION;
+import static io.airlift.tpch.TpchTable.SUPPLIER;
+import static java.util.Arrays.stream;
+import static org.testng.Assert.assertEquals;
+
+public class TestTpchMetadata
+{
+    private static final double TOLERANCE = 0.01;
+
+    private final TpchMetadata tpchMetadata = new TpchMetadata("tpch");
+    private final ConnectorSession session = null;
+
+    @Test
+    public void testTableStats()
+    {
+        TpchMetadata.SCHEMA_NAMES.forEach(schema -> {
+            double scaleFactor = TpchMetadata.schemaNameToScaleFactor(schema);
+
+            testTableStats(schema, REGION, 5);
+            testTableStats(schema, NATION, 25);
+            testTableStats(schema, SUPPLIER, 10_000 * scaleFactor);
+            testTableStats(schema, CUSTOMER, 150_000 * scaleFactor);
+            testTableStats(schema, PART, 200_000 * scaleFactor);
+            testTableStats(schema, PART_SUPPLIER, 800_000 * scaleFactor);
+            testTableStats(schema, ORDERS, 1_500_000 * scaleFactor);
+            testTableStats(schema, LINE_ITEM, 6_000_000 * scaleFactor);
+        });
+    }
+
+    @Test
+    public void testTableStatsWithConstraints()
+    {
+        TpchMetadata.SCHEMA_NAMES.forEach(schema -> {
+            double scaleFactor = TpchMetadata.schemaNameToScaleFactor(schema);
+
+            testTableStats(schema, ORDERS, Constraint.alwaysFalse(), 0);
+            testTableStats(schema, ORDERS, constraint(ORDER_STATUS, "NO SUCH STATUS"), 0);
+            testTableStats(schema, ORDERS, constraint(ORDER_STATUS, "F"), 730_400 * scaleFactor);
+            testTableStats(schema, ORDERS, constraint(ORDER_STATUS, "O"), 733_300 * scaleFactor);
+            testTableStats(schema, ORDERS, constraint(ORDER_STATUS, "P"), 38_543 * scaleFactor);
+            testTableStats(schema, ORDERS, constraint(ORDER_STATUS, "F", "NO SUCH STATUS"), 730_400 * scaleFactor);
+            testTableStats(schema, ORDERS, constraint(ORDER_STATUS, "F", "O", "P"), 1_500_000 * scaleFactor);
+        });
+    }
+
+    private void testTableStats(String schema, TpchTable<?> table, double expectedRowCount)
+    {
+        testTableStats(schema, table, Constraint.alwaysTrue(), expectedRowCount);
+    }
+
+    private void testTableStats(String schema, TpchTable<?> table, Constraint<ColumnHandle> constraint, double expectedRowCount)
+    {
+        TpchTableHandle tableHandle = tpchMetadata.getTableHandle(session, new SchemaTableName(schema, table.getTableName()));
+        TableStatistics tableStatistics = tpchMetadata.getTableStatistics(session, tableHandle, constraint);
+
+        double actualRowCountValue = tableStatistics.getRowCount().getValue();
+        assertEquals(tableStatistics.getTableStatistics(), ImmutableMap.of("row_count", new Estimate(actualRowCountValue)));
+        assertEquals(actualRowCountValue, expectedRowCount, expectedRowCount * TOLERANCE);
+    }
+
+    private Constraint<ColumnHandle> constraint(TpchColumn<?> column, String... values)
+    {
+        List<TupleDomain<ColumnHandle>> valueDomains = stream(values)
+                .map(value -> fromFixedValues(valueBinding(column, value)))
+                .collect(Collectors.toList());
+        TupleDomain<ColumnHandle> domain = TupleDomain.columnWiseUnion(valueDomains);
+        return new Constraint<>(domain, convertToPredicate(domain));
+    }
+
+    private ImmutableMap<ColumnHandle, NullableValue> valueBinding(TpchColumn<?> column, String value)
+    {
+        return ImmutableMap.of(
+                tpchMetadata.toColumnHandle(column),
+                new NullableValue(TpchMetadata.getPrestoType(column), utf8Slice(value)));
+    }
+}

--- a/presto-tpch/src/test/java/com/facebook/presto/tpch/TestTpchMetadata.java
+++ b/presto-tpch/src/test/java/com/facebook/presto/tpch/TestTpchMetadata.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.predicate.NullableValue;
 import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.statistics.ColumnStatistics;
 import com.facebook.presto.spi.statistics.Estimate;
 import com.facebook.presto.spi.statistics.TableStatistics;
 import com.google.common.collect.ImmutableMap;
@@ -27,12 +28,51 @@ import io.airlift.tpch.TpchTable;
 import org.testng.annotations.Test;
 
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Optional;
 
+import static com.facebook.presto.spi.Constraint.alwaysFalse;
+import static com.facebook.presto.spi.Constraint.alwaysTrue;
 import static com.facebook.presto.spi.predicate.TupleDomain.fromFixedValues;
+import static com.facebook.presto.spi.statistics.Estimate.unknownValue;
+import static com.facebook.presto.spi.statistics.Estimate.zeroValue;
 import static com.facebook.presto.tpch.TpchRecordSet.convertToPredicate;
 import static io.airlift.slice.Slices.utf8Slice;
+import static io.airlift.tpch.CustomerColumn.ADDRESS;
+import static io.airlift.tpch.CustomerColumn.CUSTOMER_KEY;
+import static io.airlift.tpch.CustomerColumn.MARKET_SEGMENT;
+import static io.airlift.tpch.CustomerColumn.NAME;
+import static io.airlift.tpch.LineItemColumn.COMMIT_DATE;
+import static io.airlift.tpch.LineItemColumn.DISCOUNT;
+import static io.airlift.tpch.LineItemColumn.EXTENDED_PRICE;
+import static io.airlift.tpch.LineItemColumn.LINE_NUMBER;
+import static io.airlift.tpch.LineItemColumn.QUANTITY;
+import static io.airlift.tpch.LineItemColumn.RECEIPT_DATE;
+import static io.airlift.tpch.LineItemColumn.RETURN_FLAG;
+import static io.airlift.tpch.LineItemColumn.SHIP_DATE;
+import static io.airlift.tpch.LineItemColumn.SHIP_INSTRUCTIONS;
+import static io.airlift.tpch.LineItemColumn.SHIP_MODE;
+import static io.airlift.tpch.LineItemColumn.STATUS;
+import static io.airlift.tpch.LineItemColumn.TAX;
+import static io.airlift.tpch.NationColumn.NATION_KEY;
+import static io.airlift.tpch.OrderColumn.CLERK;
+import static io.airlift.tpch.OrderColumn.ORDER_DATE;
+import static io.airlift.tpch.OrderColumn.ORDER_KEY;
+import static io.airlift.tpch.OrderColumn.ORDER_PRIORITY;
 import static io.airlift.tpch.OrderColumn.ORDER_STATUS;
+import static io.airlift.tpch.OrderColumn.SHIP_PRIORITY;
+import static io.airlift.tpch.OrderColumn.TOTAL_PRICE;
+import static io.airlift.tpch.PartColumn.BRAND;
+import static io.airlift.tpch.PartColumn.CONTAINER;
+import static io.airlift.tpch.PartColumn.MANUFACTURER;
+import static io.airlift.tpch.PartColumn.PART_KEY;
+import static io.airlift.tpch.PartColumn.RETAIL_PRICE;
+import static io.airlift.tpch.PartColumn.SIZE;
+import static io.airlift.tpch.PartColumn.TYPE;
+import static io.airlift.tpch.PartSupplierColumn.AVAILABLE_QUANTITY;
+import static io.airlift.tpch.PartSupplierColumn.COMMENT;
+import static io.airlift.tpch.RegionColumn.REGION_KEY;
+import static io.airlift.tpch.SupplierColumn.ACCOUNT_BALANCE;
+import static io.airlift.tpch.SupplierColumn.SUPPLIER_KEY;
 import static io.airlift.tpch.TpchTable.CUSTOMER;
 import static io.airlift.tpch.TpchTable.LINE_ITEM;
 import static io.airlift.tpch.TpchTable.NATION;
@@ -42,6 +82,8 @@ import static io.airlift.tpch.TpchTable.PART_SUPPLIER;
 import static io.airlift.tpch.TpchTable.REGION;
 import static io.airlift.tpch.TpchTable.SUPPLIER;
 import static java.util.Arrays.stream;
+import static java.util.Optional.empty;
+import static java.util.stream.Collectors.toList;
 import static org.testng.Assert.assertEquals;
 
 public class TestTpchMetadata
@@ -74,7 +116,7 @@ public class TestTpchMetadata
         TpchMetadata.SCHEMA_NAMES.forEach(schema -> {
             double scaleFactor = TpchMetadata.schemaNameToScaleFactor(schema);
 
-            testTableStats(schema, ORDERS, Constraint.alwaysFalse(), 0);
+            testTableStats(schema, ORDERS, alwaysFalse(), 0);
             testTableStats(schema, ORDERS, constraint(ORDER_STATUS, "NO SUCH STATUS"), 0);
             testTableStats(schema, ORDERS, constraint(ORDER_STATUS, "F"), 730_400 * scaleFactor);
             testTableStats(schema, ORDERS, constraint(ORDER_STATUS, "O"), 733_300 * scaleFactor);
@@ -86,7 +128,7 @@ public class TestTpchMetadata
 
     private void testTableStats(String schema, TpchTable<?> table, double expectedRowCount)
     {
-        testTableStats(schema, table, Constraint.alwaysTrue(), expectedRowCount);
+        testTableStats(schema, table, alwaysTrue(), expectedRowCount);
     }
 
     private void testTableStats(String schema, TpchTable<?> table, Constraint<ColumnHandle> constraint, double expectedRowCount)
@@ -99,11 +141,161 @@ public class TestTpchMetadata
         assertEquals(actualRowCountValue, expectedRowCount, expectedRowCount * TOLERANCE);
     }
 
+    @Test
+    public void testColumnStats()
+    {
+        TpchMetadata.SCHEMA_NAMES.forEach(schema -> {
+            double scaleFactor = TpchMetadata.schemaNameToScaleFactor(schema);
+
+            //id columns
+            testColumnStats(schema, REGION, REGION_KEY, columnStatistics(5, 0, 4));
+            testColumnStats(schema, NATION, NATION_KEY, columnStatistics(25, 0, 24));
+            testColumnStats(schema, SUPPLIER, SUPPLIER_KEY, columnStatistics(10_000 * scaleFactor, 1, 10_000 * scaleFactor));
+            testColumnStats(schema, CUSTOMER, CUSTOMER_KEY, columnStatistics(150_000 * scaleFactor, 1, 150_000 * scaleFactor));
+            testColumnStats(schema, PART, PART_KEY, columnStatistics(200_000 * scaleFactor, 1, 200_000 * scaleFactor));
+            testColumnStats(schema, ORDERS, ORDER_KEY, columnStatistics(1_500_000 * scaleFactor, 1, 6_000_000 * scaleFactor));
+
+            //foreign keys to dictionary identifier columns
+            testColumnStats(schema, NATION, REGION_KEY, columnStatistics(5, 0, 4));
+            testColumnStats(schema, SUPPLIER, NATION_KEY, columnStatistics(25, 0, 24));
+
+            //foreign keys to scalable identifier columns
+            testColumnStats(schema, PART_SUPPLIER, SUPPLIER_KEY, columnStatistics(10_000 * scaleFactor, 1, 10_000 * scaleFactor));
+            testColumnStats(schema, PART_SUPPLIER, PART_KEY, columnStatistics(200_000 * scaleFactor, 1, 200_000 * scaleFactor));
+
+            //semi-uniquely valued varchar columns
+            testColumnStats(schema, PART_SUPPLIER, COMMENT, columnStatistics(800_000 * scaleFactor));
+            testColumnStats(schema, CUSTOMER, NAME, columnStatistics(150_000 * scaleFactor));
+            testColumnStats(schema, CUSTOMER, ADDRESS, columnStatistics(150_000 * scaleFactor));
+            testColumnStats(schema, CUSTOMER, COMMENT, columnStatistics(150_000 * scaleFactor));
+
+            //non-scalable columns:
+            //dictionaries:
+            testColumnStats(schema, CUSTOMER, MARKET_SEGMENT, columnStatistics(5, "AUTOMOBILE", "MACHINERY"));
+            testColumnStats(schema, ORDERS, CLERK, columnStatistics(1000, "Clerk#000000001", "Clerk#000001000"));
+            testColumnStats(schema, ORDERS, ORDER_STATUS, columnStatistics(3, "F", "P"));
+            testColumnStats(schema, ORDERS, ORDER_PRIORITY, columnStatistics(5, "1-URGENT", "5-LOW"));
+            testColumnStats(schema, PART, BRAND, columnStatistics(25, "Brand#11", "Brand#55"));
+            testColumnStats(schema, PART, CONTAINER, columnStatistics(40, "JUMBO BAG", "WRAP PKG"));
+            testColumnStats(schema, PART, MANUFACTURER, columnStatistics(5, "Manufacturer#1", "Manufacturer#5"));
+            testColumnStats(schema, PART, SIZE, columnStatistics(50, 1, 50));
+            testColumnStats(schema, PART, TYPE, columnStatistics(150, "ECONOMY ANODIZED BRASS", "STANDARD POLISHED TIN"));
+            testColumnStats(schema, LINE_ITEM, RETURN_FLAG, columnStatistics(3, "A", "R"));
+            testColumnStats(schema, LINE_ITEM, SHIP_INSTRUCTIONS, columnStatistics(4, "COLLECT COD", "TAKE BACK RETURN"));
+            testColumnStats(schema, LINE_ITEM, SHIP_MODE, columnStatistics(7, "AIR", "TRUCK"));
+            testColumnStats(schema, LINE_ITEM, STATUS, columnStatistics(2, "F", "O"));
+
+            //low-valued numeric columns
+            testColumnStats(schema, ORDERS, SHIP_PRIORITY, columnStatistics(1, 0, 0));
+            testColumnStats(schema, LINE_ITEM, LINE_NUMBER, columnStatistics(7, 1, 7));
+            testColumnStats(schema, LINE_ITEM, QUANTITY, columnStatistics(50, 1, 50));
+            testColumnStats(schema, LINE_ITEM, DISCOUNT, columnStatistics(11, 0, 0.1));
+            testColumnStats(schema, LINE_ITEM, TAX, columnStatistics(9, 0, 0.08));
+
+            //dates:
+            testColumnStats(schema, ORDERS, ORDER_DATE, columnStatistics(2_400, 8_035, 10_440));
+            testColumnStats(schema, LINE_ITEM, COMMIT_DATE, columnStatistics(2_450, 8_035, 10_500));
+            testColumnStats(schema, LINE_ITEM, SHIP_DATE, columnStatistics(2_525, 8_035, 10_500));
+            testColumnStats(schema, LINE_ITEM, RECEIPT_DATE, columnStatistics(2_550, 8_035, 10_500));
+
+            //AVAILABLE_QUANTITY and all money-related columns have quite visible non-scalable min and max
+            //but their ndv reaches a plateau for bigger SFs because of the data type used
+            //for this reason, those can't be estimated easily
+            testColumnStats(schema, PART_SUPPLIER, AVAILABLE_QUANTITY, unknownStatistics());
+            testColumnStats(schema, PART, RETAIL_PRICE, unknownStatistics());
+            testColumnStats(schema, LINE_ITEM, EXTENDED_PRICE, unknownStatistics());
+            testColumnStats(schema, ORDERS, TOTAL_PRICE, unknownStatistics());
+            testColumnStats(schema, SUPPLIER, ACCOUNT_BALANCE, unknownStatistics());
+            testColumnStats(schema, CUSTOMER, ACCOUNT_BALANCE, unknownStatistics());
+        });
+    }
+
+    @Test
+    public void testColumnStatsWithConstraints()
+    {
+        TpchMetadata.SCHEMA_NAMES.forEach(schema -> {
+            double scaleFactor = TpchMetadata.schemaNameToScaleFactor(schema);
+
+            //value count, min and max are supported for the constrained column
+            testColumnStats(schema, ORDERS, ORDER_STATUS, constraint(ORDER_STATUS, "F"), columnStatistics(1, "F", "F"));
+            testColumnStats(schema, ORDERS, ORDER_STATUS, constraint(ORDER_STATUS, "O"), columnStatistics(1, "O", "O"));
+            testColumnStats(schema, ORDERS, ORDER_STATUS, constraint(ORDER_STATUS, "P"), columnStatistics(1, "P", "P"));
+
+            //only min and max values for non-scaling columns can be estimated for non-constrained columns
+            testColumnStats(schema, ORDERS, ORDER_KEY, constraint(ORDER_STATUS, "F"), rangeStatistics(3, 6_000_000 * scaleFactor));
+            testColumnStats(schema, ORDERS, ORDER_KEY, constraint(ORDER_STATUS, "O"), rangeStatistics(1, 6_000_000 * scaleFactor));
+            testColumnStats(schema, ORDERS, ORDER_KEY, constraint(ORDER_STATUS, "P"), rangeStatistics(65, 6_000_000 * scaleFactor));
+            testColumnStats(schema, ORDERS, CLERK, constraint(ORDER_STATUS, "O"), rangeStatistics("Clerk#000000001", "Clerk#000001000"));
+            testColumnStats(schema, ORDERS, COMMENT, constraint(ORDER_STATUS, "O"), unknownStatistics());
+
+            //nothing can be said for always false constraints
+            testColumnStats(schema, ORDERS, ORDER_STATUS, alwaysFalse(), columnStatistics(0));
+            testColumnStats(schema, ORDERS, ORDER_KEY, alwaysFalse(), columnStatistics(0));
+            testColumnStats(schema, ORDERS, ORDER_STATUS, constraint(ORDER_STATUS, "NO SUCH STATUS"), columnStatistics(0));
+            testColumnStats(schema, ORDERS, ORDER_KEY, constraint(ORDER_STATUS, "NO SUCH STATUS"), columnStatistics(0));
+
+            //unmodified stats are returned for the always true constraint
+            testColumnStats(schema, ORDERS, ORDER_STATUS, alwaysTrue(), columnStatistics(3, "F", "P"));
+            testColumnStats(schema, ORDERS, ORDER_KEY, alwaysTrue(), columnStatistics(1_500_000 * scaleFactor, 1, 6_000_000 * scaleFactor));
+
+            //constraints on columns other than ORDER_STATUS are not supported and are ignored
+            testColumnStats(schema, ORDERS, ORDER_STATUS, constraint(CLERK, "NO SUCH CLERK"), columnStatistics(3, "F", "P"));
+            testColumnStats(schema, ORDERS, ORDER_KEY, constraint(CLERK, "Clerk#000000001"), columnStatistics(1_500_000 * scaleFactor, 1, 6_000_000 * scaleFactor));
+
+            //compound constraints are supported
+            testColumnStats(schema, ORDERS, ORDER_STATUS, constraint(ORDER_STATUS, "F", "NO SUCH STATUS"), columnStatistics(1, "F", "F"));
+            testColumnStats(schema, ORDERS, ORDER_KEY, constraint(ORDER_STATUS, "F", "NO SUCH STATUS"), rangeStatistics(3, 6_000_000 * scaleFactor));
+
+            testColumnStats(schema, ORDERS, ORDER_STATUS, constraint(ORDER_STATUS, "F", "O"), columnStatistics(2, "F", "O"));
+            testColumnStats(schema, ORDERS, ORDER_KEY, constraint(ORDER_STATUS, "F", "O"), rangeStatistics(1, 6_000_000 * scaleFactor));
+
+            testColumnStats(schema, ORDERS, ORDER_STATUS, constraint(ORDER_STATUS, "F", "O", "P"), columnStatistics(3, "F", "P"));
+            testColumnStats(schema, ORDERS, ORDER_KEY, constraint(ORDER_STATUS, "F", "O", "P"), columnStatistics(1_500_000 * scaleFactor, 1, 6_000_000 * scaleFactor));
+        });
+    }
+
+    private void testColumnStats(String schema, TpchTable<?> table, TpchColumn<?> column, ColumnStatistics expectedStatistics)
+    {
+        testColumnStats(schema, table, column, alwaysTrue(), expectedStatistics);
+    }
+
+    private void testColumnStats(String schema, TpchTable<?> table, TpchColumn<?> column, Constraint<ColumnHandle> constraint, ColumnStatistics expected)
+    {
+        TpchTableHandle tableHandle = tpchMetadata.getTableHandle(session, new SchemaTableName(schema, table.getTableName()));
+        TableStatistics tableStatistics = tpchMetadata.getTableStatistics(session, tableHandle, constraint);
+        ColumnHandle columnHandle = tpchMetadata.getColumnHandles(session, tableHandle).get(column.getSimplifiedColumnName());
+
+        ColumnStatistics actual = tableStatistics.getColumnStatistics().get(columnHandle);
+
+        EstimateAssertion estimateAssertion = new EstimateAssertion(TOLERANCE);
+
+        estimateAssertion.assertClose(
+                actual.getOnlyRangeColumnStatistics().getDistinctValuesCount(),
+                expected.getOnlyRangeColumnStatistics().getDistinctValuesCount(),
+                "distinctValuesCount-s differ");
+        estimateAssertion.assertClose(
+                actual.getOnlyRangeColumnStatistics().getDataSize(),
+                expected.getOnlyRangeColumnStatistics().getDataSize(),
+                "dataSize-s differ");
+        estimateAssertion.assertClose(
+                actual.getNullsFraction(),
+                expected.getNullsFraction(),
+                "nullsFraction-s differ");
+        estimateAssertion.assertClose(
+                actual.getOnlyRangeColumnStatistics().getLowValue(),
+                expected.getOnlyRangeColumnStatistics().getLowValue(),
+                "lowValue-s differ");
+        estimateAssertion.assertClose(
+                actual.getOnlyRangeColumnStatistics().getHighValue(),
+                expected.getOnlyRangeColumnStatistics().getHighValue(),
+                "highValue-s differ");
+    }
+
     private Constraint<ColumnHandle> constraint(TpchColumn<?> column, String... values)
     {
         List<TupleDomain<ColumnHandle>> valueDomains = stream(values)
                 .map(value -> fromFixedValues(valueBinding(column, value)))
-                .collect(Collectors.toList());
+                .collect(toList());
         TupleDomain<ColumnHandle> domain = TupleDomain.columnWiseUnion(valueDomains);
         return new Constraint<>(domain, convertToPredicate(domain));
     }
@@ -113,5 +305,47 @@ public class TestTpchMetadata
         return ImmutableMap.of(
                 tpchMetadata.toColumnHandle(column),
                 new NullableValue(TpchMetadata.getPrestoType(column), utf8Slice(value)));
+    }
+
+    private ColumnStatistics columnStatistics(double distinctValuesCount)
+    {
+        return createColumnStatistics(Optional.of(distinctValuesCount), empty(), empty());
+    }
+
+    private ColumnStatistics columnStatistics(double distinctValuesCount, String min, String max)
+    {
+        return createColumnStatistics(Optional.of(distinctValuesCount), Optional.of(utf8Slice(min)), Optional.of(utf8Slice(max)));
+    }
+
+    private ColumnStatistics columnStatistics(double distinctValuesCount, double min, double max)
+    {
+        return createColumnStatistics(Optional.of(distinctValuesCount), Optional.of(min), Optional.of(max));
+    }
+
+    private ColumnStatistics rangeStatistics(String min, String max)
+    {
+        return createColumnStatistics(empty(), Optional.of(utf8Slice(min)), Optional.of(utf8Slice(max)));
+    }
+
+    private ColumnStatistics rangeStatistics(double min, double max)
+    {
+        return createColumnStatistics(empty(), Optional.of(min), Optional.of(max));
+    }
+
+    private ColumnStatistics unknownStatistics()
+    {
+        return createColumnStatistics(empty(), empty(), empty());
+    }
+
+    private ColumnStatistics createColumnStatistics(Optional<Double> distinctValuesCount, Optional<Object> min, Optional<Object> max)
+    {
+        return ColumnStatistics.builder()
+                .addRange(rb -> rb
+                        .setDistinctValuesCount(distinctValuesCount.map(Estimate::new).orElse(unknownValue()))
+                        .setLowValue(min)
+                        .setHighValue(max)
+                        .setFraction(new Estimate(1.0)))
+                .setNullsFraction(zeroValue())
+                .build();
     }
 }

--- a/presto-tpch/src/test/java/com/facebook/presto/tpch/statistics/RecordTpchTableStatsTool.java
+++ b/presto-tpch/src/test/java/com/facebook/presto/tpch/statistics/RecordTpchTableStatsTool.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tpch.statistics;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.google.common.collect.ImmutableList;
+import io.airlift.tpch.TpchColumn;
+import io.airlift.tpch.TpchEntity;
+import io.airlift.tpch.TpchTable;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import static com.facebook.presto.tpch.TpchMetadata.schemaNameToScaleFactor;
+import static io.airlift.tpch.OrderColumn.ORDER_STATUS;
+import static io.airlift.tpch.TpchTable.ORDERS;
+import static java.lang.String.format;
+import static java.util.Optional.empty;
+
+/**
+ * This is a tool used to record statistics for TPCH tables.
+ * <p>
+ * The results are output to {@code presto-tpch/src/main/resources/tpch/statistics/${schemaName}} directory.
+ * <p>
+ * The tool is run by invoking its {@code main} method.
+ */
+public class RecordTpchTableStatsTool
+{
+    private final TableStatisticsRecorder tableStatisticsRecorder;
+    private final TableStatisticsDataRepository tableStatisticsDataRepository;
+
+    public RecordTpchTableStatsTool(TableStatisticsRecorder tableStatisticsRecorder, TableStatisticsDataRepository tableStatisticsDataRepository)
+    {
+        this.tableStatisticsRecorder = tableStatisticsRecorder;
+        this.tableStatisticsDataRepository = tableStatisticsDataRepository;
+    }
+
+    public static void main(String[] args)
+            throws IOException
+    {
+        RecordTpchTableStatsTool tool = new RecordTpchTableStatsTool(new TableStatisticsRecorder(), new TableStatisticsDataRepository(createObjectMapper()));
+
+        ImmutableList.of("tiny", "sf1").forEach(schemaName -> {
+            TpchTable.getTables()
+                    .forEach(table -> tool.computeAndOutputStatsFor(schemaName, table));
+
+            Stream.of("F", "O", "P").forEach(partitionValue -> {
+                tool.computeAndOutputStatsFor(schemaName, ORDERS, ORDER_STATUS, partitionValue);
+            });
+        });
+    }
+
+    private static ObjectMapper createObjectMapper()
+    {
+        return new ObjectMapper()
+                .registerModule(new Jdk8Module());
+    }
+
+    private <E extends TpchEntity> void computeAndOutputStatsFor(String schemaName, TpchTable<E> table)
+    {
+        computeAndOutputStatsFor(schemaName, table, row -> true, empty(), empty());
+    }
+
+    private <E extends TpchEntity> void computeAndOutputStatsFor(String schemaName, TpchTable<E> table, TpchColumn<E> partitionColumn, String partitionValue)
+    {
+        Predicate<E> predicate = row -> partitionColumn.getString(row).equals(partitionValue);
+        computeAndOutputStatsFor(schemaName, table, predicate, Optional.of(partitionColumn), Optional.of(partitionValue));
+    }
+
+    private <E extends TpchEntity> void computeAndOutputStatsFor(String schemaName, TpchTable<E> table, Predicate<E> predicate, Optional<TpchColumn<?>> partitionColumn, Optional<String> partitionValue)
+    {
+        double scaleFactor = schemaNameToScaleFactor(schemaName);
+
+        long start = System.nanoTime();
+
+        TableStatisticsData statisticsData = tableStatisticsRecorder.recordStatistics(table, predicate, scaleFactor);
+
+        long duration = (System.nanoTime() - start) / 1_000_000;
+        System.out.println(format("Finished stats recording for %s[%s] sf %s, took %s ms", table.getTableName(), partitionValue.orElse(""), scaleFactor, duration));
+
+        tableStatisticsDataRepository.save(schemaName, table, partitionColumn, partitionValue, statisticsData);
+    }
+}


### PR DESCRIPTION
Supersedes #559 

Rebased on  epic/statistics-7.  Tests are failing because of failures on the epic/statistics-7 branch.  There's also one test in TestJoinEnumerator failing  due to a bug in the stats calculator that throws an NPE when there are no stats.  I'll rebase when that branch is fixed and make sure that there are no join enumeration related failures.  

I squashed in all the fixups.  I also squashed the cross join stuff into the main join enumeration commit because it changed the code enough that maintaining that separately while making other requested changes became intractable.  If you want me to split it out again I can do that, but I'd prefer to wait until all other changes are done.  