### PR TITLE
fixup! Add spill for join

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
@@ -215,7 +215,7 @@ public class TestHashJoinOperator
             for (int i = 0; i < buildOperatorCount; i++) {
                 if (whenSpill.get(i) == WhenSpill.DURING_USAGE) {
                     checkState(input.hasNext(), "spill requested DURING_USAGE, but input is kind of exhausted");
-                    revokeMemory(buildSideSetup.buildOperators.get(i));
+                    scheduleRevokeMemory(buildSideSetup.buildOperators.get(i));
                 }
             }
 
@@ -276,6 +276,11 @@ public class TestHashJoinOperator
     {
         getFutureValue(operator.startMemoryRevoke());
         operator.finishMemoryRevoke();
+    }
+
+    private static void scheduleRevokeMemory(Operator operator)
+    {
+        operator.getOperatorContext().requestMemoryRevoking();
     }
 
     private static <T> List<T> concat(List<T> initialElements, List<T> moreElements)


### PR DESCRIPTION
Fix test.
`revokeMemory` memory could not be used as it interfered witch `process` being called in the background by executor threads.
