### PR TITLE
Consider current node count when estimating costs

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/CostCalculatorUsingExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/CostCalculatorUsingExchanges.java
@@ -37,6 +37,7 @@ import javax.annotation.concurrent.ThreadSafe;
 import javax.inject.Inject;
 
 import java.util.Map;
+import java.util.function.IntSupplier;
 
 import static com.facebook.presto.cost.PlanNodeCostEstimate.UNKNOWN_COST;
 import static com.facebook.presto.cost.PlanNodeCostEstimate.ZERO_COST;
@@ -51,17 +52,17 @@ import static java.util.Objects.requireNonNull;
 public class CostCalculatorUsingExchanges
         implements CostCalculator
 {
-    private final int numberOfNodes;
+    private final IntSupplier numberOfNodes;
 
     @Inject
     public CostCalculatorUsingExchanges(InternalNodeManager nodeManager)
     {
-        this(nodeManager.getAllNodes().getActiveNodes().size());
+        this(() -> nodeManager.getAllNodes().getActiveNodes().size());
     }
 
-    public CostCalculatorUsingExchanges(int numberOfNodes)
+    public CostCalculatorUsingExchanges(IntSupplier numberOfNodes)
     {
-        this.numberOfNodes = numberOfNodes;
+        this.numberOfNodes = requireNonNull(numberOfNodes, "numberOfNodes is null");
     }
 
     @Override
@@ -71,7 +72,7 @@ public class CostCalculatorUsingExchanges
                 session,
                 types,
                 lookup,
-                numberOfNodes);
+                numberOfNodes.getAsInt());
 
         return planNode.accept(costEstimator, null);
     }

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -409,7 +409,7 @@ public class LocalQueryRunner
                 new CoefficientBasedStatsCalculator(metadata),
                 ServerMainModule.createNewStatsCalculator(metadata, new FilterStatsCalculator(metadata), new ScalarStatsCalculator(metadata)));
         this.costCalculator = new CostCalculatorUsingExchanges(getNodeCount());
-        this.estimatedExchangesCostCalculator = new CostCalculatorWithEstimatedExchanges(costCalculator, nodeCountForStats);
+        this.estimatedExchangesCostCalculator = new CostCalculatorWithEstimatedExchanges(costCalculator, () -> nodeCountForStats);
         this.lookup = new StatelessLookup(statsCalculator, costCalculator);
         this.singleStreamSpillerFactory = new FileSingleStreamSpillerFactory(blockEncodingSerde, spillerStats, featuresConfig);
         this.partitioningSpillerFactory = new GenericPartitioningSpillerFactory(this.singleStreamSpillerFactory);

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
@@ -63,7 +63,7 @@ public class TestCostCalculator
 {
     private static final int NUMBER_OF_NODES = 10;
     private final CostCalculator costCalculatorUsingExchanges = new CostCalculatorUsingExchanges(NUMBER_OF_NODES);
-    private final CostCalculator costCalculatorWithEstimatedExchanges = new CostCalculatorWithEstimatedExchanges(costCalculatorUsingExchanges, NUMBER_OF_NODES);
+    private final CostCalculator costCalculatorWithEstimatedExchanges = new CostCalculatorWithEstimatedExchanges(costCalculatorUsingExchanges, () -> NUMBER_OF_NODES);
     private Session session = testSessionBuilder().build();
 
     @Test

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -314,7 +314,7 @@ public abstract class AbstractTestQueryFramework
                         new CoefficientBasedStatsCalculator(metadata),
                         ServerMainModule.createNewStatsCalculator(metadata, new FilterStatsCalculator(metadata), new ScalarStatsCalculator(metadata))),
                 costCalculator,
-                new CostCalculatorWithEstimatedExchanges(costCalculator, queryRunner.getNodeCount())).get();
+                new CostCalculatorWithEstimatedExchanges(costCalculator, queryRunner::getNodeCount)).get();
         return new QueryExplainer(
                 optimizers,
                 metadata,


### PR DESCRIPTION
Consider current node count when estimating costs. Otherwise we're likely to assume there is exactly 1 node always (the coordinator), as worker nodes are likely to connect after `CostCalculatorWithEstimatedExchanges` is instantiated.