### PR TITLE
Improve q14 performance

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/FileFormatDataSourceStats.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/FileFormatDataSourceStats.java
@@ -24,7 +24,6 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 public class FileFormatDataSourceStats
 {
     private final DistributionStat readBytes = new DistributionStat();
-    private final DistributionStat loadedBlockBytes = new DistributionStat();
     private final TimeStat time0Bto100KB = new TimeStat(MILLISECONDS);
     private final TimeStat time100KBto1MB = new TimeStat(MILLISECONDS);
     private final TimeStat time1MBto10MB = new TimeStat(MILLISECONDS);
@@ -35,13 +34,6 @@ public class FileFormatDataSourceStats
     public DistributionStat getReadBytes()
     {
         return readBytes;
-    }
-
-    @Managed
-    @Nested
-    public DistributionStat getLoadedBlockBytes()
-    {
-        return loadedBlockBytes;
     }
 
     @Managed
@@ -87,10 +79,5 @@ public class FileFormatDataSourceStats
         else {
             time10MBPlus.add(nanos, NANOSECONDS);
         }
-    }
-
-    public void addLoadedBlockSize(long bytes)
-    {
-        loadedBlockBytes.add(bytes);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcPageSourceFactory.java
@@ -190,8 +190,7 @@ public class OrcPageSourceFactory
                     orcDataSource,
                     physicalColumns,
                     typeManager,
-                    systemMemoryUsage,
-                    stats);
+                    systemMemoryUsage);
         }
         catch (Exception e) {
             try {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcPageSourceMemoryTracking.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcPageSourceMemoryTracking.java
@@ -157,8 +157,7 @@ public class TestOrcPageSourceMemoryTracking
         // Numbers used in assertions in this test may change when implementation is modified,
         // feel free to change them if they break in the future
 
-        FileFormatDataSourceStats stats = new FileFormatDataSourceStats();
-        ConnectorPageSource pageSource = testPreparer.newPageSource(stats);
+        ConnectorPageSource pageSource = testPreparer.newPageSource();
 
         assertEquals(pageSource.getSystemMemoryUsage(), 0);
 
@@ -224,7 +223,6 @@ public class TestOrcPageSourceMemoryTracking
         assertTrue(pageSource.isFinished());
         assertEquals(pageSource.getSystemMemoryUsage(), 0);
         pageSource.close();
-        assertEquals((int) stats.getLoadedBlockBytes().getAllTime().getCount(), 50);
     }
 
     @Test
@@ -364,9 +362,9 @@ public class TestOrcPageSourceMemoryTracking
             fileSplit = createTestFile(tempFilePath, new OrcOutputFormat(), serde, null, testColumns, NUM_ROWS);
         }
 
-        public ConnectorPageSource newPageSource(FileFormatDataSourceStats stats)
+        public ConnectorPageSource newPageSource()
         {
-            OrcPageSourceFactory orcPageSourceFactory = new OrcPageSourceFactory(TYPE_MANAGER, false, HDFS_ENVIRONMENT, stats);
+            OrcPageSourceFactory orcPageSourceFactory = new OrcPageSourceFactory(TYPE_MANAGER, false, HDFS_ENVIRONMENT, new FileFormatDataSourceStats());
             return HivePageSourceProvider.createHivePageSource(
                     ImmutableSet.of(),
                     ImmutableSet.of(orcPageSourceFactory),
@@ -389,7 +387,7 @@ public class TestOrcPageSourceMemoryTracking
 
         public SourceOperator newTableScanOperator(DriverContext driverContext)
         {
-            ConnectorPageSource pageSource = newPageSource(new FileFormatDataSourceStats());
+            ConnectorPageSource pageSource = newPageSource();
             SourceOperatorFactory sourceOperatorFactory = new TableScanOperatorFactory(
                     0,
                     new PlanNodeId("0"),
@@ -404,7 +402,7 @@ public class TestOrcPageSourceMemoryTracking
 
         public SourceOperator newScanFilterAndProjectOperator(DriverContext driverContext)
         {
-            ConnectorPageSource pageSource = newPageSource(new FileFormatDataSourceStats());
+            ConnectorPageSource pageSource = newPageSource();
             ImmutableList.Builder<RowExpression> projectionsBuilder = ImmutableList.builder();
             for (int i = 0; i < types.size(); i++) {
                 projectionsBuilder.add(field(i, types.get(i)));

--- a/presto-main/src/main/java/com/facebook/presto/operator/project/PageProcessor.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/PageProcessor.java
@@ -18,8 +18,9 @@ import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.DictionaryBlock;
 import com.facebook.presto.spi.block.DictionaryId;
+import com.facebook.presto.spi.block.LazyBlock;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.AbstractIterator;
-import com.google.common.collect.Iterators;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -30,9 +31,11 @@ import java.util.Optional;
 import java.util.function.Function;
 
 import static com.facebook.presto.operator.project.PageProcessorOutput.EMPTY_PAGE_PROCESSOR_OUTPUT;
+import static com.facebook.presto.operator.project.SelectedPositions.positionsRange;
 import static com.facebook.presto.spi.block.DictionaryId.randomDictionaryId;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Iterators.singletonIterator;
 import static java.util.Objects.requireNonNull;
 
 @NotThreadSafe
@@ -83,17 +86,34 @@ public class PageProcessor
             }
 
             if (projections.isEmpty()) {
-                return new PageProcessorOutput(page.getRetainedSizeInBytes(), Iterators.singletonIterator(new Page(selectedPositions.size())));
+                return new PageProcessorOutput(() -> calculateRetainedSizeWithoutLoading(page), singletonIterator(new Page(selectedPositions.size())));
             }
 
             if (selectedPositions.size() != page.getPositionCount()) {
-                return new PageProcessorOutput(page.getRetainedSizeInBytes(), new PositionsPageProcessorIterator(session, page, selectedPositions));
+                PositionsPageProcessorIterator pages = new PositionsPageProcessorIterator(session, page, selectedPositions);
+                return new PageProcessorOutput(pages::getRetainedSizeInBytes, pages);
             }
         }
 
-        return new PageProcessorOutput(
-                page.getRetainedSizeInBytes(),
-                new PositionsPageProcessorIterator(session, page, SelectedPositions.positionsRange(0, page.getPositionCount())));
+        PositionsPageProcessorIterator pages = new PositionsPageProcessorIterator(session, page, positionsRange(0, page.getPositionCount()));
+        return new PageProcessorOutput(pages::getRetainedSizeInBytes, pages);
+    }
+
+    @VisibleForTesting
+    public List<PageProjection> getProjections()
+    {
+        return projections;
+    }
+
+    private static long calculateRetainedSizeWithoutLoading(Page page)
+    {
+        long retainedSizeInBytes = 0;
+        for (Block block : page.getBlocks()) {
+            if (!(block instanceof LazyBlock) || ((LazyBlock) block).isLoaded()) {
+                retainedSizeInBytes += block.getRetainedSizeInBytes();
+            }
+        }
+        return retainedSizeInBytes;
     }
 
     private class PositionsPageProcessorIterator
@@ -104,6 +124,7 @@ public class PageProcessor
 
         private SelectedPositions selectedPositions;
         private final Block[] previouslyComputedResults;
+        private long retainedSizeInBytes;
 
         public PositionsPageProcessorIterator(ConnectorSession session, Page page, SelectedPositions selectedPositions)
         {
@@ -111,6 +132,12 @@ public class PageProcessor
             this.page = page;
             this.selectedPositions = selectedPositions;
             this.previouslyComputedResults = new Block[projections.size()];
+            updateRetainedSize();
+        }
+
+        public long getRetainedSizeInBytes()
+        {
+            return retainedSizeInBytes;
         }
 
         @Override
@@ -118,6 +145,7 @@ public class PageProcessor
         {
             while (true) {
                 if (selectedPositions.isEmpty()) {
+                    updateRetainedSize();
                     return endOfData();
                 }
 
@@ -155,7 +183,18 @@ public class PageProcessor
                     }
                 }
 
+                updateRetainedSize();
                 return page;
+            }
+        }
+
+        private void updateRetainedSize()
+        {
+            retainedSizeInBytes = calculateRetainedSizeWithoutLoading(page);
+            for (Block previouslyComputedResult : previouslyComputedResults) {
+                if (previouslyComputedResult != null) {
+                    retainedSizeInBytes += previouslyComputedResult.getRetainedSizeInBytes();
+                }
             }
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestScanFilterAndProjectOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestScanFilterAndProjectOperator.java
@@ -14,13 +14,19 @@
 package com.facebook.presto.operator;
 
 import com.facebook.presto.SequencePageBuilder;
+import com.facebook.presto.block.BlockAssertions;
 import com.facebook.presto.connector.ConnectorId;
 import com.facebook.presto.metadata.Split;
 import com.facebook.presto.operator.index.PageRecordSet;
 import com.facebook.presto.operator.project.PageProcessor;
+import com.facebook.presto.operator.project.TestPageProcessor.LazyPagePageProjection;
+import com.facebook.presto.operator.project.TestPageProcessor.SelectAllFilter;
+import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.FixedPageSource;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.RecordPageSource;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.LazyBlock;
 import com.facebook.presto.sql.gen.ExpressionCompiler;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.facebook.presto.sql.relational.RowExpression;
@@ -39,6 +45,7 @@ import java.util.function.Supplier;
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
 import static com.facebook.presto.operator.OperatorAssertion.toMaterializedResult;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.sql.relational.Expressions.field;
 import static com.facebook.presto.testing.TestingTaskContext.createTaskContext;
@@ -87,6 +94,44 @@ public class TestScanFilterAndProjectOperator
 
         MaterializedResult expected = toMaterializedResult(driverContext.getSession(), ImmutableList.of(VARCHAR), ImmutableList.of(input));
         MaterializedResult actual = toMaterializedResult(driverContext.getSession(), ImmutableList.of(VARCHAR), toPages(operator));
+
+        assertEquals(actual.getRowCount(), expected.getRowCount());
+        assertEquals(actual, expected);
+    }
+
+    @Test
+    public void testPageSourceLazyLoad()
+            throws Exception
+    {
+        Block inputBlock = BlockAssertions.createLongSequenceBlock(0, 100);
+        // If column 1 is loaded, test will fail
+        Page input = new Page(100, inputBlock, new LazyBlock(100, lazyBlock -> {
+            throw new AssertionError("Lazy block should not be loaded");
+        }));
+        DriverContext driverContext = newDriverContext();
+
+        List<RowExpression> projections = ImmutableList.of(field(0, VARCHAR));
+        Supplier<CursorProcessor> cursorProcessor = expressionCompiler.compileCursorProcessor(Optional.empty(), projections, "key");
+        PageProcessor pageProcessor = new PageProcessor(Optional.of(new SelectAllFilter()), ImmutableList.of(new LazyPagePageProjection()));
+
+        ScanFilterAndProjectOperator.ScanFilterAndProjectOperatorFactory factory = new ScanFilterAndProjectOperator.ScanFilterAndProjectOperatorFactory(
+                0,
+                new PlanNodeId("test"),
+                new PlanNodeId("0"),
+                (session, split, columns) -> new SinglePagePageSource(input),
+                cursorProcessor,
+                () -> pageProcessor,
+                ImmutableList.of(),
+                ImmutableList.of(BIGINT),
+                new DataSize(0, BYTE),
+                0);
+
+        SourceOperator operator = factory.createOperator(driverContext);
+        operator.addSplit(new Split(new ConnectorId("test"), TestingTransactionHandle.create(), TestingSplit.createLocalSplit()));
+        operator.noMoreSplits();
+
+        MaterializedResult expected = toMaterializedResult(driverContext.getSession(), ImmutableList.of(BIGINT), ImmutableList.of(new Page(inputBlock)));
+        MaterializedResult actual = toMaterializedResult(driverContext.getSession(), ImmutableList.of(BIGINT), toPages(operator));
 
         assertEquals(actual.getRowCount(), expected.getRowCount());
         assertEquals(actual, expected);
@@ -153,5 +198,60 @@ public class TestScanFilterAndProjectOperator
         return createTaskContext(executor, TEST_SESSION)
                 .addPipelineContext(0, true, true)
                 .addDriverContext();
+    }
+
+    public class SinglePagePageSource
+            implements ConnectorPageSource
+    {
+        private Page page;
+
+        public SinglePagePageSource(Page page)
+        {
+            this.page = page;
+        }
+
+        @Override
+        public void close()
+        {
+            page = null;
+        }
+
+        @Override
+        public long getTotalBytes()
+        {
+            return 0;
+        }
+
+        @Override
+        public long getCompletedBytes()
+        {
+            return 0;
+        }
+
+        @Override
+        public long getReadTimeNanos()
+        {
+            return 0;
+        }
+
+        @Override
+        public long getSystemMemoryUsage()
+        {
+            return 0;
+        }
+
+        @Override
+        public boolean isFinished()
+        {
+            return page == null;
+        }
+
+        @Override
+        public Page getNextPage()
+        {
+            Page page = this.page;
+            this.page = null;
+            return page;
+        }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/project/TestMergingPageOutput.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/project/TestMergingPageOutput.java
@@ -156,6 +156,6 @@ public class TestMergingPageOutput
     private static PageProcessorOutput createPageProcessorOutput(List<Page> pages)
     {
         long retainedSizeInBytes = pages.stream().mapToLong(Page::getRetainedSizeInBytes).sum();
-        return new PageProcessorOutput(retainedSizeInBytes, pages.iterator());
+        return new PageProcessorOutput(() -> retainedSizeInBytes, pages.iterator());
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyBlock.java
@@ -233,6 +233,11 @@ public class LazyBlock
         this.block = requireNonNull(block, "block is null");
     }
 
+    public boolean isLoaded()
+    {
+        return block != null;
+    }
+
     @Override
     public void assureLoaded()
     {


### PR DESCRIPTION
- Revert additional statistics for ORC (Those statistics cause considerable synchronization overhead)
- Avoid eager loading of all of the Page blocks in PageProcessor