### PR TITLE
Cbo 1 anti join heuristics

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/JoinStatsRule.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/JoinStatsRule.java
@@ -49,12 +49,21 @@ public class JoinStatsRule
         implements ComposableStatsCalculator.Rule
 {
     private static final Pattern PATTERN = Pattern.typeOf(JoinNode.class);
+    private static final double DEFAULT_UNMATCHED_JOIN_COMPLEMENT_NDVS_COEFFICIENT = 0.5;
 
     private final FilterStatsCalculator filterStatsCalculator;
+    private final double unmatchedJoinComplementNdvsCoefficient;
 
     public JoinStatsRule(FilterStatsCalculator filterStatsCalculator)
     {
+        this(filterStatsCalculator, DEFAULT_UNMATCHED_JOIN_COMPLEMENT_NDVS_COEFFICIENT);
+    }
+
+    @VisibleForTesting
+    JoinStatsRule(FilterStatsCalculator filterStatsCalculator, double unmatchedJoinComplementNdvsCoefficient)
+    {
         this.filterStatsCalculator = filterStatsCalculator;
+        this.unmatchedJoinComplementNdvsCoefficient = unmatchedJoinComplementNdvsCoefficient;
     }
 
     @Override
@@ -87,22 +96,27 @@ public class JoinStatsRule
 
     private PlanNodeStatsEstimate computeFullJoinStats(JoinNode node, PlanNodeStatsEstimate leftStats, PlanNodeStatsEstimate rightStats, Session session, Map<Symbol, Type> types)
     {
-        AntiJoinStats rightAntiJoinStats = calculateAntiJoinStats(node.getFilter(), flippedCriteria(node), rightStats, leftStats);
-        return addAntiJoinStats(computeLeftJoinStats(node, leftStats, rightStats, session, types), rightAntiJoinStats.getStats(), rightAntiJoinStats.getSelectedClauseSymbol());
+        JoinComplementStats rightJoinComplementStats = calculateJoinComplementStats(node.getFilter(), flippedCriteria(node), rightStats, leftStats);
+        return addJoinComplementStats(computeLeftJoinStats(node, leftStats, rightStats, session, types), rightJoinComplementStats, getSelectedClauseSymbolMaxNdvs(rightJoinComplementStats, rightStats));
     }
 
     private PlanNodeStatsEstimate computeLeftJoinStats(JoinNode node, PlanNodeStatsEstimate leftStats, PlanNodeStatsEstimate rightStats, Session session, Map<Symbol, Type> types)
     {
         PlanNodeStatsEstimate innerJoinStats = computeInnerJoinStats(node, leftStats, rightStats, session, types);
-        AntiJoinStats leftAntiJoinStats = calculateAntiJoinStats(node.getFilter(), node.getCriteria(), leftStats, rightStats);
-        return addAntiJoinStats(innerJoinStats, leftAntiJoinStats.getStats(), leftAntiJoinStats.getSelectedClauseSymbol());
+        JoinComplementStats leftJoinComplementStats = calculateJoinComplementStats(node.getFilter(), node.getCriteria(), leftStats, rightStats);
+        return addJoinComplementStats(innerJoinStats, leftJoinComplementStats, getSelectedClauseSymbolMaxNdvs(leftJoinComplementStats, leftStats));
     }
 
     private PlanNodeStatsEstimate computeRightJoinStats(JoinNode node, PlanNodeStatsEstimate leftStats, PlanNodeStatsEstimate rightStats, Session session, Map<Symbol, Type> types)
     {
         PlanNodeStatsEstimate innerJoinStats = computeInnerJoinStats(node, leftStats, rightStats, session, types);
-        AntiJoinStats rightAntiJoinStats = calculateAntiJoinStats(node.getFilter(), flippedCriteria(node), rightStats, leftStats);
-        return addAntiJoinStats(innerJoinStats, rightAntiJoinStats.getStats(), rightAntiJoinStats.getSelectedClauseSymbol());
+        JoinComplementStats rightJoinComplementStats = calculateJoinComplementStats(node.getFilter(), flippedCriteria(node), rightStats, leftStats);
+        return addJoinComplementStats(innerJoinStats, rightJoinComplementStats, getSelectedClauseSymbolMaxNdvs(rightJoinComplementStats, rightStats));
+    }
+
+    private double getSelectedClauseSymbolMaxNdvs(JoinComplementStats joinComplementStats, PlanNodeStatsEstimate stats)
+    {
+        return joinComplementStats.getSelectedClauseSymbol().map(symbol -> stats.getSymbolStatistics(symbol).getDistinctValuesCount()).orElse(NaN);
     }
 
     private PlanNodeStatsEstimate computeInnerJoinStats(JoinNode node, PlanNodeStatsEstimate leftStats, PlanNodeStatsEstimate rightStats, Session session, Map<Symbol, Type> types)
@@ -186,41 +200,41 @@ public class JoinStatsRule
     }
 
     @VisibleForTesting
-    AntiJoinStats calculateAntiJoinStats(Optional<Expression> filter, List<JoinNode.EquiJoinClause> criteria, PlanNodeStatsEstimate leftStats, PlanNodeStatsEstimate rightStats)
+    JoinComplementStats calculateJoinComplementStats(Optional<Expression> filter, List<JoinNode.EquiJoinClause> criteria, PlanNodeStatsEstimate leftStats, PlanNodeStatsEstimate rightStats)
     {
         // TODO: add support for non-equality conditions (e.g: <=, !=, >)
         if (filter.isPresent()) {
             // non-equi filters are not supported
-            return new AntiJoinStats(UNKNOWN_STATS, Optional.empty());
+            return new JoinComplementStats(UNKNOWN_STATS, Optional.empty());
         }
 
         if (criteria.isEmpty()) {
             if (rightStats.getOutputRowCount() > 0) {
                 // all left side rows are matched
-                return new AntiJoinStats(leftStats.mapOutputRowCount(rowCount -> 0.0), Optional.empty());
+                return new JoinComplementStats(leftStats.mapOutputRowCount(rowCount -> 0.0), Optional.empty());
             }
             else if (rightStats.getOutputRowCount() == 0) {
                 // none left side rows are matched
-                return new AntiJoinStats(leftStats, Optional.empty());
+                return new JoinComplementStats(leftStats, Optional.empty());
             }
             else {
                 // right stats row count is NaN
-                return new AntiJoinStats(UNKNOWN_STATS, Optional.empty());
+                return new JoinComplementStats(UNKNOWN_STATS, Optional.empty());
             }
         }
 
-        // heuristics: select the most selective criteria for anti join clause
+        // heuristics: select the most selective criteria for join complement clause
         return IntStream.range(0, criteria.size())
                 .mapToObj(drivingClauseId -> {
                     EquiJoinClause drivingClause = criteria.get(drivingClauseId);
                     List<EquiJoinClause> remainingClauses = copyWithout(criteria, drivingClauseId);
-                    return calculateAntiJoinStats(leftStats, rightStats, drivingClause, remainingClauses);
+                    return calculateJoinComplementStats(leftStats, rightStats, drivingClause, remainingClauses);
                 })
-                .max(comparingDouble(antiJoinStats -> antiJoinStats.getStats().getOutputRowCount()))
+                .max(comparingDouble(joinComplementStats -> joinComplementStats.getStats().getOutputRowCount()))
                 .get();
     }
 
-    private AntiJoinStats calculateAntiJoinStats(PlanNodeStatsEstimate leftStats, PlanNodeStatsEstimate rightStats, EquiJoinClause drivingClause, List<EquiJoinClause> remainingClauses)
+    private JoinComplementStats calculateJoinComplementStats(PlanNodeStatsEstimate leftStats, PlanNodeStatsEstimate rightStats, EquiJoinClause drivingClause, List<EquiJoinClause> remainingClauses)
     {
         PlanNodeStatsEstimate result = leftStats;
 
@@ -229,10 +243,10 @@ public class JoinStatsRule
 
         // TODO: use range methods when they have defined (and consistent) semantics
         double leftNDV = leftColumnStats.getDistinctValuesCount();
-        double rightNDV = rightColumnStats.getDistinctValuesCount();
+        double matchingRightNDV = rightColumnStats.getDistinctValuesCount() * unmatchedJoinComplementNdvsCoefficient;
 
-        if (leftNDV > rightNDV) {
-            double selectedRangeFraction = leftColumnStats.getValuesFraction() * (leftNDV - rightNDV) / leftNDV;
+        if (leftNDV > matchingRightNDV) {
+            double selectedRangeFraction = leftColumnStats.getValuesFraction() * (leftNDV - matchingRightNDV) / leftNDV;
             double scaleFactor = selectedRangeFraction + leftColumnStats.getNullsFraction();
             double newLeftNullsFraction = leftColumnStats.getNullsFraction() / scaleFactor;
             result = result.mapSymbolColumnStatistics(drivingClause.getLeft(), columnStats ->
@@ -240,11 +254,11 @@ public class JoinStatsRule
                             .setLowValue(leftColumnStats.getLowValue())
                             .setHighValue(leftColumnStats.getHighValue())
                             .setNullsFraction(newLeftNullsFraction)
-                            .setDistinctValuesCount(leftNDV - rightNDV)
+                            .setDistinctValuesCount(leftNDV - matchingRightNDV)
                             .build());
             result = result.mapOutputRowCount(rowCount -> rowCount * scaleFactor);
         }
-        else if (leftNDV <= rightNDV) {
+        else if (leftNDV <= matchingRightNDV) {
             // only null values are left
             result = result.mapSymbolColumnStatistics(drivingClause.getLeft(), columnStats ->
                     SymbolStatsEstimate.buildFrom(columnStats)
@@ -257,7 +271,7 @@ public class JoinStatsRule
         }
         else {
             // either leftNDV or rightNDV is NaN
-            return new AntiJoinStats(UNKNOWN_STATS, Optional.empty());
+            return new JoinComplementStats(UNKNOWN_STATS, Optional.empty());
         }
 
         // account for remaining clauses
@@ -265,34 +279,34 @@ public class JoinStatsRule
             result = result.mapOutputRowCount(rowCount -> min(leftStats.getOutputRowCount(), rowCount / UNKNOWN_FILTER_COEFFICIENT));
         }
 
-        return new AntiJoinStats(result, Optional.of(drivingClause.getLeft()));
+        return new JoinComplementStats(result, Optional.of(drivingClause.getLeft()));
     }
 
     @VisibleForTesting
-    PlanNodeStatsEstimate addAntiJoinStats(PlanNodeStatsEstimate joinStats, PlanNodeStatsEstimate antiJoinStats, Optional<Symbol> joinSymbol)
+    PlanNodeStatsEstimate addJoinComplementStats(PlanNodeStatsEstimate innerJoinStats, JoinComplementStats joinComplementStats, double selectedClauseSymbolMaxNdv)
     {
-        checkState(joinStats.getSymbolsWithKnownStatistics().containsAll(antiJoinStats.getSymbolsWithKnownStatistics()));
+        checkState(innerJoinStats.getSymbolsWithKnownStatistics().containsAll(joinComplementStats.getStats().getSymbolsWithKnownStatistics()));
 
-        double joinOutputRowCount = joinStats.getOutputRowCount();
-        double antiJoinOutputRowCount = antiJoinStats.getOutputRowCount();
-        double totalRowCount = joinOutputRowCount + antiJoinOutputRowCount;
-        PlanNodeStatsEstimate outputStats = joinStats.mapOutputRowCount(rowCount -> rowCount + antiJoinOutputRowCount);
+        double joinOutputRowCount = innerJoinStats.getOutputRowCount();
+        double joinComplementOutputRowCount = joinComplementStats.getStats().getOutputRowCount();
+        double totalRowCount = joinOutputRowCount + joinComplementOutputRowCount;
+        PlanNodeStatsEstimate outputStats = innerJoinStats.mapOutputRowCount(rowCount -> rowCount + joinComplementOutputRowCount);
 
-        for (Symbol symbol : antiJoinStats.getSymbolsWithKnownStatistics()) {
+        for (Symbol symbol : joinComplementStats.getStats().getSymbolsWithKnownStatistics()) {
             outputStats = outputStats.mapSymbolColumnStatistics(symbol, joinColumnStats -> {
-                SymbolStatsEstimate antiJoinColumnStats = antiJoinStats.getSymbolStatistics(symbol);
+                SymbolStatsEstimate joinComplementColumnStats = joinComplementStats.getStats().getSymbolStatistics(symbol);
                 // weighted average
-                double newNullsFraction = (joinColumnStats.getNullsFraction() * joinOutputRowCount + antiJoinColumnStats.getNullsFraction() * antiJoinOutputRowCount) / totalRowCount;
+                double newNullsFraction = (joinColumnStats.getNullsFraction() * joinOutputRowCount + joinComplementColumnStats.getNullsFraction() * joinComplementOutputRowCount) / totalRowCount;
                 double distinctValues;
-                if (joinSymbol.isPresent() && joinSymbol.get().equals(symbol)) {
-                    distinctValues = joinColumnStats.getDistinctValuesCount() + antiJoinColumnStats.getDistinctValuesCount();
+                if (joinComplementStats.getSelectedClauseSymbol().isPresent() && joinComplementStats.getSelectedClauseSymbol().get().equals(symbol)) {
+                    distinctValues = min(joinColumnStats.getDistinctValuesCount() + joinComplementColumnStats.getDistinctValuesCount(), selectedClauseSymbolMaxNdv);
                 }
                 else {
                     distinctValues = joinColumnStats.getDistinctValuesCount();
                 }
                 return SymbolStatsEstimate.buildFrom(joinColumnStats)
-                        .setLowValue(rangeMin(joinColumnStats.getLowValue(), antiJoinColumnStats.getLowValue()))
-                        .setHighValue(rangeMax(joinColumnStats.getHighValue(), antiJoinColumnStats.getHighValue()))
+                        .setLowValue(rangeMin(joinColumnStats.getLowValue(), joinComplementColumnStats.getLowValue()))
+                        .setHighValue(rangeMax(joinColumnStats.getHighValue(), joinComplementColumnStats.getHighValue()))
                         .setDistinctValuesCount(distinctValues)
                         .setNullsFraction(newNullsFraction)
                         .build();
@@ -300,9 +314,9 @@ public class JoinStatsRule
         }
 
         // add nulls to columns that don't exist in right stats
-        for (Symbol symbol : difference(joinStats.getSymbolsWithKnownStatistics(), antiJoinStats.getSymbolsWithKnownStatistics())) {
+        for (Symbol symbol : difference(innerJoinStats.getSymbolsWithKnownStatistics(), joinComplementStats.getStats().getSymbolsWithKnownStatistics())) {
             outputStats = outputStats.mapSymbolColumnStatistics(symbol, joinColumnStats ->
-                    joinColumnStats.mapNullsFraction(nullsFraction -> (nullsFraction * joinOutputRowCount + antiJoinOutputRowCount) / totalRowCount));
+                    joinColumnStats.mapNullsFraction(nullsFraction -> (nullsFraction * joinOutputRowCount + joinComplementOutputRowCount) / totalRowCount));
         }
 
         return outputStats;
@@ -327,12 +341,12 @@ public class JoinStatsRule
     }
 
     @VisibleForTesting
-    static class AntiJoinStats
+    static class JoinComplementStats
     {
         private final PlanNodeStatsEstimate stats;
         private final Optional<Symbol> selectedClauseSymbol;
 
-        public AntiJoinStats(PlanNodeStatsEstimate stats, Optional<Symbol> selectedClauseSymbol)
+        public JoinComplementStats(PlanNodeStatsEstimate stats, Optional<Symbol> selectedClauseSymbol)
         {
             this.stats = stats;
             this.selectedClauseSymbol = selectedClauseSymbol;

--- a/presto-main/src/test/java/com/facebook/presto/cost/StatsCalculatorAssertion.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/StatsCalculatorAssertion.java
@@ -24,6 +24,7 @@ import com.facebook.presto.sql.planner.plan.PlanNode;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -93,6 +94,14 @@ public class StatsCalculatorAssertion
     {
         PlanNodeStatsEstimate statsEstimate = statsCalculator.calculateStats(planNode, mockLookup(), session, types);
         statisticsAssertionConsumer.accept(PlanNodeStatsAssertion.assertThat(statsEstimate));
+        return this;
+    }
+
+    public StatsCalculatorAssertion check(ComposableStatsCalculator.Rule rule, Consumer<PlanNodeStatsAssertion> statisticsAssertionConsumer)
+    {
+        Optional<PlanNodeStatsEstimate> statsEstimate = rule.calculate(planNode, mockLookup(), session, types);
+        checkState(statsEstimate.isPresent(), "Expected stats estimates to be present");
+        statisticsAssertionConsumer.accept(PlanNodeStatsAssertion.assertThat(statsEstimate.get()));
         return this;
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestJoinStatsRule.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestJoinStatsRule.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.cost;
 
+import com.facebook.presto.cost.JoinStatsRule.JoinComplementStats;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.JoinNode.EquiJoinClause;
@@ -80,7 +81,7 @@ public class TestJoinStatsRule
             RIGHT_JOIN_COLUMN_STATS,
             RIGHT_OTHER_COLUMN_STATS);
 
-    private static final JoinStatsRule JOIN_STATS_RULE = new JoinStatsRule(new FilterStatsCalculator(createTestMetadataManager()));
+    private static final JoinStatsRule JOIN_STATS_RULE = new JoinStatsRule(new FilterStatsCalculator(createTestMetadataManager()), 1.0);
 
     private StatsCalculatorTester tester;
 
@@ -188,67 +189,67 @@ public class TestJoinStatsRule
     }
 
     @Test
-    public void testStatsForLeftAntiJoin()
+    public void testJoinComplementStats()
     {
-        PlanNodeStatsEstimate antiJoinStats = planNodeStats(LEFT_ROWS_COUNT * (LEFT_JOIN_COLUMN_NULLS + LEFT_JOIN_COLUMN_NON_NULLS / 4),
+        PlanNodeStatsEstimate joinComplementStats = planNodeStats(LEFT_ROWS_COUNT * (LEFT_JOIN_COLUMN_NULLS + LEFT_JOIN_COLUMN_NON_NULLS / 4),
                 symbolStatistics(LEFT_JOIN_COLUMN, 0.0, 20.0, LEFT_JOIN_COLUMN_NULLS / (LEFT_JOIN_COLUMN_NULLS + LEFT_JOIN_COLUMN_NON_NULLS / 4), 5),
                 LEFT_OTHER_COLUMN_STATS);
 
-        assertThat(JOIN_STATS_RULE.calculateAntiJoinStats(
+        assertThat(JOIN_STATS_RULE.calculateJoinComplementStats(
                 Optional.empty(),
                 ImmutableList.of(new JoinNode.EquiJoinClause(new Symbol(LEFT_JOIN_COLUMN), new Symbol(RIGHT_JOIN_COLUMN))),
-                LEFT_STATS, RIGHT_STATS).getStats()).equalTo(antiJoinStats);
+                LEFT_STATS, RIGHT_STATS).getStats()).equalTo(joinComplementStats);
     }
 
     @Test
-    public void testStatsForRightAntiJoin()
+    public void testRightJoinComplementStats()
     {
-        PlanNodeStatsEstimate antiJoinStats = planNodeStats(RIGHT_ROWS_COUNT * RIGHT_JOIN_COLUMN_NULLS,
+        PlanNodeStatsEstimate joinComplementStats = planNodeStats(RIGHT_ROWS_COUNT * RIGHT_JOIN_COLUMN_NULLS,
                 symbolStatistics(RIGHT_JOIN_COLUMN, NaN, NaN, 1.0, 0),
                 RIGHT_OTHER_COLUMN_STATS);
 
-        assertThat(JOIN_STATS_RULE.calculateAntiJoinStats(
+        assertThat(JOIN_STATS_RULE.calculateJoinComplementStats(
                 Optional.empty(),
                 ImmutableList.of(new JoinNode.EquiJoinClause(new Symbol(RIGHT_JOIN_COLUMN), new Symbol(LEFT_JOIN_COLUMN))),
-                RIGHT_STATS, LEFT_STATS).getStats()).equalTo(antiJoinStats);
+                RIGHT_STATS, LEFT_STATS).getStats()).equalTo(joinComplementStats);
     }
 
     @Test
-    public void testStatsForLeftAntiJoinWithNoClauses()
+    public void testLeftJoinComplementStatsWithNoClauses()
     {
-        assertThat(JOIN_STATS_RULE.calculateAntiJoinStats(
+        assertThat(JOIN_STATS_RULE.calculateJoinComplementStats(
                 Optional.empty(),
                 ImmutableList.of(),
                 LEFT_STATS, RIGHT_STATS).getStats()).equalTo(LEFT_STATS.mapOutputRowCount(rowCount -> 0.0));
     }
 
     @Test
-    public void testStatsForLeftAntiJoinWithMultipleClauses()
+    public void testLeftJoinComplementStatsWithMultipleClauses()
     {
-        PlanNodeStatsEstimate antiJoinStats = planNodeStats(LEFT_ROWS_COUNT * (LEFT_JOIN_COLUMN_NULLS + LEFT_JOIN_COLUMN_NON_NULLS / 4),
+        PlanNodeStatsEstimate joinComplementStats = planNodeStats(LEFT_ROWS_COUNT * (LEFT_JOIN_COLUMN_NULLS + LEFT_JOIN_COLUMN_NON_NULLS / 4),
                 symbolStatistics(LEFT_JOIN_COLUMN, 0.0, 20.0, LEFT_JOIN_COLUMN_NULLS / (LEFT_JOIN_COLUMN_NULLS + LEFT_JOIN_COLUMN_NON_NULLS / 4), 5),
                 LEFT_OTHER_COLUMN_STATS).mapOutputRowCount(rowCount -> rowCount / UNKNOWN_FILTER_COEFFICIENT);
 
-        assertThat(JOIN_STATS_RULE.calculateAntiJoinStats(
+        assertThat(JOIN_STATS_RULE.calculateJoinComplementStats(
                 Optional.empty(),
                 ImmutableList.of(new JoinNode.EquiJoinClause(new Symbol(LEFT_JOIN_COLUMN), new Symbol(RIGHT_JOIN_COLUMN)), new JoinNode.EquiJoinClause(new Symbol(LEFT_OTHER_COLUMN), new Symbol(RIGHT_OTHER_COLUMN))),
-                LEFT_STATS, RIGHT_STATS).getStats()).equalTo(antiJoinStats);
+                LEFT_STATS, RIGHT_STATS).getStats()).equalTo(joinComplementStats);
     }
 
     @Test
     public void testStatsForLeftAndRightJoin()
     {
         double innerJoinRowCount = LEFT_ROWS_COUNT * RIGHT_ROWS_COUNT / LEFT_JOIN_COLUMN_NDV * LEFT_JOIN_COLUMN_NON_NULLS * RIGHT_JOIN_COLUMN_NON_NULLS;
-        double antiJoinRowCount = LEFT_ROWS_COUNT * (LEFT_JOIN_COLUMN_NULLS + LEFT_JOIN_COLUMN_NON_NULLS / 4);
-        double antiJoinColumnNulls = LEFT_JOIN_COLUMN_NULLS / (LEFT_JOIN_COLUMN_NULLS + LEFT_JOIN_COLUMN_NON_NULLS / 4);
-        double totalRowCount = innerJoinRowCount + antiJoinRowCount;
+        double joinComplementRowCount = LEFT_ROWS_COUNT * (LEFT_JOIN_COLUMN_NULLS + LEFT_JOIN_COLUMN_NON_NULLS / 4);
+        double joinComplementColumnNulls = LEFT_JOIN_COLUMN_NULLS / (LEFT_JOIN_COLUMN_NULLS + LEFT_JOIN_COLUMN_NON_NULLS / 4);
+        double totalRowCount = innerJoinRowCount + joinComplementRowCount;
 
         PlanNodeStatsEstimate leftJoinStats = planNodeStats(
                 totalRowCount,
-                symbolStatistics(LEFT_JOIN_COLUMN, 0.0, 20.0, antiJoinColumnNulls * antiJoinRowCount / totalRowCount, LEFT_JOIN_COLUMN_NDV),
+                symbolStatistics(LEFT_JOIN_COLUMN, 0.0, 20.0, joinComplementColumnNulls * joinComplementRowCount / totalRowCount, LEFT_JOIN_COLUMN_NDV),
                 LEFT_OTHER_COLUMN_STATS,
-                symbolStatistics(RIGHT_JOIN_COLUMN, 5.0, 20.0, antiJoinRowCount / totalRowCount, RIGHT_JOIN_COLUMN_NDV),
-                symbolStatistics(RIGHT_OTHER_COLUMN, 24, 24, (0.24 * innerJoinRowCount + antiJoinRowCount) / totalRowCount, 1));
+                symbolStatistics(RIGHT_JOIN_COLUMN, 5.0, 20.0, joinComplementRowCount / totalRowCount, RIGHT_JOIN_COLUMN_NDV),
+                symbolStatistics(RIGHT_OTHER_COLUMN, 24, 24, (0.24 * innerJoinRowCount + joinComplementRowCount) / totalRowCount, 1));
 
         assertJoinStats(LEFT, LEFT_STATS, RIGHT_STATS, leftJoinStats);
         assertJoinStats(RIGHT, RIGHT_JOIN_COLUMN, RIGHT_OTHER_COLUMN, LEFT_JOIN_COLUMN, LEFT_OTHER_COLUMN, RIGHT_STATS, LEFT_STATS, leftJoinStats);
@@ -258,33 +259,33 @@ public class TestJoinStatsRule
     public void testStatsForFullJoin()
     {
         double innerJoinRowCount = LEFT_ROWS_COUNT * RIGHT_ROWS_COUNT / LEFT_JOIN_COLUMN_NDV * LEFT_JOIN_COLUMN_NON_NULLS * RIGHT_JOIN_COLUMN_NON_NULLS;
-        double leftAntiJoinRowCount = LEFT_ROWS_COUNT * (LEFT_JOIN_COLUMN_NULLS + LEFT_JOIN_COLUMN_NON_NULLS / 4);
-        double leftAntiJoinColumnNulls = LEFT_JOIN_COLUMN_NULLS / (LEFT_JOIN_COLUMN_NULLS + LEFT_JOIN_COLUMN_NON_NULLS / 4);
-        double rightAntiJoinRowCount = RIGHT_ROWS_COUNT * RIGHT_JOIN_COLUMN_NULLS;
-        double rightAntiJoinColumnNulls = 1.0;
-        double totalRowCount = innerJoinRowCount + leftAntiJoinRowCount + rightAntiJoinRowCount;
+        double leftJoinComplementRowCount = LEFT_ROWS_COUNT * (LEFT_JOIN_COLUMN_NULLS + LEFT_JOIN_COLUMN_NON_NULLS / 4);
+        double leftJoinComplementColumnNulls = LEFT_JOIN_COLUMN_NULLS / (LEFT_JOIN_COLUMN_NULLS + LEFT_JOIN_COLUMN_NON_NULLS / 4);
+        double rightJoinComplementRowCount = RIGHT_ROWS_COUNT * RIGHT_JOIN_COLUMN_NULLS;
+        double rightJoinComplementColumnNulls = 1.0;
+        double totalRowCount = innerJoinRowCount + leftJoinComplementRowCount + rightJoinComplementRowCount;
 
         PlanNodeStatsEstimate leftJoinStats = planNodeStats(
                 totalRowCount,
-                symbolStatistics(LEFT_JOIN_COLUMN, 0.0, 20.0, (leftAntiJoinColumnNulls * leftAntiJoinRowCount + rightAntiJoinRowCount) / totalRowCount, LEFT_JOIN_COLUMN_NDV),
-                symbolStatistics(LEFT_OTHER_COLUMN, 42, 42, (0.42 * (innerJoinRowCount + leftAntiJoinRowCount) + rightAntiJoinRowCount) / totalRowCount, 1),
-                symbolStatistics(RIGHT_JOIN_COLUMN, 5.0, 20.0, (rightAntiJoinColumnNulls * rightAntiJoinRowCount + leftAntiJoinRowCount) / totalRowCount, RIGHT_JOIN_COLUMN_NDV),
-                symbolStatistics(RIGHT_OTHER_COLUMN, 24, 24, (0.24 * (innerJoinRowCount + rightAntiJoinRowCount) + leftAntiJoinRowCount) / totalRowCount, 1));
+                symbolStatistics(LEFT_JOIN_COLUMN, 0.0, 20.0, (leftJoinComplementColumnNulls * leftJoinComplementRowCount + rightJoinComplementRowCount) / totalRowCount, LEFT_JOIN_COLUMN_NDV),
+                symbolStatistics(LEFT_OTHER_COLUMN, 42, 42, (0.42 * (innerJoinRowCount + leftJoinComplementRowCount) + rightJoinComplementRowCount) / totalRowCount, 1),
+                symbolStatistics(RIGHT_JOIN_COLUMN, 5.0, 20.0, (rightJoinComplementColumnNulls * rightJoinComplementRowCount + leftJoinComplementRowCount) / totalRowCount, RIGHT_JOIN_COLUMN_NDV),
+                symbolStatistics(RIGHT_OTHER_COLUMN, 24, 24, (0.24 * (innerJoinRowCount + rightJoinComplementRowCount) + leftJoinComplementRowCount) / totalRowCount, 1));
 
         assertJoinStats(FULL, LEFT_STATS, RIGHT_STATS, leftJoinStats);
     }
 
     @Test
-    public void testAddAntiJoinStats()
+    public void testAddJoinComplementStats()
     {
         PlanNodeStatsEstimate statsToAdd = planNodeStats(RIGHT_ROWS_COUNT,
                 symbolStatistics(LEFT_JOIN_COLUMN, -5.0, 5.0, 0.2, 5));
 
         PlanNodeStatsEstimate addedStats = planNodeStats(TOTAL_ROWS_COUNT,
-                symbolStatistics(LEFT_JOIN_COLUMN, -5.0, 20.0, (LEFT_ROWS_COUNT * LEFT_JOIN_COLUMN_NULLS + RIGHT_ROWS_COUNT * 0.2) / TOTAL_ROWS_COUNT, 25),
+                symbolStatistics(LEFT_JOIN_COLUMN, -5.0, 20.0, (LEFT_ROWS_COUNT * LEFT_JOIN_COLUMN_NULLS + RIGHT_ROWS_COUNT * 0.2) / TOTAL_ROWS_COUNT, LEFT_JOIN_COLUMN_NDV + 5),
                 symbolStatistics(LEFT_OTHER_COLUMN, 42, 42, (0.42 * LEFT_ROWS_COUNT + RIGHT_ROWS_COUNT) / TOTAL_ROWS_COUNT, 1));
 
-        assertThat(JOIN_STATS_RULE.addAntiJoinStats(LEFT_STATS, statsToAdd, Optional.of((new Symbol(LEFT_JOIN_COLUMN))))).equalTo(addedStats);
+        assertThat(JOIN_STATS_RULE.addJoinComplementStats(LEFT_STATS, new JoinComplementStats(statsToAdd, Optional.of(new Symbol(LEFT_JOIN_COLUMN))), LEFT_JOIN_COLUMN_NDV + 5)).equalTo(addedStats);
     }
 
     private void assertJoinStats(JoinNode.Type joinType, PlanNodeStatsEstimate leftStats, PlanNodeStatsEstimate rightStats, PlanNodeStatsEstimate resultStats)
@@ -305,7 +306,7 @@ public class TestJoinStatsRule
                             new EquiJoinClause(leftJoinColumnSymbol, rightJoinColumnSymbol));
         }).withSourceStats(0, leftStats)
                 .withSourceStats(1, rightStats)
-                .check(stats -> stats.equalTo(resultStats));
+                .check(JOIN_STATS_RULE, stats -> stats.equalTo(resultStats));
     }
 
     private static PlanNodeStatsEstimate planNodeStats(double rowCount, SymbolStatistics... symbolStatistics)

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchLocalStats.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchLocalStats.java
@@ -123,21 +123,21 @@ public class TestTpchLocalStats
         // simple equi join
         statisticsAssertion.check("SELECT * FROM supplier left join nation on s_nationkey = n_nationkey",
                 checks -> checks
-                        .estimate(OUTPUT_ROW_COUNT, defaultTolerance())
-                        .verifyExactColumnStatistics("s_nationkey")
-                        .verifyExactColumnStatistics("n_nationkey")
-                        .verifyExactColumnStatistics("s_suppkey"));
+                        .estimate(OUTPUT_ROW_COUNT, relativeError(0.70))
+                        .verifyColumnStatistics("s_nationkey", absoluteError(0.40))
+                        .verifyColumnStatistics("n_nationkey", absoluteError(0.40))
+                        .verifyColumnStatistics("s_suppkey", absoluteError(0.40)));
         statisticsAssertion.check("SELECT * FROM supplier left join nation on s_nationkey = n_nationkey AND n_nationkey <= 12",
                 checks -> checks
-                        .estimate(OUTPUT_ROW_COUNT, defaultTolerance())
-                        .verifyExactColumnStatistics("s_nationkey")
-                        .verifyColumnStatistics("n_nationkey", relativeError(0.10))
-                        .verifyExactColumnStatistics("s_suppkey"));
+                        .estimate(OUTPUT_ROW_COUNT, relativeError(0.70))
+                        .verifyColumnStatistics("s_nationkey", absoluteError(0.40))
+                        .verifyColumnStatistics("n_nationkey", relativeError(0.40))
+                        .verifyColumnStatistics("s_suppkey", absoluteError(0.40)));
         statisticsAssertion.check("SELECT * FROM (SELECT * FROM supplier WHERE s_nationkey <= 12) left join nation on s_nationkey = n_nationkey",
                 checks -> checks
-                        .estimate(OUTPUT_ROW_COUNT, relativeError(0.15))
-                        .verifyColumnStatistics("s_nationkey", relativeError(0.15))
-                        .verifyColumnStatistics("n_nationkey", relativeError(0.10)));
+                        .estimate(OUTPUT_ROW_COUNT, relativeError(0.70))
+                        .verifyColumnStatistics("s_nationkey", absoluteError(2.0))
+                        .verifyColumnStatistics("n_nationkey", absoluteError(2.0)));
     }
 
     @Test
@@ -146,21 +146,21 @@ public class TestTpchLocalStats
         // simple equi join
         statisticsAssertion.check("SELECT * FROM nation right join supplier on s_nationkey = n_nationkey",
                 checks -> checks
-                        .estimate(OUTPUT_ROW_COUNT, defaultTolerance())
-                        .verifyExactColumnStatistics("s_nationkey")
-                        .verifyExactColumnStatistics("n_nationkey")
-                        .verifyExactColumnStatistics("s_suppkey"));
+                        .estimate(OUTPUT_ROW_COUNT, relativeError(0.70))
+                        .verifyColumnStatistics("s_nationkey", absoluteError(0.40))
+                        .verifyColumnStatistics("n_nationkey", absoluteError(0.40))
+                        .verifyColumnStatistics("s_suppkey", absoluteError(0.40)));
         statisticsAssertion.check("SELECT * FROM nation right join supplier on s_nationkey = n_nationkey AND n_nationkey <= 12",
                 checks -> checks
-                        .estimate(OUTPUT_ROW_COUNT, defaultTolerance())
-                        .verifyExactColumnStatistics("s_nationkey")
-                        .verifyColumnStatistics("n_nationkey", relativeError(0.10))
-                        .verifyExactColumnStatistics("s_suppkey"));
+                        .estimate(OUTPUT_ROW_COUNT, relativeError(0.70))
+                        .verifyColumnStatistics("s_nationkey", absoluteError(0.40))
+                        .verifyColumnStatistics("n_nationkey", relativeError(0.40))
+                        .verifyColumnStatistics("s_suppkey", absoluteError(0.40)));
         statisticsAssertion.check("SELECT * FROM nation right JOIN (SELECT * FROM supplier WHERE s_nationkey <= 12) on s_nationkey = n_nationkey",
                 checks -> checks
-                        .estimate(OUTPUT_ROW_COUNT, relativeError(0.15))
-                        .verifyColumnStatistics("s_nationkey", relativeError(0.15))
-                        .verifyColumnStatistics("n_nationkey", relativeError(0.10)));
+                        .estimate(OUTPUT_ROW_COUNT, relativeError(0.70))
+                        .verifyColumnStatistics("s_nationkey", absoluteError(2.0))
+                        .verifyColumnStatistics("n_nationkey", absoluteError(2.0)));
     }
 
     @Test
@@ -169,21 +169,21 @@ public class TestTpchLocalStats
         // simple equi join
         statisticsAssertion.check("SELECT * FROM nation full join supplier on s_nationkey = n_nationkey",
                 checks -> checks
-                        .estimate(OUTPUT_ROW_COUNT, defaultTolerance())
-                        .verifyExactColumnStatistics("s_nationkey")
-                        .verifyExactColumnStatistics("n_nationkey")
-                        .verifyExactColumnStatistics("s_suppkey"));
+                        .estimate(OUTPUT_ROW_COUNT, relativeError(0.70))
+                        .verifyColumnStatistics("s_nationkey", absoluteError(0.40))
+                        .verifyColumnStatistics("n_nationkey", absoluteError(0.40))
+                        .verifyColumnStatistics("s_suppkey", absoluteError(0.40)));
         statisticsAssertion.check("SELECT * FROM (SELECT * FROM nation WHERE n_nationkey <= 12) full join supplier on s_nationkey = n_nationkey",
                 checks -> checks
-                        .estimate(OUTPUT_ROW_COUNT, defaultTolerance())
-                        .verifyExactColumnStatistics("s_nationkey")
-                        .verifyColumnStatistics("n_nationkey", relativeError(0.10))
-                        .verifyExactColumnStatistics("s_suppkey"));
+                        .estimate(OUTPUT_ROW_COUNT, relativeError(0.70))
+                        .verifyColumnStatistics("s_nationkey", absoluteError(0.40))
+                        .verifyColumnStatistics("n_nationkey", relativeError(0.40))
+                        .verifyColumnStatistics("s_suppkey", absoluteError(0.40)));
         statisticsAssertion.check("SELECT * FROM nation full join (SELECT * FROM supplier WHERE s_nationkey <= 12) on s_nationkey = n_nationkey",
                 checks -> checks
-                        .estimate(OUTPUT_ROW_COUNT, relativeError(0.15))
-                        .verifyColumnStatistics("s_nationkey", relativeError(0.15))
-                        .verifyColumnStatistics("n_nationkey", relativeError(0.10)));
+                        .estimate(OUTPUT_ROW_COUNT, relativeError(0.70))
+                        .verifyColumnStatistics("s_nationkey", relativeError(0.40))
+                        .verifyColumnStatistics("n_nationkey", relativeError(0.40)));
     }
 
     @Test


### PR DESCRIPTION
This causes outer join stats to be slightly overestimated.

I have checked that q78 works as fast in cbo_automatic as ecj_repartitioned (around 24 secs).
ecj_automatic works faster (<20secs).