### PR TITLE
Fix PlanPrinter formatting

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -496,6 +496,15 @@ public class PlanPrinter
         return "?";
     }
 
+    private static String formatAsLong(double value)
+    {
+        if (isFinite(value)) {
+            return format(Locale.US, "%d", Math.round(value));
+        }
+
+        return "?";
+    }
+
     private static String formatPositions(long positions)
     {
         if (positions == 1) {
@@ -1324,18 +1333,13 @@ public class PlanPrinter
         {
             PlanNodeStatsEstimate stats = lookup.getStats(node, session, types);
             PlanNodeCostEstimate cost = lookup.getCumulativeCost(node, session, types);
-            return String.format("{rows: %s, bytes: %s, cpu: %s, memory: %s, network: %s}",
-                    formatEstimate(stats.getOutputRowCount()),
+            return String.format("{rows: %s (%s), cpu: %s, memory: %s, network: %s}",
+                    formatAsLong(stats.getOutputRowCount()),
                     formatEstimateAsDataSize(stats.getOutputSizeInBytes()),
-                    formatEstimate(cost.getCpuCost()),
-                    formatEstimateAsDataSize(cost.getMemoryCost()),
-                    formatEstimate(cost.getNetworkCost()));
+                    formatDouble(cost.getCpuCost()),
+                    formatDouble(cost.getMemoryCost()),
+                    formatDouble(cost.getNetworkCost()));
         }
-    }
-
-    private static String formatEstimate(double value)
-    {
-        return isNaN(value) ? "?" : String.valueOf(value);
     }
 
     private static String formatEstimateAsDataSize(double value)


### PR DESCRIPTION
Ensure consistent printing for rows as long in various components.
Do not print memory component of cost in bytes.