### PR TITLE
Special case NOT(IS NULL) predicate stats

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/FilterStatsCalculator.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/FilterStatsCalculator.java
@@ -132,6 +132,9 @@ public class FilterStatsCalculator
         @Override
         protected Optional<PlanNodeStatsEstimate> visitNotExpression(NotExpression node, Void context)
         {
+            if (node.getValue() instanceof IsNullPredicate) {
+                return process(new IsNotNullPredicate(((IsNullPredicate) node.getValue()).getValue()));
+            }
             return process(node.getValue()).map(childStats -> differenceInStats(input, childStats));
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestFilterStatsCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestFilterStatsCalculator.java
@@ -319,6 +319,7 @@ public class TestFilterStatsCalculator
     {
         Expression innerExpression = new ComparisonExpression(ComparisonExpressionType.LESS_THAN, new SymbolReference("x"), new DoubleLiteral("0.0"));
         Expression unknownExpression = new FunctionCall(QualifiedName.of("sin"), ImmutableList.of(new SymbolReference("x")));
+        Expression isNullExpression = new IsNullPredicate(new SymbolReference("x"));
 
         assertExpression(new NotExpression(innerExpression))
                 .outputRowsCount(625) // FIXME - nulls shouldn't be restored
@@ -338,6 +339,15 @@ public class TestFilterStatsCalculator
                                 .highValue(10.0)
                                 .distinctValuesCount(40.0)
                                 .nullsFraction(0.25));
+
+        assertExpression(new NotExpression(isNullExpression))
+                .outputRowsCount(750)
+                .symbolStats(new Symbol("x"), symbolAssert ->
+                        symbolAssert.averageRowSize(4.0)
+                                .lowValue(-10.0)
+                                .highValue(10.0)
+                                .distinctValuesCount(40.0)
+                                .nullsFraction(0));
     }
 
     @Test


### PR DESCRIPTION
When the input to a not expression is an IsNullPredicate, compute stats
for an IsNotNullPredicate.