### PR TITLE
Fix bug with StatisticRanges for non-numeric values

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/FilterStatsCalculator.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/FilterStatsCalculator.java
@@ -35,6 +35,7 @@ import com.facebook.presto.sql.tree.SymbolReference;
 import javax.inject.Inject;
 
 import java.util.Map;
+import java.util.OptionalDouble;
 
 import static com.facebook.presto.cost.ComparisonStatsCalculator.comparisonSymbolToLiteralStats;
 import static com.facebook.presto.cost.ComparisonStatsCalculator.comparisonSymbolToSymbolStats;
@@ -261,11 +262,11 @@ public class FilterStatsCalculator
             }
         }
 
-        private double doubleValueFromLiteral(Type type, Literal literal)
+        private OptionalDouble doubleValueFromLiteral(Type type, Literal literal)
         {
             Object literalValue = LiteralInterpreter.evaluate(metadata, session.toConnectorSession(), literal);
             DomainConverter domainConverter = new DomainConverter(type, metadata.getFunctionRegistry(), session.toConnectorSession());
-            return domainConverter.translateToDouble(literalValue).orElse(NaN);
+            return domainConverter.translateToDouble(literalValue);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/cost/StatisticRange.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/StatisticRange.java
@@ -115,8 +115,10 @@ public class StatisticRange
         double overlapPercentOfRight = other.overlapPercentWith(this);
         double overlapDistinctValuesLeft = overlapPercentOfLeft * distinctValues;
         double overlapDistinctValuesRight = overlapPercentOfRight * other.distinctValues;
+        double minInputDistinctValues = minExcludeNaN(this.distinctValues, other.distinctValues);
 
-        return maxExcludeNaN(overlapDistinctValuesLeft, overlapDistinctValuesRight);
+        return minExcludeNaN(minInputDistinctValues,
+                maxExcludeNaN(overlapDistinctValuesLeft, overlapDistinctValuesRight));
     }
 
     public StatisticRange intersect(StatisticRange other)

--- a/presto-main/src/main/java/com/facebook/presto/cost/StatisticRange.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/StatisticRange.java
@@ -88,6 +88,9 @@ public class StatisticRange
 
         double lengthOfIntersect = min(high, other.high) - max(low, other.low);
         if (isInfinite(lengthOfIntersect)) {
+            if (isFinite(this.distinctValues) && isFinite(other.distinctValues)) {
+                return min(this.distinctValues, other.distinctValues) / max(this.distinctValues, other.distinctValues);
+            }
             return INFINITE_TO_INFINITE_RANGE_INTERSECT_OVERLAP_HEURISTIC_FACTOR;
         }
         if (lengthOfIntersect == 0) {

--- a/presto-main/src/main/java/com/facebook/presto/cost/StatisticRange.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/StatisticRange.java
@@ -16,7 +16,9 @@ package com.facebook.presto.cost;
 import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkState;
+import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.NaN;
+import static java.lang.Double.POSITIVE_INFINITY;
 import static java.lang.Double.isFinite;
 import static java.lang.Double.isInfinite;
 import static java.lang.Double.isNaN;
@@ -36,8 +38,8 @@ public class StatisticRange
     {
         checkState(low <= high || (isNaN(low) && isNaN(high)), "Low must be smaller or equal to high or range must be empty (NaN, NaN)");
         checkState(distinctValues >= 0 || isNaN(distinctValues), "Distinct values count cannot be negative");
-        this.low = low;
-        this.high = high;
+        this.low = isNaN(low) ? NEGATIVE_INFINITY : low;
+        this.high = isNaN(high) ? POSITIVE_INFINITY : high;
         this.distinctValues = distinctValues;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/cost/StatisticRange.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/StatisticRange.java
@@ -16,9 +16,7 @@ package com.facebook.presto.cost;
 import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkState;
-import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.NaN;
-import static java.lang.Double.POSITIVE_INFINITY;
 import static java.lang.Double.isFinite;
 import static java.lang.Double.isInfinite;
 import static java.lang.Double.isNaN;
@@ -38,8 +36,8 @@ public class StatisticRange
     {
         checkState(low <= high || (isNaN(low) && isNaN(high)), "Low must be smaller or equal to high or range must be empty (NaN, NaN)");
         checkState(distinctValues >= 0 || isNaN(distinctValues), "Distinct values count cannot be negative");
-        this.low = isNaN(low) ? NEGATIVE_INFINITY : low;
-        this.high = isNaN(high) ? POSITIVE_INFINITY : high;
+        this.low = low;
+        this.high = high;
         this.distinctValues = distinctValues;
     }
 


### PR DESCRIPTION
The high and low values of non-numeric ranges were sometimes represented
by NaN.  This meant that when checking the intersection with another
range, the results always came up empty.

A simple query to illustrate the issue is:

``EXPLAIN SELECT * FROM lineitem WHERE returnflag = 'R'``

In this example the high and low values for returnflag in the tablescan stats are represented as positive and negative infinity.  However, for the literal 'R', the high and low values are represented by NaN (see `FilterStatsCalculator.visitComparisonExpression` and then `ComparisonStatsCalculator.comparisonSymbolToLiteralStats()`).  As a result, when we do an intersect of the two ranges, we get an empty range since NaN isn't greater or less than anything.  It thinks the table has 0 rows and 0 bytes.  This leads to bad plans in more complex queries.

This fix was used to verify that resolving the issue fixes the query exceeds max memory error for tpc-h q10.  It looks like NaN is returned explicitly in a number of places in StatisticsRange, so a more robust solution may be needed to make things clearer/more consistent.  I didn't want to get into this more deeply without confirming what the right approach is.  I opened a PR to illustrate the issue, but feel free to modify it or scrap it and fix it differently. 

@fiedukow @losipiuk 
