### PR TITLE
Extend fast inequality join

### DIFF
--- a/presto-benchmark/src/test/java/com/facebook/presto/benchmark/BenchmarkInequalityJoin.java
+++ b/presto-benchmark/src/test/java/com/facebook/presto/benchmark/BenchmarkInequalityJoin.java
@@ -107,6 +107,20 @@ public class BenchmarkInequalityJoin
                 .execute("SELECT count(*) FROM t1 JOIN t2 on (t1.bucket = t2.bucket) WHERE t1.val1 < t2.val2");
     }
 
+    @Benchmark
+    public List<Page> benchmarkJoinWithArithmeticInPredicate(Context context)
+    {
+        return context.getQueryRunner()
+                .execute("SELECT count(*) FROM t1 JOIN t2 on (t1.bucket = t2.bucket) AND t1.val1 < t2.val2 + 10");
+    }
+
+    @Benchmark
+    public List<Page> benchmarkJoinWithFunctionPredicate(Context context)
+    {
+        return context.getQueryRunner()
+                .execute("SELECT count(*) FROM t1 JOIN t2 on (t1.bucket = t2.bucket) AND t1.val1 < sin(t2.val2)");
+    }
+
     public static void main(String[] args)
             throws RunnerException
     {

--- a/presto-benchmark/src/test/java/com/facebook/presto/benchmark/BenchmarkInequalityJoin.java
+++ b/presto-benchmark/src/test/java/com/facebook/presto/benchmark/BenchmarkInequalityJoin.java
@@ -121,6 +121,13 @@ public class BenchmarkInequalityJoin
                 .execute("SELECT count(*) FROM t1 JOIN t2 on (t1.bucket = t2.bucket) AND t1.val1 < sin(t2.val2)");
     }
 
+    @Benchmark
+    public List<Page> benchmarkRangePredicateJoin(Context context)
+    {
+        return context.getQueryRunner()
+                .execute("SELECT count(*) FROM t1 JOIN t2 on (t1.bucket = t2.bucket) AND t1.val1 + 1 < t2.val2 AND t2.val2 < t1.val1 + 5 ");
+    }
+
     public static void main(String[] args)
             throws RunnerException
     {

--- a/presto-main/src/main/java/com/facebook/presto/operator/JoinFilterFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/JoinFilterFunction.java
@@ -17,12 +17,8 @@ import com.facebook.presto.spi.Page;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
-import java.util.Optional;
-
 @NotThreadSafe
 public interface JoinFilterFunction
 {
     boolean filter(int leftAddress, int rightPosition, Page rightPage);
-
-    Optional<Integer> getSortChannel();
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/JoinHashSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/JoinHashSupplier.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator;
 import com.facebook.presto.Session;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.sql.gen.JoinFilterFunctionCompiler.JoinFilterFunctionFactory;
+import com.google.common.collect.ImmutableList;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 
 import java.util.List;
@@ -83,9 +84,13 @@ public class JoinHashSupplier
         // are not thread safe...
         Optional<JoinFilterFunction> filterFunction =
                 filterFunctionFactory.map(factory -> factory.create(session.toConnectorSession(), addresses, channels));
+        List<JoinFilterFunction> inequalityJoinFilterConjuncts = filterFunctionFactory
+                .map(factory -> factory.inequalityJoinFilterConjuncts(session.toConnectorSession(), addresses, channels))
+                .orElse(ImmutableList.of());
+
         return new JoinHash(
                 pagesHash,
                 filterFunction,
-                positionLinks.map(links -> links.create(filterFunction)));
+                positionLinks.map(links -> links.create(inequalityJoinFilterConjuncts)));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/PositionLinks.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PositionLinks.java
@@ -15,7 +15,7 @@ package com.facebook.presto.operator;
 
 import com.facebook.presto.spi.Page;
 
-import java.util.Optional;
+import java.util.List;
 
 /**
  * This class is responsible for iterating over build rows, which have
@@ -66,9 +66,9 @@ public interface PositionLinks
     interface Factory
     {
         /**
-         * JoinFilterFunction has to be created and supplied for each thread using PositionLinks
+         * JoinFilterFunctions has to be created and supplied for each thread using PositionLinks
          * since JoinFilterFunction is not thread safe...
          */
-        PositionLinks create(Optional<JoinFilterFunction> joinFilterFunction);
+        PositionLinks create(List<JoinFilterFunction> inequalityJoinFilterConjuncts);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/SortedPositionLinks.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SortedPositionLinks.java
@@ -44,12 +44,16 @@ import static java.util.Objects.requireNonNull;
  * <p>
  * To use lessThanFunction in this class, it must be an expression in form of:
  * <p>
- * {@code f(probeColumn1, probeColumn2, ..., probeColumnN) COMPARE g(buildColumn1, ..., buildColumnN)}
+ * {@code f(probeColumn1, probeColumn2, ..., probeColumnN) COMPARE buildSymbolRef1, ..., buildSymbolRefN}
  * <p>
  * where {@code COMPARE} is one of: {@code < <= > >=}
  * <p>
+ * and buildSymbolRef is a symbol reference on the buildColumn which has been pushed to
+ * the underlying Scan node. Eg: a column or expression which appears in the ON clause of a join
+ * and whose result appears in one of the join channel data blocks.
+ *
  * That allows us to define an order of the elements in positionLinks (this defining which
- * element is smaller) using {@code g(...)} function and to perform a binary search using
+ * element is smaller) using {@code buildSymbplRef} and to perform a binary search using
  * {@code f(probePosition)} value.
  */
 public final class SortedPositionLinks

--- a/presto-main/src/main/java/com/facebook/presto/operator/StandardJoinFilterFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/StandardJoinFilterFunction.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableList;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 
 import java.util.List;
-import java.util.Optional;
 
 import static com.facebook.presto.operator.SyntheticAddress.decodePosition;
 import static com.facebook.presto.operator.SyntheticAddress.decodeSliceIndex;
@@ -33,13 +32,11 @@ public class StandardJoinFilterFunction
     private final InternalJoinFilterFunction filterFunction;
     private final LongArrayList addresses;
     private final List<Block[]> pages;
-    private final Optional<Integer> sortChannel;
 
-    public StandardJoinFilterFunction(InternalJoinFilterFunction filterFunction, LongArrayList addresses, List<List<Block>> channels, Optional<Integer> sortChannel)
+    public StandardJoinFilterFunction(InternalJoinFilterFunction filterFunction, LongArrayList addresses, List<List<Block>> channels)
     {
         this.filterFunction = requireNonNull(filterFunction, "filterFunction can not be null");
         this.addresses = requireNonNull(addresses, "addresses is null");
-        this.sortChannel = requireNonNull(sortChannel, "sortChannel is null");
 
         requireNonNull(channels, "channels can not be null");
         ImmutableList.Builder<Block[]> pagesBuilder = ImmutableList.builder();
@@ -64,12 +61,6 @@ public class StandardJoinFilterFunction
         int blockPosition = decodePosition(pageAddress);
 
         return filterFunction.filter(blockPosition, getLeftBlocks(blockIndex), rightPosition, rightPage.getBlocks());
-    }
-
-    @Override
-    public Optional<Integer> getSortChannel()
-    {
-        return sortChannel;
     }
 
     private Block[] getLeftBlocks(int leftBlockIndex)

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinFilterFunctionCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinFilterFunctionCompiler.java
@@ -408,7 +408,7 @@ public class JoinFilterFunctionCompiler
                         new DynamicClassLoader(getClass().getClassLoader()),
                         JoinFilterFunction.class,
                         StandardJoinFilterFunction.class);
-                isolatedJoinFilterFunctionConstructor = isolatedJoinFilterFunction.getConstructor(InternalJoinFilterFunction.class, LongArrayList.class, List.class, Optional.class);
+                isolatedJoinFilterFunctionConstructor = isolatedJoinFilterFunction.getConstructor(InternalJoinFilterFunction.class, LongArrayList.class, List.class);
             }
             catch (NoSuchMethodException e) {
                 throw Throwables.propagate(e);
@@ -420,7 +420,7 @@ public class JoinFilterFunctionCompiler
         {
             try {
                 InternalJoinFilterFunction internalJoinFilterFunction = internalJoinFilterFunctionConstructor.newInstance(session);
-                return isolatedJoinFilterFunctionConstructor.newInstance(internalJoinFilterFunction, addresses, channels, sortChannel);
+                return isolatedJoinFilterFunctionConstructor.newInstance(internalJoinFilterFunction, addresses, channels);
             }
             catch (ReflectiveOperationException e) {
                 throw Throwables.propagate(e);

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinFilterFunctionCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinFilterFunctionCompiler.java
@@ -371,13 +371,14 @@ public class JoinFilterFunctionCompiler
             }
             JoinFilterCacheKey that = (JoinFilterCacheKey) o;
             return leftBlocksSize == that.leftBlocksSize &&
-                    Objects.equals(filter, that.filter);
+                    Objects.equals(filter, that.filter) &&
+                    Objects.equals(sortChannel, that.sortChannel);
         }
 
         @Override
         public int hashCode()
         {
-            return Objects.hash(filter, leftBlocksSize);
+            return Objects.hash(filter, leftBlocksSize, sortChannel);
         }
 
         @Override
@@ -386,6 +387,7 @@ public class JoinFilterFunctionCompiler
             return toStringHelper(this)
                     .add("filter", filter)
                     .add("leftBlocksSize", leftBlocksSize)
+                    .add("sortChannel", sortChannel)
                     .toString();
         }
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SortExpressionExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SortExpressionExtractor.java
@@ -34,6 +34,9 @@ import static java.util.Objects.requireNonNull;
  * <p>
  * A.a < B.x
  * <p>
+ * where a is the build side symbol reference mapping to any expression
+ * which has been pushed down to the corresponding Scan node.
+ * <p>
  * It could be extended to handle any expressions like:
  * <p>
  * A.a * sin(A.b) / log(B.x) < cos(B.z)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SortExpressionExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SortExpressionExtractor.java
@@ -86,6 +86,7 @@ public final class SortExpressionExtractor
 
     private static Optional<SymbolReference> asBuildSymbolReference(Set<Symbol> buildLayout, Expression expression)
     {
+        // this is required to make sure the expression is pushed down (sort channel has the expression result)
         if (expression instanceof SymbolReference) {
             SymbolReference symbolReference = (SymbolReference) expression;
             if (buildLayout.contains(new Symbol(symbolReference.getName()))) {

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
@@ -689,7 +689,7 @@ public class TestHashJoinOperator
     private static LookupSourceFactory buildHash(boolean parallelBuild, TaskContext taskContext, List<Integer> hashChannels, RowPagesBuilder buildPages, Optional<InternalJoinFilterFunction> filterFunction)
     {
         Optional<JoinFilterFunctionFactory> filterFunctionFactory = filterFunction
-                .map(function -> (session, addresses, channels) -> new StandardJoinFilterFunction(function, addresses, channels, Optional.empty()));
+                .map(function -> (session, addresses, channels) -> new StandardJoinFilterFunction(function, addresses, channels));
 
         int partitionCount = parallelBuild ? PARTITION_COUNT : 1;
         LocalExchange localExchange = new LocalExchange(FIXED_HASH_DISTRIBUTION, partitionCount, buildPages.getTypes(), hashChannels, buildPages.getHashChannel());

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestPositionLinks.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestPositionLinks.java
@@ -68,12 +68,6 @@ public class TestPositionLinks
             {
                 return BIGINT.getLong(rightPage.getBlock(0), leftAddress) > 4;
             }
-
-            @Override
-            public Optional<Integer> getSortChannel()
-            {
-                throw new UnsupportedOperationException();
-            }
         };
 
         PositionLinks.FactoryBuilder factoryBuilder = buildSortedPositionLinks();
@@ -98,12 +92,6 @@ public class TestPositionLinks
             public boolean filter(int leftAddress, int rightPosition, Page rightPage)
             {
                 return BIGINT.getLong(rightPage.getBlock(0), leftAddress) < 4;
-            }
-
-            @Override
-            public Optional<Integer> getSortChannel()
-            {
-                throw new UnsupportedOperationException();
             }
         };
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestPositionLinks.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestPositionLinks.java
@@ -43,7 +43,7 @@ public class TestPositionLinks
         assertEquals(factoryBuilder.link(11, 10), 11);
         assertEquals(factoryBuilder.link(12, 11), 12);
 
-        PositionLinks positionLinks = factoryBuilder.build().create(Optional.empty());
+        PositionLinks positionLinks = factoryBuilder.build().create(ImmutableList.of());
 
         assertEquals(positionLinks.start(3, 0, TEST_PAGE), 3);
         assertEquals(positionLinks.next(3, 0, TEST_PAGE), 2);
@@ -71,7 +71,7 @@ public class TestPositionLinks
         };
 
         PositionLinks.FactoryBuilder factoryBuilder = buildSortedPositionLinks();
-        PositionLinks positionLinks = factoryBuilder.build().create(Optional.of(filterFunction));
+        PositionLinks positionLinks = factoryBuilder.build().create(ImmutableList.of(filterFunction));
 
         assertEquals(positionLinks.start(0, 0, TEST_PAGE), 5);
         assertEquals(positionLinks.next(5, 0, TEST_PAGE), 6);
@@ -80,6 +80,27 @@ public class TestPositionLinks
         assertEquals(positionLinks.start(10, 0, TEST_PAGE), 10);
         assertEquals(positionLinks.next(10, 0, TEST_PAGE), 11);
         assertEquals(positionLinks.next(11, 0, TEST_PAGE), 12);
+        assertEquals(positionLinks.next(12, 0, TEST_PAGE), -1);
+    }
+
+    @Test
+    public void testSortedPositionLinksForRangePredicates()
+    {
+        JoinFilterFunction filterFunctionOne = (leftAddress, rightPosition, rightPage) -> BIGINT.getLong(rightPage.getBlock(0), leftAddress) > 4;
+
+        JoinFilterFunction filterFunctionTwo = (leftAddress, rightPosition, rightPage) -> BIGINT.getLong(rightPage.getBlock(0), leftAddress) <= 11;
+
+        PositionLinks.FactoryBuilder factoryBuilder = buildSortedPositionLinks();
+        PositionLinks positionLinks = factoryBuilder.build().create(ImmutableList.of(filterFunctionOne, filterFunctionTwo));
+
+        assertEquals(positionLinks.start(0, 0, TEST_PAGE), 5);
+        assertEquals(positionLinks.next(4, 0, TEST_PAGE), 5);
+        assertEquals(positionLinks.next(5, 0, TEST_PAGE), 6);
+        assertEquals(positionLinks.next(6, 0, TEST_PAGE), -1);
+
+        assertEquals(positionLinks.start(10, 0, TEST_PAGE), 10);
+        assertEquals(positionLinks.next(10, 0, TEST_PAGE), 11);
+        assertEquals(positionLinks.next(11, 0, TEST_PAGE), -1);
         assertEquals(positionLinks.next(12, 0, TEST_PAGE), -1);
     }
 
@@ -96,7 +117,7 @@ public class TestPositionLinks
         };
 
         PositionLinks.FactoryBuilder factoryBuilder = buildSortedPositionLinks();
-        PositionLinks positionLinks = factoryBuilder.build().create(Optional.of(filterFunction));
+        PositionLinks positionLinks = factoryBuilder.build().create(ImmutableList.of(filterFunction));
 
         assertEquals(positionLinks.start(0, 0, TEST_PAGE), 0);
         assertEquals(positionLinks.next(0, 0, TEST_PAGE), 1);
@@ -135,7 +156,7 @@ public class TestPositionLinks
                 ImmutableList.of(ImmutableList.of(TEST_PAGE.getBlock(0))),
                 ImmutableList.of(),
                 Optional.empty(),
-                Optional.of(new SortExpression(0)));
+                Optional.of(new SortExpression(0, ImmutableList.of())));
     }
 
     private static LongArrayList addresses()

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestSortExpressionExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestSortExpressionExtractor.java
@@ -14,14 +14,8 @@
 package com.facebook.presto.sql.planner;
 
 import com.facebook.presto.sql.parser.SqlParser;
-import com.facebook.presto.sql.tree.ArithmeticBinaryExpression;
-import com.facebook.presto.sql.tree.ComparisonExpression;
-import com.facebook.presto.sql.tree.ComparisonExpressionType;
 import com.facebook.presto.sql.tree.Expression;
-import com.facebook.presto.sql.tree.FunctionCall;
-import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.SymbolReference;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
 
@@ -38,45 +32,17 @@ public class TestSortExpressionExtractor
     @Test
     public void testGetSortExpression()
     {
-        assertGetSortExpression(
-                new ComparisonExpression(
-                        ComparisonExpressionType.GREATER_THAN,
-                        new SymbolReference("p1"),
-                        new SymbolReference("b1")),
-                "b1");
+        assertGetSortExpression(expression("p1 > b1"), "b1");
 
-        assertGetSortExpression(
-                new ComparisonExpression(
-                        ComparisonExpressionType.LESS_THAN_OR_EQUAL,
-                        new SymbolReference("b2"),
-                        new SymbolReference("p1")),
-                "b2");
+        assertGetSortExpression(expression("b2 <= p1"), "b2");
 
-        assertGetSortExpression(
-                new ComparisonExpression(
-                        ComparisonExpressionType.GREATER_THAN,
-                        new SymbolReference("b2"),
-                        new SymbolReference("p1")),
-                "b2");
+        assertGetSortExpression(expression("b2 > p1"), "b2");
 
-        assertGetSortExpression(
-                new ComparisonExpression(
-                        ComparisonExpressionType.GREATER_THAN,
-                        new SymbolReference("b2"),
-                        new FunctionCall(QualifiedName.of("sin"), ImmutableList.of(new SymbolReference("p1")))),
-                "b2");
+        assertGetSortExpression(expression("b2 > sin(p1)"), "b2");
 
-        assertGetSortExpression(
-                new ComparisonExpression(
-                        ComparisonExpressionType.GREATER_THAN,
-                        new SymbolReference("b2"),
-                        new FunctionCall(QualifiedName.of("random"), ImmutableList.of(new SymbolReference("p1")))));
+        assertGetSortExpression(expression("b2 > random(p1)"));
 
-        assertGetSortExpression(
-                new ComparisonExpression(
-                        ComparisonExpressionType.GREATER_THAN,
-                        new SymbolReference("b1"),
-                        new ArithmeticBinaryExpression(ArithmeticBinaryExpression.Type.ADD, new SymbolReference("b2"), new SymbolReference("p1"))));
+        assertGetSortExpression(expression("b1 > p1 + b2"));
 
         assertGetSortExpression(expression("sin(b1) > p1"));
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -2310,6 +2310,8 @@ public abstract class AbstractTestQueries
                 "VALUES -1");
         // test with only null value in build side
         assertQuery("SELECT b FROM nation n, (VALUES (0, NULL)) t(a, b) WHERE n.regionkey - 100 < t.b AND n.nationkey = t.a", "SELECT 1 WHERE FALSE");
+        // test with function predicate in ON clause
+        assertQuery("SELECT n.nationkey, r.regionkey FROM nation n JOIN region r ON n.regionkey = r.regionkey AND length(n.name) < length(substr(r.name, 5))");
     }
 
     @Test
@@ -2329,6 +2331,8 @@ public abstract class AbstractTestQueries
                 "VALUES -1");
         // test with only null value in build side
         assertQuery("SELECT b FROM nation n, (VALUES (0, NULL)) t(a, b) WHERE n.regionkey + 100 > t.b AND n.nationkey = t.a", "SELECT 1 WHERE FALSE");
+        /// test with function predicate in ON clause
+        assertQuery("SELECT n.nationkey, r.regionkey FROM nation n JOIN region r ON n.regionkey = r.regionkey AND length(n.name) > length(substr(r.name, 5))");
     }
 
     @Test
@@ -2337,6 +2341,9 @@ public abstract class AbstractTestQueries
     {
         assertQuery(
                 "SELECT o.orderkey, o.orderdate, l.shipdate FROM orders o JOIN lineitem l ON l.orderkey = o.orderkey AND l.shipdate < o.orderdate + INTERVAL '10' DAY",
+                "SELECT o.orderkey, o.orderdate, l.shipdate FROM orders o JOIN lineitem l ON l.orderkey = o.orderkey AND l.shipdate < DATEADD('DAY', 10, o.orderdate)");
+        assertQuery(
+                "SELECT o.orderkey, o.orderdate, l.shipdate FROM lineitem l JOIN orders o ON l.orderkey = o.orderkey AND l.shipdate < DATE_ADD('DAY', 10, o.orderdate)",
                 "SELECT o.orderkey, o.orderdate, l.shipdate FROM orders o JOIN lineitem l ON l.orderkey = o.orderkey AND l.shipdate < DATEADD('DAY', 10, o.orderdate)");
     }
 


### PR DESCRIPTION
Follow up PR to extend functionality added in  https://github.com/prestodb/presto/pull/7097. The tests result below. @losipiuk Please review.

PR branch

```
Benchmark                                                     (buckets)  (fastInequalityJoins)  (filterOutCoefficient)  Mode  Cnt     Score     Error  Units
BenchmarkInequalityJoin.benchmarkJoin                               100                   true                      10  avgt   30   234.191 ±  33.999  ms/op
BenchmarkInequalityJoin.benchmarkJoin                               100                  false                      10  avgt   30  2360.016 ± 189.837  ms/op
BenchmarkInequalityJoin.benchmarkJoin                              1000                   true                      10  avgt   30   187.426 ±  24.792  ms/op
BenchmarkInequalityJoin.benchmarkJoin                              1000                  false                      10  avgt   30   414.487 ±  27.297  ms/op
BenchmarkInequalityJoin.benchmarkJoin                             10000                   true                      10  avgt   30   198.977 ±  35.756  ms/op
BenchmarkInequalityJoin.benchmarkJoin                             10000                  false                      10  avgt   30   239.980 ±  18.026  ms/op
BenchmarkInequalityJoin.benchmarkJoin                             60000                   true                      10  avgt   30   173.009 ±   6.956  ms/op
BenchmarkInequalityJoin.benchmarkJoin                             60000                  false                      10  avgt   30   181.165 ±   8.649  ms/op
BenchmarkInequalityJoin.benchmarkJoinWithExpressionPredicate        100                   true                      10  avgt   30   280.396 ±  17.991  ms/op
BenchmarkInequalityJoin.benchmarkJoinWithExpressionPredicate        100                  false                      10  avgt   30  2376.180 ± 125.109  ms/op
BenchmarkInequalityJoin.benchmarkJoinWithExpressionPredicate       1000                   true                      10  avgt   30   210.539 ±  11.744  ms/op
BenchmarkInequalityJoin.benchmarkJoinWithExpressionPredicate       1000                  false                      10  avgt   30   471.721 ±  45.251  ms/op
BenchmarkInequalityJoin.benchmarkJoinWithExpressionPredicate      10000                   true                      10  avgt   30   203.669 ±   9.373  ms/op
BenchmarkInequalityJoin.benchmarkJoinWithExpressionPredicate      10000                  false                      10  avgt   30   259.281 ±  13.036  ms/op
BenchmarkInequalityJoin.benchmarkJoinWithExpressionPredicate      60000                   true                      10  avgt   30   203.048 ±  10.953  ms/op
BenchmarkInequalityJoin.benchmarkJoinWithExpressionPredicate      60000                  false                      10  avgt   30   199.349 ±   9.362  ms/op
BenchmarkInequalityJoin.benchmarkJoinWithFunctionPredicate          100                   true                      10  avgt   30   216.786 ±  12.600  ms/op
BenchmarkInequalityJoin.benchmarkJoinWithFunctionPredicate          100                  false                      10  avgt   30  2408.483 ±  97.140  ms/op
BenchmarkInequalityJoin.benchmarkJoinWithFunctionPredicate         1000                   true                      10  avgt   30   195.763 ±  13.215  ms/op
BenchmarkInequalityJoin.benchmarkJoinWithFunctionPredicate         1000                  false                      10  avgt   30   580.025 ± 120.265  ms/op
BenchmarkInequalityJoin.benchmarkJoinWithFunctionPredicate        10000                   true                      10  avgt   30   226.885 ±  24.685  ms/op
BenchmarkInequalityJoin.benchmarkJoinWithFunctionPredicate        10000                  false                      10  avgt   30   274.404 ±  18.313  ms/op
BenchmarkInequalityJoin.benchmarkJoinWithFunctionPredicate        60000                   true                      10  avgt   30   197.643 ±  11.469  ms/op
BenchmarkInequalityJoin.benchmarkJoinWithFunctionPredicate        60000                  false                      10  avgt   30   210.390 ±  15.268  ms/op
BenchmarkInequalityJoin.benchmarkRangePredicateJoin                 100                   true                      10  avgt   30   247.428 ±  11.549  ms/op
BenchmarkInequalityJoin.benchmarkRangePredicateJoin                 100                  false                      10  avgt   30  2487.442 ±  60.085  ms/op
BenchmarkInequalityJoin.benchmarkRangePredicateJoin                1000                   true                      10  avgt   30   240.810 ±  14.584  ms/op
BenchmarkInequalityJoin.benchmarkRangePredicateJoin                1000                  false                      10  avgt   30   527.124 ±  47.483  ms/op
BenchmarkInequalityJoin.benchmarkRangePredicateJoin               10000                   true                      10  avgt   30   226.683 ±  11.559  ms/op
BenchmarkInequalityJoin.benchmarkRangePredicateJoin               10000                  false                      10  avgt   30   270.130 ±  13.167  ms/op
BenchmarkInequalityJoin.benchmarkRangePredicateJoin               60000                   true                      10  avgt   30   226.237 ±   8.305  ms/op
BenchmarkInequalityJoin.benchmarkRangePredicateJoin               60000                  false                      10  avgt   30   218.149 ±   9.184  ms/op
```
sprint-59 branch
```
Benchmark                                                     (buckets)  (fastInequalityJoins)  (filterOutCoefficient)  Mode  Cnt     Score     Error  Units
BenchmarkInequalityJoin.benchmarkJoin                               100                   true                      10  avgt   30   222.267 ±  36.490  ms/op
BenchmarkInequalityJoin.benchmarkJoin                               100                  false                      10  avgt   30  2409.789 ± 193.371  ms/op
BenchmarkInequalityJoin.benchmarkJoin                              1000                   true                      10  avgt   30   192.559 ±  25.289  ms/op
BenchmarkInequalityJoin.benchmarkJoin                              1000                  false                      10  avgt   30   458.951 ±  56.590  ms/op
BenchmarkInequalityJoin.benchmarkJoin                             10000                   true                      10  avgt   30   186.968 ±  31.170  ms/op
BenchmarkInequalityJoin.benchmarkJoin                             10000                  false                      10  avgt   30   191.897 ±  13.314  ms/op
BenchmarkInequalityJoin.benchmarkJoin                             60000                   true                      10  avgt   30   153.550 ±  12.891  ms/op
BenchmarkInequalityJoin.benchmarkJoin                             60000                  false                      10  avgt   30   168.607 ±  10.826  ms/op
BenchmarkInequalityJoin.benchmarkJoinWithExpressionPredicate        100                   true                      10  avgt   30   279.125 ±  23.798  ms/op
BenchmarkInequalityJoin.benchmarkJoinWithExpressionPredicate        100                  false                      10  avgt   30  2375.963 ±  78.662  ms/op
BenchmarkInequalityJoin.benchmarkJoinWithExpressionPredicate       1000                   true                      10  avgt   30   208.635 ±  12.900  ms/op
BenchmarkInequalityJoin.benchmarkJoinWithExpressionPredicate       1000                  false                      10  avgt   30   479.930 ±  54.966  ms/op
BenchmarkInequalityJoin.benchmarkJoinWithExpressionPredicate      10000                   true                      10  avgt   30   191.762 ±  12.959  ms/op
BenchmarkInequalityJoin.benchmarkJoinWithExpressionPredicate      10000                  false                      10  avgt   30   240.564 ±  18.699  ms/op
BenchmarkInequalityJoin.benchmarkJoinWithExpressionPredicate      60000                   true                      10  avgt   30   182.319 ±  13.622  ms/op
BenchmarkInequalityJoin.benchmarkJoinWithExpressionPredicate      60000                  false                      10  avgt   30   190.407 ±   8.862  ms/op
BenchmarkInequalityJoin.benchmarkJoinWithFunctionPredicate          100                   true                      10  avgt   30   193.858 ±  12.845  ms/op
BenchmarkInequalityJoin.benchmarkJoinWithFunctionPredicate          100                  false                      10  avgt   30  2288.445 ±  55.931  ms/op
BenchmarkInequalityJoin.benchmarkJoinWithFunctionPredicate         1000                   true                      10  avgt   30   206.152 ±  10.544  ms/op
BenchmarkInequalityJoin.benchmarkJoinWithFunctionPredicate         1000                  false                      10  avgt   30   479.045 ±  54.701  ms/op
BenchmarkInequalityJoin.benchmarkJoinWithFunctionPredicate        10000                   true                      10  avgt   30   207.194 ±  12.368  ms/op
BenchmarkInequalityJoin.benchmarkJoinWithFunctionPredicate        10000                  false                      10  avgt   30   252.875 ±  15.385  ms/op
BenchmarkInequalityJoin.benchmarkJoinWithFunctionPredicate        60000                   true                      10  avgt   30   178.251 ±   6.402  ms/op
BenchmarkInequalityJoin.benchmarkJoinWithFunctionPredicate        60000                  false                      10  avgt   30   201.308 ±  12.452  ms/op
BenchmarkInequalityJoin.benchmarkRangePredicateJoin                 100                   true                      10  avgt   30  2435.688 ± 143.372  ms/op
BenchmarkInequalityJoin.benchmarkRangePredicateJoin                 100                  false                      10  avgt   30  2433.708 ±  64.086  ms/op
BenchmarkInequalityJoin.benchmarkRangePredicateJoin                1000                   true                      10  avgt   30   488.757 ±  33.252  ms/op
BenchmarkInequalityJoin.benchmarkRangePredicateJoin                1000                  false                      10  avgt   30   507.685 ±  34.516  ms/op
BenchmarkInequalityJoin.benchmarkRangePredicateJoin               10000                   true                      10  avgt   30   263.682 ±  14.438  ms/op
BenchmarkInequalityJoin.benchmarkRangePredicateJoin               10000                  false                      10  avgt   30   261.671 ±  14.073  ms/op
BenchmarkInequalityJoin.benchmarkRangePredicateJoin               60000                   true                      10  avgt   30   216.391 ±  11.229  ms/op
BenchmarkInequalityJoin.benchmarkRangePredicateJoin               60000                  false                      10  avgt   30   217.869 ±  11.015  ms/op
```
The PR extends the functionality to speed up query with range predicates eg: `benchmarkRangePredicateJoin` . But I added benchmark tests for other queries which were already addressed by the optimization. So you can see the comparison below with and without this optimization.

```
								(buckets)  (fastInequalityJoins)     (sprint-59)	    (PR branch)
BenchmarkInequalityJoin.benchmarkJoin 				100		true		222.267 ±  36.490  ms/op   234.191 ±  33.999  ms/op
BenchmarkInequalityJoin.benchmarkJoin 				100		false	       2409.789 ± 193.371  ms/op  2360.016 ± 189.837  ms/op
BenchmarkInequalityJoin.benchmarkJoinWithExpressionPredicate	100		true		279.125 ±  23.798  ms/op   280.396 ±  17.991  ms/op
BenchmarkInequalityJoin.benchmarkJoinWithExpressionPredicate	100		false	       2375.963 ±  78.662  ms/op  2376.180 ± 125.109  ms/op
BenchmarkInequalityJoin.benchmarkJoinWithFunctionPredicate	100		true		193.858 ±  12.845  ms/op   216.786 ±  12.600  ms/op
BenchmarkInequalityJoin.benchmarkJoinWithFunctionPredicate	100		false	       2288.445 ±  55.931  ms/op  2408.483 ±  97.140  ms/op
BenchmarkInequalityJoin.benchmarkRangePredicateJoin		100		true	      2435.688 ± 143.372  ms/op	   247.428 ±  11.549  ms/op
BenchmarkInequalityJoin.benchmarkRangePredicateJoin		100		false	      2433.708 ±  64.086  ms/op   2487.442 ±  60.085  ms/op
```


