### PR TITLE
Get the correct distribution type for ROJ and LOJ

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/DetermineJoinDistributionType.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/DetermineJoinDistributionType.java
@@ -36,6 +36,7 @@ import static com.facebook.presto.sql.planner.optimizations.ScalarQueryUtil.isSc
 import static com.facebook.presto.sql.planner.plan.JoinNode.DistributionType.PARTITIONED;
 import static com.facebook.presto.sql.planner.plan.JoinNode.DistributionType.REPLICATED;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.FULL;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.LEFT;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.RIGHT;
 
 public class DetermineJoinDistributionType
@@ -92,12 +93,18 @@ public class DetermineJoinDistributionType
                             lookup, symbolAllocator, session));
         }
 
-        if (type != RIGHT && type != FULL && joinDistributionType.canReplicate()) {
-            JoinNode possibleJoinNode  = joinNode.withDistributionType(REPLICATED);
-            possibleJoinNodes.add(getJoinNodeWithCost(possibleJoinNode, lookup, symbolAllocator, session));
-            possibleJoinNodes.add(
-                    getJoinNodeWithCost(possibleJoinNode.flipChildren().withDistributionType(REPLICATED),
-                            lookup, symbolAllocator, session));
+        if (type != FULL && joinDistributionType.canReplicate()) {
+            // RIGHT OUTER JOIN only works with hash partitioned data.
+            if (type != RIGHT) {
+                possibleJoinNodes.add(getJoinNodeWithCost(joinNode.withDistributionType(REPLICATED),
+                        lookup, symbolAllocator, session));
+            }
+
+            // Don't flip LEFT OUTER JOIN, as RIGHT OUTER JOIN only works with hash partitioned data.
+            if (type != LEFT) {
+                possibleJoinNodes.add(getJoinNodeWithCost(joinNode.flipChildren().withDistributionType(REPLICATED),
+                        lookup, symbolAllocator, session));
+            }
         }
 
         if (possibleJoinNodes.stream().anyMatch(result -> result.getCost().isUnknown()) || possibleJoinNodes.isEmpty()) {


### PR DESCRIPTION
Due to some restriction with the LookupJoinOperator we cannot
use replicated join for Right Outer Joins. Make sure that the
join nodes are flipped only when the replicated join can be used.