### PR TITLE
Add doc for TestReorderJoins

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestReorderJoins.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestReorderJoins.java
@@ -37,6 +37,14 @@ import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static org.testng.Assert.assertEquals;
 
+/**
+ * This tests verify joins order in plans generated for TPC-H queries using
+ * cost-based optimizer. They are intended to signal that a code change results
+ * in a change of generated plans.
+ *
+ * Most of the plans are currently suboptimal, so the tests results will likely
+ * change. They should be changed with care.
+ */
 public class TestReorderJoins
         extends BasePlanTest
 {


### PR DESCRIPTION
Added tests that verify join order in all TPC-H queries when using CBO and automatic distribution type.

Our intention was to make changes in plans more visible and track regressions that make worse some plans while improving others. The resulting plans adjusted to the current version of code are, however, far from optimal, so one should not resist from changing them.