### PR TITLE
Add max memory check for costing

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -60,6 +60,7 @@ import com.facebook.presto.execution.scheduler.NodeScheduler;
 import com.facebook.presto.execution.scheduler.NodeSchedulerConfig;
 import com.facebook.presto.index.IndexManager;
 import com.facebook.presto.memory.MemoryManagerConfig;
+import com.facebook.presto.memory.NodeMemoryConfig;
 import com.facebook.presto.metadata.CatalogManager;
 import com.facebook.presto.metadata.HandleResolver;
 import com.facebook.presto.metadata.InMemoryNodeManager;
@@ -773,7 +774,7 @@ public class LocalQueryRunner
                 featuresConfig,
                 forceSingleNode,
                 new MBeanExporter(new TestingMBeanServer()),
-                new CostComparator(featuresConfig),
+                new CostComparator(featuresConfig, new NodeMemoryConfig()),
                 statsCalculator,
                 costCalculator,
                 estimatedExchangesCostCalculator).get();

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestDetermineJoinDistributionType.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestDetermineJoinDistributionType.java
@@ -18,6 +18,7 @@ import com.facebook.presto.cost.CostComparator;
 import com.facebook.presto.cost.PlanNodeStatsEstimate;
 import com.facebook.presto.cost.StatsCalculator;
 import com.facebook.presto.cost.SymbolStatsEstimate;
+import com.facebook.presto.memory.NodeMemoryConfig;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
 import com.facebook.presto.sql.planner.plan.JoinNode;
@@ -26,6 +27,7 @@ import com.facebook.presto.testing.LocalQueryRunner;
 import com.facebook.presto.testing.TestingStatsCalculator;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.airlift.units.DataSize;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -49,6 +51,7 @@ public class TestDetermineJoinDistributionType
 {
     private RuleTester tester;
     private StatsCalculator statsCalculator;
+    private NodeMemoryConfig nodeMemoryConfig;
 
     @BeforeClass
     public void setUp()
@@ -61,6 +64,7 @@ public class TestDetermineJoinDistributionType
         LocalQueryRunner queryRunner = queryRunnerWithFakeNodeCountForStats(session, 4);
         tester = new RuleTester(queryRunner);
         statsCalculator = queryRunner.getStatsCalculator();
+        nodeMemoryConfig = new NodeMemoryConfig().setMaxQueryMemoryPerNode(new DataSize(12, DataSize.Unit.GIGABYTE));
     }
 
     @Test
@@ -76,7 +80,7 @@ public class TestDetermineJoinDistributionType
                         .addSymbolStatistics(ImmutableMap.of(new Symbol("B1"), new SymbolStatsEstimate(0, 100, 0, 640000, 100)))
                         .build()));
 
-        tester.assertThat(new DetermineJoinDistributionType(new CostComparator(1, 1, 1)))
+        tester.assertThat(new DetermineJoinDistributionType(new CostComparator(1, 1, 1, nodeMemoryConfig)))
                 .withStatsCalculator(testingStatsCalculator)
                 .on(p ->
                         p.join(
@@ -109,7 +113,7 @@ public class TestDetermineJoinDistributionType
                         .addSymbolStatistics(ImmutableMap.of(new Symbol("B1"), new SymbolStatsEstimate(0, 100, 0, 640000, 100)))
                         .build()));
 
-        tester.assertThat(new DetermineJoinDistributionType(new CostComparator(1, 1, 1)))
+        tester.assertThat(new DetermineJoinDistributionType(new CostComparator(1, 1, 1, nodeMemoryConfig)))
                 .withStatsCalculator(testingStatsCalculator)
                 .on(p ->
                         p.join(
@@ -143,7 +147,7 @@ public class TestDetermineJoinDistributionType
                         .addSymbolStatistics(ImmutableMap.of(new Symbol("B1"), new SymbolStatsEstimate(0, 100, 0, 640000, 100)))
                         .build()));
 
-        tester.assertThat(new DetermineJoinDistributionType(new CostComparator(1, 1, 1)))
+        tester.assertThat(new DetermineJoinDistributionType(new CostComparator(1, 1, 1, nodeMemoryConfig)))
                 .withStatsCalculator(testingStatsCalculator)
                 .on(p ->
                         p.join(
@@ -176,7 +180,7 @@ public class TestDetermineJoinDistributionType
                         .addSymbolStatistics(ImmutableMap.of(new Symbol("B1"), new SymbolStatsEstimate(0, 100, 0, 640000, 100)))
                         .build()));
 
-        tester.assertThat(new DetermineJoinDistributionType(new CostComparator(1, 1, 1)))
+        tester.assertThat(new DetermineJoinDistributionType(new CostComparator(1, 1, 1, nodeMemoryConfig)))
                 .withStatsCalculator(testingStatsCalculator)
                 .on(p ->
                         p.join(
@@ -210,7 +214,7 @@ public class TestDetermineJoinDistributionType
                         .addSymbolStatistics(ImmutableMap.of(new Symbol("B1"), new SymbolStatsEstimate(0, 100, 0, 640000, 100)))
                         .build()));
 
-        tester.assertThat(new DetermineJoinDistributionType(new CostComparator(1, 1, 1)))
+        tester.assertThat(new DetermineJoinDistributionType(new CostComparator(1, 1, 1, nodeMemoryConfig)))
                 .withStatsCalculator(testingStatsCalculator)
                 .on(p ->
                         p.join(
@@ -243,7 +247,7 @@ public class TestDetermineJoinDistributionType
                         .addSymbolStatistics(ImmutableMap.of(new Symbol("B1"), new SymbolStatsEstimate(0, 100, 0, 640000, 100)))
                         .build()));
 
-        tester.assertThat(new DetermineJoinDistributionType(new CostComparator(1, 1, 1)))
+        tester.assertThat(new DetermineJoinDistributionType(new CostComparator(1, 1, 1, nodeMemoryConfig)))
                 .withStatsCalculator(testingStatsCalculator)
                 .on(p ->
                         p.join(
@@ -276,7 +280,7 @@ public class TestDetermineJoinDistributionType
                         .addSymbolStatistics(ImmutableMap.of(new Symbol("B1"), new SymbolStatsEstimate(0, 100, 0, 640000, 100)))
                         .build()));
 
-        tester.assertThat(new DetermineJoinDistributionType(new CostComparator(75, 10, 15)))
+        tester.assertThat(new DetermineJoinDistributionType(new CostComparator(75, 10, 15, nodeMemoryConfig)))
                 .withStatsCalculator(testingStatsCalculator)
                 .on(p ->
                         p.join(
@@ -305,11 +309,11 @@ public class TestDetermineJoinDistributionType
                         .addSymbolStatistics(ImmutableMap.of(new Symbol("A1"), new SymbolStatsEstimate(0, 100, 0, 640000, 100)))
                         .build(),
                 new PlanNodeId("valuesB"), PlanNodeStatsEstimate.builder()
-                        .setOutputRowCount(1000000)
+                        .setOutputRowCount(10000)
                         .addSymbolStatistics(ImmutableMap.of(new Symbol("B1"), new SymbolStatsEstimate(0, 100, 0, 640000, 100)))
                         .build()));
 
-        tester.assertThat(new DetermineJoinDistributionType(new CostComparator(75, 10, 15)))
+        tester.assertThat(new DetermineJoinDistributionType(new CostComparator(75, 10, 15, nodeMemoryConfig)))
                 .withStatsCalculator(testingStatsCalculator)
                 .on(p ->
                         p.join(

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestJoinEnumerator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestJoinEnumerator.java
@@ -15,6 +15,7 @@
 package com.facebook.presto.sql.planner.iterative.rule;
 
 import com.facebook.presto.cost.CostComparator;
+import com.facebook.presto.memory.NodeMemoryConfig;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolAllocator;
@@ -23,6 +24,7 @@ import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
 import com.facebook.presto.testing.LocalQueryRunner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import io.airlift.units.DataSize;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -94,7 +96,8 @@ public class TestJoinEnumerator
                 queryRunner.getDefaultSession(),
                 queryRunner.getLookup(),
                 multiJoinNode.getFilter(),
-                new CostComparator(1, 1, 1));
+                new CostComparator(1, 1, 1,
+                        new NodeMemoryConfig().setMaxQueryMemoryPerNode(new DataSize(4, DataSize.Unit.GIGABYTE))));
         JoinEnumerationResult actual = joinEnumerator.createJoinAccordingToPartitioning(multiJoinNode.getSources(), multiJoinNode.getOutputSymbols(), ImmutableSet.of(0));
         assertFalse(actual.getPlanNode().isPresent());
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestReorderJoins.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestReorderJoins.java
@@ -19,6 +19,7 @@ import com.facebook.presto.cost.CostComparator;
 import com.facebook.presto.cost.PlanNodeStatsEstimate;
 import com.facebook.presto.cost.StatsCalculator;
 import com.facebook.presto.cost.SymbolStatsEstimate;
+import com.facebook.presto.memory.NodeMemoryConfig;
 import com.facebook.presto.spi.TestingColumnHandle;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.planner.Symbol;
@@ -35,6 +36,7 @@ import com.facebook.presto.testing.LocalQueryRunner;
 import com.facebook.presto.testing.TestingStatsCalculator;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.airlift.units.DataSize;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -60,6 +62,7 @@ public class TestReorderJoins
     private RuleTester tester;
     private StatsCalculator statsCalculator;
     private CostCalculator costCalculator;
+    private NodeMemoryConfig nodeMemoryConfig;
 
     @BeforeClass
     public void setUp()
@@ -74,6 +77,7 @@ public class TestReorderJoins
         statsCalculator = queryRunner.getStatsCalculator();
         costCalculator = queryRunner.getEstimatedExchangesCostCalculator();
         tester = new RuleTester(queryRunner);
+        nodeMemoryConfig = new NodeMemoryConfig().setMaxQueryMemoryPerNode(new DataSize(8, DataSize.Unit.GIGABYTE));
     }
 
     @AfterClass(alwaysRun = true)
@@ -98,7 +102,7 @@ public class TestReorderJoins
                         .addSymbolStatistics(ImmutableMap.of(new Symbol("B1"), new SymbolStatsEstimate(0, 100, 0, 100, 100)))
                         .build()));
 
-        tester.assertThat(new ReorderJoins(new CostComparator(1, 1, 1), testingStatsCalculator, costCalculator))
+        tester.assertThat(new ReorderJoins(new CostComparator(1, 1, 1, nodeMemoryConfig), testingStatsCalculator, costCalculator))
                 .withStatsCalculator(testingStatsCalculator)
                 .on(p ->
                         p.join(
@@ -131,7 +135,7 @@ public class TestReorderJoins
                         .addSymbolStatistics(ImmutableMap.of(new Symbol("B1"), new SymbolStatsEstimate(0, 100, 0, 640000, 100)))
                         .build()));
 
-        tester.assertThat(new ReorderJoins(new CostComparator(1, 1, 1), testingStatsCalculator, costCalculator))
+        tester.assertThat(new ReorderJoins(new CostComparator(1, 1, 1, nodeMemoryConfig), testingStatsCalculator, costCalculator))
                 .withStatsCalculator(testingStatsCalculator)
                 .on(p ->
                         p.join(
@@ -164,7 +168,7 @@ public class TestReorderJoins
                         .addSymbolStatistics(ImmutableMap.of(new Symbol("B1"), new SymbolStatsEstimate(0, 100, 0, 640000, 100)))
                         .build()));
 
-        tester.assertThat(new ReorderJoins(new CostComparator(1, 1, 1), testingStatsCalculator, costCalculator))
+        tester.assertThat(new ReorderJoins(new CostComparator(1, 1, 1, nodeMemoryConfig), testingStatsCalculator, costCalculator))
                 .withStatsCalculator(testingStatsCalculator)
                 .on(p ->
                         p.join(
@@ -198,7 +202,7 @@ public class TestReorderJoins
                         .addSymbolStatistics(ImmutableMap.of(new Symbol("B1"), new SymbolStatsEstimate(0, 100, 0, 640000, 100)))
                         .build()));
 
-        tester.assertThat(new ReorderJoins(new CostComparator(1, 1, 1), testingStatsCalculator, costCalculator))
+        tester.assertThat(new ReorderJoins(new CostComparator(1, 1, 1, nodeMemoryConfig), testingStatsCalculator, costCalculator))
                 .withStatsCalculator(testingStatsCalculator)
                 .on(p ->
                         p.join(
@@ -231,7 +235,7 @@ public class TestReorderJoins
                         .addSymbolStatistics(ImmutableMap.of(new Symbol("B1"), new SymbolStatsEstimate(0, 100, 0, 640000, 100)))
                         .build()));
 
-        tester.assertThat(new ReorderJoins(new CostComparator(1, 1, 1), testingStatsCalculator, costCalculator))
+        tester.assertThat(new ReorderJoins(new CostComparator(1, 1, 1, nodeMemoryConfig), testingStatsCalculator, costCalculator))
                 .withStatsCalculator(testingStatsCalculator)
                 .on(p ->
                         p.join(
@@ -265,7 +269,7 @@ public class TestReorderJoins
                         .addSymbolStatistics(ImmutableMap.of(new Symbol("B1"), new SymbolStatsEstimate(0, 100, 0, 640000, 100)))
                         .build()));
 
-        tester.assertThat(new ReorderJoins(new CostComparator(1, 1, 1), testingStatsCalculator, costCalculator))
+        tester.assertThat(new ReorderJoins(new CostComparator(1, 1, 1, nodeMemoryConfig), testingStatsCalculator, costCalculator))
                 .withStatsCalculator(testingStatsCalculator)
                 .on(p ->
                         p.join(
@@ -282,7 +286,7 @@ public class TestReorderJoins
     public void testDoesNotFireWithNoStats()
     {
         StatsCalculator testingStatsCalculator = new UnknownStatsCalculator();
-        tester.assertThat(new ReorderJoins(new CostComparator(1, 1, 1), testingStatsCalculator, costCalculator))
+        tester.assertThat(new ReorderJoins(new CostComparator(1, 1, 1, nodeMemoryConfig), testingStatsCalculator, costCalculator))
                 .withStatsCalculator(testingStatsCalculator)
                 .on(p ->
                         p.join(
@@ -298,7 +302,7 @@ public class TestReorderJoins
     @Test
     public void testDoesNotFireForNonDeterministicFilter()
     {
-        tester.assertThat(new ReorderJoins(new CostComparator(1, 1, 1), statsCalculator, costCalculator))
+        tester.assertThat(new ReorderJoins(new CostComparator(1, 1, 1, nodeMemoryConfig), statsCalculator, costCalculator))
                 .on(p ->
                         p.join(
                                 INNER,
@@ -332,7 +336,7 @@ public class TestReorderJoins
                         .addSymbolStatistics(ImmutableMap.of(new Symbol("C1"), new SymbolStatsEstimate(0, 100, 0, 100, 100)))
                         .build()));
 
-        tester.assertThat(new ReorderJoins(new CostComparator(1, 1, 1), testingStatsCalculator, costCalculator))
+        tester.assertThat(new ReorderJoins(new CostComparator(1, 1, 1, nodeMemoryConfig), testingStatsCalculator, costCalculator))
                 .withStatsCalculator(testingStatsCalculator)
                 .on(p ->
                         p.join(

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -22,6 +22,7 @@ import com.facebook.presto.cost.CostComparator;
 import com.facebook.presto.cost.FilterStatsCalculator;
 import com.facebook.presto.cost.ScalarStatsCalculator;
 import com.facebook.presto.cost.SelectingStatsCalculator;
+import com.facebook.presto.memory.NodeMemoryConfig;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.server.ServerMainModule;
 import com.facebook.presto.spi.security.AccessDeniedException;
@@ -309,7 +310,7 @@ public abstract class AbstractTestQueryFramework
                 featuresConfig,
                 forceSingleNode,
                 new MBeanExporter(new TestingMBeanServer()),
-                new CostComparator(featuresConfig),
+                new CostComparator(featuresConfig, new NodeMemoryConfig()),
                 new SelectingStatsCalculator(
                         new CoefficientBasedStatsCalculator(metadata),
                         ServerMainModule.createNewStatsCalculator(metadata, new FilterStatsCalculator(metadata), new ScalarStatsCalculator(metadata))),


### PR DESCRIPTION
While comparing costs if either of the costs has memory
estimate higher than the max memory limit configured for
queries or total distributed memory usage allowed for queries
then discard that cost.

If both the estimates for memory are higher then choose the lower
cost option.