### PR TITLE
Don't override sort order for duplicated symbols

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -693,10 +693,11 @@ class QueryPlanner
             }
 
             // Rewrite ORDER BY in terms of pre-projected inputs
-            Map<Symbol, SortOrder> orderings = new LinkedHashMap<>();
+            LinkedHashMap<Symbol, SortOrder> orderings = new LinkedHashMap<>();
             for (SortItem item : getSortItemsFromOrderBy(window.getOrderBy())) {
                 Symbol symbol = subPlan.translate(item.getSortKey());
-                orderings.put(symbol, toSortOrder(item));
+                // don't override existing keys, i.e. when "ORDER BY a ASC, a DESC" is specified
+                orderings.putIfAbsent(symbol, toSortOrder(item));
             }
 
             // Rewrite frame bounds in terms of pre-projected inputs

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -62,6 +62,7 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.TimeType.TIME;
 import static com.facebook.presto.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
@@ -4075,6 +4076,21 @@ public abstract class AbstractTestQueries
                 .row(5.0, 0.0)
                 .row(5.0, 0.0)
                 .row(5.0, 0.0)
+                .build();
+
+        assertEquals(actual, expected);
+    }
+
+    @Test
+    public void testWindowsOrderingOnTheSameSymbolTwice()
+            throws Exception
+    {
+        MaterializedResult actual = computeActual("SELECT x, row_number() OVER(ORDER BY x ASC, x DESC) FROM (VALUES (INTEGER '1'), (INTEGER '2'), (INTEGER '3')) t(x)");
+
+        MaterializedResult expected = resultBuilder(getSession(), INTEGER, BIGINT)
+                .row(1, 1L)
+                .row(2, 2L)
+                .row(3, 3L)
                 .build();
 
         assertEquals(actual, expected);


### PR DESCRIPTION
In order to handle cases like "ORDER BY a ASC, a DESC" correctly we must not override the orderings.
Correct semantics according to ISO/IEC 9075-2:2011(E) 10.10 (especially relevant here is 10.10.h) is to consider sort key in ordering only if previously encountered sort keys didn't establish the order.
It is not possible to have a tie which could have been broken by having the same symbol further in the <sorting specification list>, unless we extend <sort specification> to support more than just <ordering specifcation> and <null ordering>, e.g. by adding collations.

---

Fixes https://github.com/prestodb/presto/issues/8816