### PR TITLE
Don't sum distinct values counts in UnionStatsRule

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/ExchangeStatsRule.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/ExchangeStatsRule.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.facebook.presto.cost.PlanNodeStatsEstimateMath.addStats;
+import static com.facebook.presto.cost.PlanNodeStatsEstimateMath.addStatsAndSumDistinctValues;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 
@@ -55,7 +55,7 @@ public class ExchangeStatsRule
             PlanNodeStatsEstimate sourceStatsWithMappedSymbols = mapToOutputSymbols(sourceStats, exchangeNode.getInputs().get(i), exchangeNode.getOutputSymbols());
 
             if (estimate.isPresent()) {
-                estimate = Optional.of(addStats(estimate.get(), sourceStatsWithMappedSymbols));
+                estimate = Optional.of(addStatsAndSumDistinctValues(estimate.get(), sourceStatsWithMappedSymbols));
             }
             else {
                 estimate = Optional.of(sourceStatsWithMappedSymbols);
@@ -73,7 +73,7 @@ public class ExchangeStatsRule
                 .setOutputRowCount(estimate.getOutputRowCount());
 
         for (int i = 0; i < inputs.size(); i++) {
-                mapped.addSymbolStatistics(outputs.get(i), estimate.getSymbolStatistics(inputs.get(i)));
+            mapped.addSymbolStatistics(outputs.get(i), estimate.getSymbolStatistics(inputs.get(i)));
         }
 
         return mapped.build();

--- a/presto-main/src/main/java/com/facebook/presto/cost/FilterStatsCalculator.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/FilterStatsCalculator.java
@@ -44,7 +44,7 @@ import java.util.OptionalDouble;
 
 import static com.facebook.presto.cost.ComparisonStatsCalculator.comparisonExpressionToExpressionStats;
 import static com.facebook.presto.cost.ComparisonStatsCalculator.comparisonExpressionToLiteralStats;
-import static com.facebook.presto.cost.PlanNodeStatsEstimateMath.addStats;
+import static com.facebook.presto.cost.PlanNodeStatsEstimateMath.addStatsAndSumDistinctValues;
 import static com.facebook.presto.cost.PlanNodeStatsEstimateMath.differenceInNonRangeStats;
 import static com.facebook.presto.cost.PlanNodeStatsEstimateMath.differenceInStats;
 import static com.facebook.presto.cost.SymbolStatsEstimate.UNKNOWN_STATS;
@@ -167,7 +167,7 @@ public class FilterStatsCalculator
                         return visitExpression(node, context);
                     }
                     checkState(andStats.isPresent(), "Expected andStats to be present");
-                    PlanNodeStatsEstimate sumStats = addStats(leftStats.get(), rightStats.get());
+                    PlanNodeStatsEstimate sumStats = addStatsAndSumDistinctValues(leftStats.get(), rightStats.get());
                     return Optional.of(differenceInNonRangeStats(sumStats, andStats.get()));
                 default:
                     throw new IllegalStateException(format("Unimplemented logical binary operator expression %s", node.getType()));
@@ -256,7 +256,7 @@ public class FilterStatsCalculator
 
             PlanNodeStatsEstimate statsSum = valuesEqualityStats.stream()
                     .map(Optional::get)
-                    .reduce(filterForFalseExpression().get(), PlanNodeStatsEstimateMath::addStats);
+                    .reduce(filterForFalseExpression().get(), PlanNodeStatsEstimateMath::addStatsAndSumDistinctValues);
 
             if (isNaN(statsSum.getOutputRowCount())) {
                 return visitExpression(node, context);

--- a/presto-main/src/main/java/com/facebook/presto/cost/PlanNodeStatsEstimateMath.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/PlanNodeStatsEstimateMath.java
@@ -29,7 +29,8 @@ public class PlanNodeStatsEstimateMath
     {
     }
 
-    private interface SubtractRangeStrategy
+    @FunctionalInterface
+    private interface RangeSubtractionStrategy
     {
         StatisticRange range(StatisticRange leftRange, StatisticRange rightRange);
     }
@@ -44,7 +45,7 @@ public class PlanNodeStatsEstimateMath
         return differenceInStatsWithRangeStrategy(left, right, ((leftRange, rightRange) -> leftRange));
     }
 
-    private static PlanNodeStatsEstimate differenceInStatsWithRangeStrategy(PlanNodeStatsEstimate left, PlanNodeStatsEstimate right, SubtractRangeStrategy strategy)
+    private static PlanNodeStatsEstimate differenceInStatsWithRangeStrategy(PlanNodeStatsEstimate left, PlanNodeStatsEstimate right, RangeSubtractionStrategy strategy)
     {
         PlanNodeStatsEstimate.Builder statsBuilder = PlanNodeStatsEstimate.builder();
         double newRowCount = left.getOutputRowCount() - right.getOutputRowCount();
@@ -71,7 +72,7 @@ public class PlanNodeStatsEstimateMath
             SymbolStatsEstimate rightStats,
             double rightRowCount,
             double newRowCount,
-            SubtractRangeStrategy strategy)
+            RangeSubtractionStrategy strategy)
     {
         StatisticRange leftRange = StatisticRange.from(leftStats);
         StatisticRange rightRange = StatisticRange.from(rightStats);

--- a/presto-main/src/main/java/com/facebook/presto/cost/StatisticRange.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/StatisticRange.java
@@ -139,9 +139,21 @@ public class StatisticRange
         return empty();
     }
 
-    public StatisticRange add(StatisticRange other)
+    public StatisticRange addAndSumDistinctValues(StatisticRange other)
     {
         double newDistinctValues = distinctValues + other.distinctValues;
+        return new StatisticRange(minExcludeNaN(low, other.low), maxExcludeNaN(high, other.high), newDistinctValues);
+    }
+
+    public StatisticRange addAndCollapseDistinctValues(StatisticRange other)
+    {
+        double overlapPercentOfThis = this.overlapPercentWith(other);
+        double overlapPercentOfOther = other.overlapPercentWith(this);
+        double overlapDistinctValuesThis = overlapPercentOfThis * distinctValues;
+        double overlapDistinctValuesOther = overlapPercentOfOther * other.distinctValues;
+        double maxOverlappingValues = max(overlapDistinctValuesThis, overlapDistinctValuesOther);
+        double newDistinctValues = maxOverlappingValues + (1 - overlapPercentOfThis) * distinctValues + (1 - overlapPercentOfOther) * other.distinctValues;
+
         return new StatisticRange(minExcludeNaN(low, other.low), maxExcludeNaN(high, other.high), newDistinctValues);
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/cost/UnionStatsRule.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/UnionStatsRule.java
@@ -17,7 +17,7 @@ package com.facebook.presto.cost;
 import com.facebook.presto.matching.Pattern;
 import com.facebook.presto.sql.planner.plan.UnionNode;
 
-import static com.facebook.presto.cost.PlanNodeStatsEstimateMath.addStats;
+import static com.facebook.presto.cost.PlanNodeStatsEstimateMath.addStatsAndCollapseDistinctValues;
 
 public class UnionStatsRule
         extends AbstractSetOperationStatsRule
@@ -33,6 +33,6 @@ public class UnionStatsRule
     @Override
     protected PlanNodeStatsEstimate operate(PlanNodeStatsEstimate first, PlanNodeStatsEstimate second)
     {
-        return addStats(first, second);
+        return addStatsAndCollapseDistinctValues(first, second);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestUnionStatsRule.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestUnionStatsRule.java
@@ -139,12 +139,12 @@ public class TestUnionStatsRule
                         .symbolStats("o3", assertion -> assertion
                                 .lowValueUnknown()
                                 .highValueUnknown()
-                                .distinctValuesCount(10.0)
+                                .distinctValuesCount(8.5)
                                 .nullsFraction(0.1666667))
                         .symbolStats("o4", assertion -> assertion
                                 .lowValue(10)
                                 .highValue(15)
-                                .distinctValuesCount(6.0)
+                                .distinctValuesCount(4.0)
                                 .nullsFraction(0.1))
                         .symbolStats("o5", assertion -> assertion
                                 .lowValue(NEGATIVE_INFINITY)


### PR DESCRIPTION
When we combined statistics for unionall queries we estimated the
distinct values count as the sum of the left and right distinct values
counts.  We've found that a better heuristic is to take the max distinct
values for the percent that they overlap, and then add the
distinct values for the non-overlapping percent.

I decided not to change the behavior of other StatsRules using addStats() without data to indicate that a different approach would be better.   But I can if people think that it would be more reasonable for those cases too.