### PR TITLE
Compute plan stats lazily

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/statistics/MetricComparator.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/statistics/MetricComparator.java
@@ -65,9 +65,11 @@ public class MetricComparator
 
     private Set<MetricComparison<?>> getMetricComparisonsLocal(String query, LocalQueryRunner runner, Set<Metric<?>> metrics)
     {
-        Plan queryPlan = inTransaction(runner, (session) -> runner.createPlan(session, query));
-        OutputNode outputNode = (OutputNode) queryPlan.getRoot();
-        return getMetricComparisons(query, runner, queryPlan, outputNode, metrics);
+        return inTransaction(runner, (session) -> {
+            Plan queryPlan = runner.createPlan(session, query);
+            OutputNode outputNode = (OutputNode) queryPlan.getRoot();
+            return getMetricComparisons(query, runner, queryPlan, outputNode, metrics);
+        });
     }
 
     private <T> T inTransaction(QueryRunner runner, Function<Session, T> transactionSessionConsumer)


### PR DESCRIPTION
When stats are computed for tests' sake in `Plan` and using
`StatelessLookup`, there is not memoization and so each node is actually
stat-ed as many times as its depth in the plan tree.