### PR TITLE
Fix filter equality check in PushDownTableConstraints

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -253,7 +253,7 @@ public class PlanOptimizers
                         stats,
                         statsCalculator,
                         estimatedExchangesCostCalculator,
-                        ImmutableSet.of(new PushDownTableConstraints(metadata))),
+                        ImmutableSet.of(new PushDownTableConstraints(metadata, sqlParser))),
                 new PruneUnreferencedOutputs(),
                 new IterativeOptimizer(
                         stats,
@@ -305,7 +305,7 @@ public class PlanOptimizers
                         stats,
                         statsCalculator,
                         estimatedExchangesCostCalculator,
-                        ImmutableSet.of(new PushDownTableConstraints(metadata))),
+                        ImmutableSet.of(new PushDownTableConstraints(metadata, sqlParser))),
                 projectionPushDown);
 
         if (featuresConfig.isOptimizeSingleDistinct()) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushDownTableConstraints.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushDownTableConstraints.java
@@ -34,6 +34,7 @@ import com.facebook.presto.sql.tree.BooleanLiteral;
 import com.facebook.presto.sql.tree.Expression;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 
 import java.util.List;
@@ -42,6 +43,7 @@ import java.util.Optional;
 import java.util.function.Predicate;
 
 import static com.facebook.presto.sql.ExpressionUtils.combineConjuncts;
+import static com.facebook.presto.sql.ExpressionUtils.extractConjuncts;
 import static com.facebook.presto.sql.ExpressionUtils.stripDeterministicConjuncts;
 import static com.facebook.presto.sql.ExpressionUtils.stripNonDeterministicConjuncts;
 import static com.google.common.base.Preconditions.checkState;
@@ -143,7 +145,7 @@ public class PushDownTableConstraints
         }
 
         FilterNode rewrittenFilter = (FilterNode) rewrittenPlan;
-        if (!rewrittenFilter.getPredicate().equals(oldPlan.getPredicate())) {
+        if (!ImmutableSet.copyOf(extractConjuncts(rewrittenFilter.getPredicate())).equals(ImmutableSet.copyOf(extractConjuncts(oldPlan.getPredicate())))) {
             return true;
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushDownTableConstraints.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushDownTableConstraints.java
@@ -18,6 +18,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.connector.ConnectorId;
 import com.facebook.presto.metadata.TableHandle;
 import com.facebook.presto.spi.predicate.Domain;
+import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
 import com.facebook.presto.testing.LocalQueryRunner;
 import com.facebook.presto.tpch.TpchColumnHandle;
@@ -58,7 +59,7 @@ public class TestPushDownTableConstraints
                 .put("orderstatus", Domain.singleValue(createVarcharType(1), utf8Slice("P")))
                 .build();
 
-        new RuleTester(queryRunner).assertThat(new PushDownTableConstraints(queryRunner.getMetadata()))
+        new RuleTester(queryRunner).assertThat(new PushDownTableConstraints(queryRunner.getMetadata(), new SqlParser()))
                 .on(p ->
                         p.filter(expression("orderstatus = 'P'"),
                                 p.tableScan(

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestReorderJoins.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestReorderJoins.java
@@ -111,7 +111,7 @@ public class TestReorderJoins
                         anyTree(
                                 join(INNER, ImmutableList.of(equiJoinClause("P_PARTKEY", "L_PARTKEY")),
                                         anyTree(PART_TABLESCAN),
-                                        anyTree(filter("L_RETURNFLAG = 'R'", LINEITEM_WITH_RETURNFLAG_TABLESCAN)))),
+                                        anyTree(filter("'R' = L_RETURNFLAG", LINEITEM_WITH_RETURNFLAG_TABLESCAN)))),
                         anyTree(filter("O_SHIPPRIORITY >= 10", ORDERS_WITH_SHIPPRIORITY_TABLESCAN)))));
     }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -5846,6 +5846,9 @@ public abstract class AbstractTestQueries
         assertQuery(
                 "SELECT table_name FROM information_schema.tables WHERE table_name = 'orders' LIMIT 1",
                 "SELECT 'orders' table_name");
+        assertQuery(
+                "SELECT table_name FROM information_schema.columns WHERE table_schema = 'tiny' AND table_name = 'customer' and column_name = 'custkey'",
+                "SELECT 'customer' table_name");
     }
 
     @Test


### PR DESCRIPTION
Ignore predicate order when checking whether filters are equal. This
prevents an infinite loop of filter reordering.