### PR TITLE
Cap aggregation row count at input row count

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/AggregationStatsRule.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/AggregationStatsRule.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 
 import static com.facebook.presto.util.MoreMath.isPositiveOrNan;
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
 
 public class AggregationStatsRule
@@ -76,7 +77,7 @@ public class AggregationStatsRule
             int nullRow = isPositiveOrNan(symbolStatistics.getNullsFraction()) ? 1 : 0;
             rowsCount *= symbolStatistics.getDistinctValuesCount() + nullRow;
         }
-        result.setOutputRowCount(rowsCount);
+        result.setOutputRowCount(min(rowsCount, input.getOutputRowCount()));
 
         for (Map.Entry<Symbol, Aggregation> aggregationEntry : aggregations.entrySet()) {
             result.addSymbolStatistics(aggregationEntry.getKey(), estimateAggregationStats(aggregationEntry.getValue(), input));

--- a/presto-main/src/main/java/com/facebook/presto/cost/PlanNodeStatsEstimateMath.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/PlanNodeStatsEstimateMath.java
@@ -148,7 +148,7 @@ public class PlanNodeStatsEstimateMath
                             .setNullsFraction(min(leftSymbolStats.getNullsFraction(), rightSymbolStats.getNullsFraction()))
                             .build());
         }
-
+        statsBuilder.setOutputRowCount(left.getOutputRowCount() + right.getOutputRowCount());  // this is the maximum row count;
         PlanNodeStatsEstimate intermediateResult = statsBuilder.build();
         return groupBy(intermediateResult, intermediateResult.getSymbolsWithKnownStatistics(), emptyMap());
     }


### PR DESCRIPTION
The row count for aggregations is estimated as the product of the ndvs of each
grouping column. However, the number of output rows can't be greater
than the number of input rows.  When the product of the number of ndvs
is greater than the the input row count, estimate the output row count
as equal to the input row count.