### PR TITLE
Fix quadratic explain cost (quick fix)

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/CoefficientBasedStatsCalculator.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/CoefficientBasedStatsCalculator.java
@@ -101,7 +101,7 @@ public class CoefficientBasedStatsCalculator
         protected PlanNodeStatsEstimate visitPlan(PlanNode node, Void context)
         {
             // TODO: Explicitly visit GroupReference and throw an IllegalArgumentException
-            // this can only be done once we get rid of the StatelessLookup
+            // this can only be done once we get rid of the StatsAndCostCalculators
             return UNKNOWN_STATS;
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -50,7 +50,7 @@ import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.PlanOptimizers;
 import com.facebook.presto.sql.planner.StageExecutionPlan;
 import com.facebook.presto.sql.planner.SubPlan;
-import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.StatelessLookup;
 import com.facebook.presto.sql.planner.optimizations.PlanOptimizer;
 import com.facebook.presto.sql.tree.Explain;
 import com.facebook.presto.sql.tree.Expression;
@@ -105,7 +105,7 @@ public final class SqlQueryExecution
     private final FailureDetector failureDetector;
 
     private final QueryExplainer queryExplainer;
-    private final Lookup lookup;
+    private final StatelessLookup statelessLookup;
     private final AtomicReference<SqlQueryScheduler> queryScheduler = new AtomicReference<>();
     private final AtomicReference<Plan> queryPlan = new AtomicReference<>();
     private final NodeTaskMap nodeTaskMap;
@@ -125,7 +125,7 @@ public final class SqlQueryExecution
             SplitManager splitManager,
             NodePartitioningManager nodePartitioningManager,
             NodeScheduler nodeScheduler,
-            Lookup lookup,
+            StatelessLookup statelessLookup,
             List<PlanOptimizer> planOptimizers,
             RemoteTaskFactory remoteTaskFactory,
             LocationFactory locationFactory,
@@ -146,7 +146,7 @@ public final class SqlQueryExecution
             this.splitManager = requireNonNull(splitManager, "splitManager is null");
             this.nodePartitioningManager = requireNonNull(nodePartitioningManager, "nodePartitioningManager is null");
             this.nodeScheduler = requireNonNull(nodeScheduler, "nodeScheduler is null");
-            this.lookup = requireNonNull(lookup, "lookup is null");
+            this.statelessLookup = requireNonNull(statelessLookup, "statelessLookup is null");
             this.planOptimizers = requireNonNull(planOptimizers, "planOptimizers is null");
             this.locationFactory = requireNonNull(locationFactory, "locationFactory is null");
             this.queryExecutor = requireNonNull(queryExecutor, "queryExecutor is null");
@@ -308,7 +308,7 @@ public final class SqlQueryExecution
 
         // plan query
         PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
-        LogicalPlanner logicalPlanner = new LogicalPlanner(stateMachine.getSession(), planOptimizers, idAllocator, metadata, sqlParser, lookup);
+        LogicalPlanner logicalPlanner = new LogicalPlanner(stateMachine.getSession(), planOptimizers, idAllocator, metadata, sqlParser, statelessLookup);
         Plan plan = logicalPlanner.plan(analysis);
         queryPlan.set(plan);
 
@@ -571,7 +571,7 @@ public final class SqlQueryExecution
         private final SplitManager splitManager;
         private final NodePartitioningManager nodePartitioningManager;
         private final NodeScheduler nodeScheduler;
-        private final Lookup lookup;
+        private final StatelessLookup statelessLookup;
         private final List<PlanOptimizer> planOptimizers;
         private final RemoteTaskFactory remoteTaskFactory;
         private final TransactionManager transactionManager;
@@ -592,7 +592,7 @@ public final class SqlQueryExecution
                 SplitManager splitManager,
                 NodePartitioningManager nodePartitioningManager,
                 NodeScheduler nodeScheduler,
-                Lookup lookup,
+                StatelessLookup statelessLookup,
                 PlanOptimizers planOptimizers,
                 RemoteTaskFactory remoteTaskFactory,
                 TransactionManager transactionManager,
@@ -623,7 +623,7 @@ public final class SqlQueryExecution
             this.queryExplainer = requireNonNull(queryExplainer, "queryExplainer is null");
 
             this.executionPolicies = requireNonNull(executionPolicies, "schedulerPolicies is null");
-            this.lookup = requireNonNull(lookup, "lookup is null");
+            this.statelessLookup = requireNonNull(statelessLookup, "statelessLookup is null");
             this.planOptimizers = planOptimizers.get();
         }
 
@@ -647,7 +647,7 @@ public final class SqlQueryExecution
                     splitManager,
                     nodePartitioningManager,
                     nodeScheduler,
-                    lookup,
+                    statelessLookup,
                     planOptimizers,
                     remoteTaskFactory,
                     locationFactory,

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -50,7 +50,7 @@ import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.PlanOptimizers;
 import com.facebook.presto.sql.planner.StageExecutionPlan;
 import com.facebook.presto.sql.planner.SubPlan;
-import com.facebook.presto.sql.planner.iterative.StatelessLookup;
+import com.facebook.presto.sql.planner.iterative.StatsAndCostCalculators;
 import com.facebook.presto.sql.planner.optimizations.PlanOptimizer;
 import com.facebook.presto.sql.tree.Explain;
 import com.facebook.presto.sql.tree.Expression;
@@ -105,7 +105,7 @@ public final class SqlQueryExecution
     private final FailureDetector failureDetector;
 
     private final QueryExplainer queryExplainer;
-    private final StatelessLookup statelessLookup;
+    private final StatsAndCostCalculators statsAndCostCalculators;
     private final AtomicReference<SqlQueryScheduler> queryScheduler = new AtomicReference<>();
     private final AtomicReference<Plan> queryPlan = new AtomicReference<>();
     private final NodeTaskMap nodeTaskMap;
@@ -125,7 +125,7 @@ public final class SqlQueryExecution
             SplitManager splitManager,
             NodePartitioningManager nodePartitioningManager,
             NodeScheduler nodeScheduler,
-            StatelessLookup statelessLookup,
+            StatsAndCostCalculators statsAndCostCalculators,
             List<PlanOptimizer> planOptimizers,
             RemoteTaskFactory remoteTaskFactory,
             LocationFactory locationFactory,
@@ -146,7 +146,7 @@ public final class SqlQueryExecution
             this.splitManager = requireNonNull(splitManager, "splitManager is null");
             this.nodePartitioningManager = requireNonNull(nodePartitioningManager, "nodePartitioningManager is null");
             this.nodeScheduler = requireNonNull(nodeScheduler, "nodeScheduler is null");
-            this.statelessLookup = requireNonNull(statelessLookup, "statelessLookup is null");
+            this.statsAndCostCalculators = requireNonNull(statsAndCostCalculators, "statsAndCostCalculators is null");
             this.planOptimizers = requireNonNull(planOptimizers, "planOptimizers is null");
             this.locationFactory = requireNonNull(locationFactory, "locationFactory is null");
             this.queryExecutor = requireNonNull(queryExecutor, "queryExecutor is null");
@@ -308,7 +308,7 @@ public final class SqlQueryExecution
 
         // plan query
         PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
-        LogicalPlanner logicalPlanner = new LogicalPlanner(stateMachine.getSession(), planOptimizers, idAllocator, metadata, sqlParser, statelessLookup);
+        LogicalPlanner logicalPlanner = new LogicalPlanner(stateMachine.getSession(), planOptimizers, idAllocator, metadata, sqlParser, statsAndCostCalculators);
         Plan plan = logicalPlanner.plan(analysis);
         queryPlan.set(plan);
 
@@ -571,7 +571,7 @@ public final class SqlQueryExecution
         private final SplitManager splitManager;
         private final NodePartitioningManager nodePartitioningManager;
         private final NodeScheduler nodeScheduler;
-        private final StatelessLookup statelessLookup;
+        private final StatsAndCostCalculators statsAndCostCalculators;
         private final List<PlanOptimizer> planOptimizers;
         private final RemoteTaskFactory remoteTaskFactory;
         private final TransactionManager transactionManager;
@@ -592,7 +592,7 @@ public final class SqlQueryExecution
                 SplitManager splitManager,
                 NodePartitioningManager nodePartitioningManager,
                 NodeScheduler nodeScheduler,
-                StatelessLookup statelessLookup,
+                StatsAndCostCalculators statsAndCostCalculators,
                 PlanOptimizers planOptimizers,
                 RemoteTaskFactory remoteTaskFactory,
                 TransactionManager transactionManager,
@@ -623,7 +623,7 @@ public final class SqlQueryExecution
             this.queryExplainer = requireNonNull(queryExplainer, "queryExplainer is null");
 
             this.executionPolicies = requireNonNull(executionPolicies, "schedulerPolicies is null");
-            this.statelessLookup = requireNonNull(statelessLookup, "statelessLookup is null");
+            this.statsAndCostCalculators = requireNonNull(statsAndCostCalculators, "statsAndCostCalculators is null");
             this.planOptimizers = planOptimizers.get();
         }
 
@@ -647,7 +647,7 @@ public final class SqlQueryExecution
                     splitManager,
                     nodePartitioningManager,
                     nodeScheduler,
-                    statelessLookup,
+                    statsAndCostCalculators,
                     planOptimizers,
                     remoteTaskFactory,
                     locationFactory,

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -144,7 +144,6 @@ import com.facebook.presto.sql.planner.CompilerConfig;
 import com.facebook.presto.sql.planner.LocalExecutionPlanner;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
 import com.facebook.presto.sql.planner.PlanOptimizers;
-import com.facebook.presto.sql.planner.iterative.Lookup;
 import com.facebook.presto.sql.planner.iterative.StatelessLookup;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
@@ -428,7 +427,7 @@ public class ServerMainModule
         binder.bind(CostCalculator.class)
                 .annotatedWith(EstimatedExchanges.class)
                 .to(CostCalculatorWithEstimatedExchanges.class).in(Scopes.SINGLETON);
-        binder.bind(Lookup.class).to(StatelessLookup.class).in(Scopes.SINGLETON);
+        binder.bind(StatelessLookup.class).in(Scopes.SINGLETON);
         binder.bind(StatsCalculator.class).annotatedWith(SelectingStatsCalculator.Old.class).to(CoefficientBasedStatsCalculator.class).in(Scopes.SINGLETON);
         binder.bind(StatsCalculator.class).to(SelectingStatsCalculator.class).in(Scopes.SINGLETON);
         binder.bind(FilterStatsCalculator.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -144,7 +144,7 @@ import com.facebook.presto.sql.planner.CompilerConfig;
 import com.facebook.presto.sql.planner.LocalExecutionPlanner;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
 import com.facebook.presto.sql.planner.PlanOptimizers;
-import com.facebook.presto.sql.planner.iterative.StatelessLookup;
+import com.facebook.presto.sql.planner.iterative.StatsAndCostCalculators;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.transaction.ForTransactionManager;
@@ -427,7 +427,7 @@ public class ServerMainModule
         binder.bind(CostCalculator.class)
                 .annotatedWith(EstimatedExchanges.class)
                 .to(CostCalculatorWithEstimatedExchanges.class).in(Scopes.SINGLETON);
-        binder.bind(StatelessLookup.class).in(Scopes.SINGLETON);
+        binder.bind(StatsAndCostCalculators.class).in(Scopes.SINGLETON);
         binder.bind(StatsCalculator.class).annotatedWith(SelectingStatsCalculator.Old.class).to(CoefficientBasedStatsCalculator.class).in(Scopes.SINGLETON);
         binder.bind(StatsCalculator.class).to(SelectingStatsCalculator.class).in(Scopes.SINGLETON);
         binder.bind(FilterStatsCalculator.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
@@ -36,7 +36,7 @@ import com.facebook.presto.spi.Node;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.split.SplitManager;
 import com.facebook.presto.sql.parser.SqlParserOptions;
-import com.facebook.presto.sql.planner.iterative.StatelessLookup;
+import com.facebook.presto.sql.planner.iterative.StatsAndCostCalculators;
 import com.facebook.presto.testing.ProcedureTester;
 import com.facebook.presto.testing.TestingAccessControlManager;
 import com.facebook.presto.testing.TestingEventListenerManager;
@@ -101,7 +101,7 @@ public class TestingPrestoServer
     private final CatalogManager catalogManager;
     private final TransactionManager transactionManager;
     private final Metadata metadata;
-    private final StatelessLookup statelessLookup;
+    private final StatsAndCostCalculators statsAndCostCalculators;
     private final TestingAccessControlManager accessControl;
     private final ProcedureTester procedureTester;
     private final Optional<InternalResourceGroupManager> resourceGroupManager;
@@ -252,7 +252,7 @@ public class TestingPrestoServer
         catalogManager = injector.getInstance(CatalogManager.class);
         transactionManager = injector.getInstance(TransactionManager.class);
         metadata = injector.getInstance(Metadata.class);
-        statelessLookup = injector.getInstance(StatelessLookup.class);
+        statsAndCostCalculators = injector.getInstance(StatsAndCostCalculators.class);
         accessControl = injector.getInstance(TestingAccessControlManager.class);
         procedureTester = injector.getInstance(ProcedureTester.class);
         splitManager = injector.getInstance(SplitManager.class);
@@ -350,9 +350,9 @@ public class TestingPrestoServer
         return metadata;
     }
 
-    public StatelessLookup getLookup()
+    public StatsAndCostCalculators getStatsAndCostCalculators()
     {
-        return statelessLookup;
+        return statsAndCostCalculators;
     }
 
     public TestingAccessControlManager getAccessControl()

--- a/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
@@ -36,7 +36,7 @@ import com.facebook.presto.spi.Node;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.split.SplitManager;
 import com.facebook.presto.sql.parser.SqlParserOptions;
-import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.StatelessLookup;
 import com.facebook.presto.testing.ProcedureTester;
 import com.facebook.presto.testing.TestingAccessControlManager;
 import com.facebook.presto.testing.TestingEventListenerManager;
@@ -101,7 +101,7 @@ public class TestingPrestoServer
     private final CatalogManager catalogManager;
     private final TransactionManager transactionManager;
     private final Metadata metadata;
-    private final Lookup lookup;
+    private final StatelessLookup statelessLookup;
     private final TestingAccessControlManager accessControl;
     private final ProcedureTester procedureTester;
     private final Optional<InternalResourceGroupManager> resourceGroupManager;
@@ -252,7 +252,7 @@ public class TestingPrestoServer
         catalogManager = injector.getInstance(CatalogManager.class);
         transactionManager = injector.getInstance(TransactionManager.class);
         metadata = injector.getInstance(Metadata.class);
-        lookup = injector.getInstance(Lookup.class);
+        statelessLookup = injector.getInstance(StatelessLookup.class);
         accessControl = injector.getInstance(TestingAccessControlManager.class);
         procedureTester = injector.getInstance(ProcedureTester.class);
         splitManager = injector.getInstance(SplitManager.class);
@@ -350,9 +350,9 @@ public class TestingPrestoServer
         return metadata;
     }
 
-    public Lookup getLookup()
+    public StatelessLookup getLookup()
     {
-        return lookup;
+        return statelessLookup;
     }
 
     public TestingAccessControlManager getAccessControl()

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/QueryExplainer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/QueryExplainer.java
@@ -24,7 +24,7 @@ import com.facebook.presto.sql.planner.PlanFragmenter;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.PlanOptimizers;
 import com.facebook.presto.sql.planner.SubPlan;
-import com.facebook.presto.sql.planner.iterative.StatelessLookup;
+import com.facebook.presto.sql.planner.iterative.StatsAndCostCalculators;
 import com.facebook.presto.sql.planner.optimizations.PlanOptimizer;
 import com.facebook.presto.sql.planner.planPrinter.PlanPrinter;
 import com.facebook.presto.sql.tree.ExplainType.Type;
@@ -46,7 +46,7 @@ public class QueryExplainer
     private final Metadata metadata;
     private final AccessControl accessControl;
     private final SqlParser sqlParser;
-    private final StatelessLookup statelessLookup;
+    private final StatsAndCostCalculators statsAndCostCalculators;
     private final Map<Class<? extends Statement>, DataDefinitionTask<?>> dataDefinitionTask;
 
     @Inject
@@ -55,14 +55,14 @@ public class QueryExplainer
             Metadata metadata,
             AccessControl accessControl,
             SqlParser sqlParser,
-            StatelessLookup statelessLookup,
+            StatsAndCostCalculators statsAndCostCalculators,
             Map<Class<? extends Statement>, DataDefinitionTask<?>> dataDefinitionTask)
     {
         this(planOptimizers.get(),
                 metadata,
                 accessControl,
                 sqlParser,
-                statelessLookup,
+                statsAndCostCalculators,
                 dataDefinitionTask);
     }
 
@@ -71,14 +71,14 @@ public class QueryExplainer
             Metadata metadata,
             AccessControl accessControl,
             SqlParser sqlParser,
-            StatelessLookup statelessLookup,
+            StatsAndCostCalculators statsAndCostCalculators,
             Map<Class<? extends Statement>, DataDefinitionTask<?>> dataDefinitionTask)
     {
         this.planOptimizers = requireNonNull(planOptimizers, "planOptimizers is null");
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
         this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
-        this.statelessLookup = requireNonNull(statelessLookup, "statelessLookup is null");
+        this.statsAndCostCalculators = requireNonNull(statsAndCostCalculators, "statsAndCostCalculators is null");
         this.dataDefinitionTask = ImmutableMap.copyOf(requireNonNull(dataDefinitionTask, "dataDefinitionTask is null"));
     }
 
@@ -98,10 +98,10 @@ public class QueryExplainer
         switch (planType) {
             case LOGICAL:
                 Plan plan = getLogicalPlan(session, statement, parameters);
-                return PlanPrinter.textLogicalPlan(plan.getRoot(), plan.getTypes(), metadata, statelessLookup.createCachingNonResolvingLookup(), session);
+                return PlanPrinter.textLogicalPlan(plan.getRoot(), plan.getTypes(), metadata, statsAndCostCalculators.createCachingNonResolvingLookup(), session);
             case DISTRIBUTED:
                 SubPlan subPlan = getDistributedPlan(session, statement, parameters);
-                return PlanPrinter.textDistributedPlan(subPlan, metadata, statelessLookup.createCachingNonResolvingLookup(), session);
+                return PlanPrinter.textDistributedPlan(subPlan, metadata, statsAndCostCalculators.createCachingNonResolvingLookup(), session);
         }
         throw new IllegalArgumentException("Unhandled plan type: " + planType);
     }
@@ -138,7 +138,7 @@ public class QueryExplainer
         PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
 
         // plan statement
-        LogicalPlanner logicalPlanner = new LogicalPlanner(session, planOptimizers, idAllocator, metadata, sqlParser, statelessLookup);
+        LogicalPlanner logicalPlanner = new LogicalPlanner(session, planOptimizers, idAllocator, metadata, sqlParser, statsAndCostCalculators);
         return logicalPlanner.plan(analysis);
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -111,7 +111,7 @@ import com.facebook.presto.sql.gen.OrderingCompiler;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.Partitioning.ArgumentBinding;
 import com.facebook.presto.sql.planner.SortExpressionExtractor.SortExpression;
-import com.facebook.presto.sql.planner.iterative.StatelessLookup;
+import com.facebook.presto.sql.planner.iterative.NonResolvingCachingLookup;
 import com.facebook.presto.sql.planner.optimizations.IndexJoinOptimizer;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.AggregationNode.Aggregation;
@@ -678,7 +678,7 @@ public class LocalExecutionPlanner
                     node.getId(),
                     queryPerformanceFetcher.get(),
                     metadata,
-                    new StatelessLookup(statsCalculator, costCalculator),
+                    new NonResolvingCachingLookup(statsCalculator, costCalculator),
                     node.isVerbose());
             return new PhysicalOperation(operatorFactory, makeLayout(node), source);
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
@@ -30,7 +30,7 @@ import com.facebook.presto.sql.analyzer.RelationId;
 import com.facebook.presto.sql.analyzer.RelationType;
 import com.facebook.presto.sql.analyzer.Scope;
 import com.facebook.presto.sql.parser.SqlParser;
-import com.facebook.presto.sql.planner.iterative.StatelessLookup;
+import com.facebook.presto.sql.planner.iterative.StatsAndCostCalculators;
 import com.facebook.presto.sql.planner.optimizations.PlanOptimizer;
 import com.facebook.presto.sql.planner.plan.Assignments;
 import com.facebook.presto.sql.planner.plan.DeleteNode;
@@ -90,14 +90,14 @@ public class LogicalPlanner
     private final SymbolAllocator symbolAllocator = new SymbolAllocator();
     private final Metadata metadata;
     private final SqlParser sqlParser;
-    private final StatelessLookup statelessLookup;
+    private final StatsAndCostCalculators statsAndCostCalculators;
 
     public LogicalPlanner(Session session,
             List<PlanOptimizer> planOptimizers,
             PlanNodeIdAllocator idAllocator,
             Metadata metadata,
             SqlParser sqlParser,
-            StatelessLookup statelessLookup)
+            StatsAndCostCalculators statsAndCostCalculators)
     {
         requireNonNull(session, "session is null");
         requireNonNull(planOptimizers, "planOptimizers is null");
@@ -110,7 +110,7 @@ public class LogicalPlanner
         this.idAllocator = idAllocator;
         this.metadata = metadata;
         this.sqlParser = sqlParser;
-        this.statelessLookup = requireNonNull(statelessLookup, "statelessLookup is null");
+        this.statsAndCostCalculators = requireNonNull(statsAndCostCalculators, "statsAndCostCalculators is null");
     }
 
     public Plan plan(Analysis analysis)
@@ -134,7 +134,7 @@ public class LogicalPlanner
             PlanSanityChecker.validate(root, session, metadata, sqlParser, symbolAllocator.getTypes());
         }
 
-        return new Plan(root, symbolAllocator.getTypes(), statelessLookup.createCachingNonResolvingLookup(), session);
+        return new Plan(root, symbolAllocator.getTypes(), statsAndCostCalculators.createCachingNonResolvingLookup(), session);
     }
 
     public PlanNode planStatement(Analysis analysis, Statement statement)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/NonResolvingCachingLookup.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/NonResolvingCachingLookup.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.cost.CostCalculator;
+import com.facebook.presto.cost.PlanNodeCostEstimate;
+import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.cost.StatsCalculator;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
+import static java.util.Objects.requireNonNull;
+
+@NotThreadSafe
+public class NonResolvingCachingLookup
+        implements Lookup
+{
+    private final StatsCalculator statsCalculator;
+    private final CostCalculator costCalculator;
+
+    private final Map<PlanNode, PlanNodeStatsEstimate> stats = new HashMap<>();
+    private final Map<PlanNode, PlanNodeCostEstimate> cummulativeCosts = new HashMap<>();
+
+    public NonResolvingCachingLookup(StatsCalculator statsCalculator, CostCalculator costCalculator)
+    {
+        this.statsCalculator = requireNonNull(statsCalculator, "statsCalculator is null");
+        this.costCalculator = requireNonNull(costCalculator, "costCalculator is null");
+    }
+
+    @Override
+    public PlanNode resolve(PlanNode node)
+    {
+        verify(!(node instanceof GroupReference), "Unexpected GroupReference");
+        return node;
+    }
+
+    @Override
+    public PlanNodeStatsEstimate getStats(PlanNode planNode, Session session, Map<Symbol, Type> types)
+    {
+        if (!stats.containsKey(planNode)) {
+            // cannot use Map.computeIfAbsent due to stats map modification in the mappingFunction callback
+            PlanNodeStatsEstimate statsEstimate = statsCalculator.calculateStats(planNode, this, session, types);
+            requireNonNull(stats, "computed stats can not be null");
+            checkState(stats.put(planNode, statsEstimate) == null, "statistics for " + planNode + " already computed");
+        }
+        return stats.get(planNode);
+    }
+
+    @Override
+    public PlanNodeCostEstimate getCumulativeCost(PlanNode planNode, Session session, Map<Symbol, Type> types)
+    {
+        if (!cummulativeCosts.containsKey(planNode)) {
+            // cannot use Map.computeIfAbsent due to costs map modification in the mappingFunction callback
+            PlanNodeCostEstimate cost = costCalculator.calculateCumulativeCost(planNode, this, session, types);
+            requireNonNull(cummulativeCosts, "computed cost can not be null");
+            checkState(cummulativeCosts.put(planNode, cost) == null, "cost for " + planNode + " already computed");
+        }
+        return cummulativeCosts.get(planNode);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/StatelessLookup.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/StatelessLookup.java
@@ -14,27 +14,17 @@
 
 package com.facebook.presto.sql.planner.iterative;
 
-import com.facebook.presto.Session;
 import com.facebook.presto.cost.CostCalculator;
-import com.facebook.presto.cost.PlanNodeCostEstimate;
-import com.facebook.presto.cost.PlanNodeStatsEstimate;
 import com.facebook.presto.cost.StatsCalculator;
-import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.sql.planner.Symbol;
-import com.facebook.presto.sql.planner.plan.PlanNode;
 
 import javax.annotation.concurrent.ThreadSafe;
 import javax.inject.Inject;
 
-import java.util.Map;
-
-import static com.google.common.base.Verify.verify;
 import static java.util.Objects.requireNonNull;
 
-// TODO: remove.  Eventually all uses of StatelessLookup should be replaced with the Lookup specific to the plan
+// TODO: remove.
 @ThreadSafe
 public class StatelessLookup
-        implements Lookup
 {
     private final StatsCalculator statsCalculator;
     private final CostCalculator costCalculator;
@@ -46,30 +36,8 @@ public class StatelessLookup
         this.costCalculator = requireNonNull(costCalculator, "costCalculator is null");
     }
 
-    @Override
-    public PlanNode resolve(PlanNode node)
+    public Lookup createCachingNonResolvingLookup()
     {
-        verify(!(node instanceof GroupReference), "Unexpected GroupReference");
-        return node;
-    }
-
-    @Override
-    public PlanNodeStatsEstimate getStats(PlanNode planNode, Session session, Map<Symbol, Type> types)
-    {
-        return statsCalculator.calculateStats(
-                planNode,
-                this,
-                session,
-                types);
-    }
-
-    @Override
-    public PlanNodeCostEstimate getCumulativeCost(PlanNode planNode, Session session, Map<Symbol, Type> types)
-    {
-        return costCalculator.calculateCumulativeCost(
-                planNode,
-                this,
-                session,
-                types);
+        return new NonResolvingCachingLookup(statsCalculator, costCalculator);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/StatsAndCostCalculators.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/StatsAndCostCalculators.java
@@ -24,13 +24,13 @@ import static java.util.Objects.requireNonNull;
 
 // TODO: remove.
 @ThreadSafe
-public class StatelessLookup
+public class StatsAndCostCalculators
 {
     private final StatsCalculator statsCalculator;
     private final CostCalculator costCalculator;
 
     @Inject
-    public StatelessLookup(StatsCalculator statsCalculator, CostCalculator costCalculator)
+    public StatsAndCostCalculators(StatsCalculator statsCalculator, CostCalculator costCalculator)
     {
         this.statsCalculator = requireNonNull(statsCalculator, "statsCalculator is null");
         this.costCalculator = requireNonNull(costCalculator, "costCalculator is null");

--- a/presto-main/src/main/java/com/facebook/presto/testing/QueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/QueryRunner.java
@@ -18,6 +18,7 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.QualifiedObjectName;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.StatelessLookup;
 import com.facebook.presto.transaction.TransactionManager;
 import org.intellij.lang.annotations.Language;
 
@@ -40,7 +41,15 @@ public interface QueryRunner
 
     Metadata getMetadata();
 
-    Lookup getLookup();
+    /**
+     * Return lookup must be used with caution, not shared among threads and dispoed of A.S.A.P
+     */
+    default Lookup getLookup()
+    {
+        return getStatelessLookup().createCachingNonResolvingLookup();
+    }
+
+    StatelessLookup getStatelessLookup();
 
     TestingAccessControlManager getAccessControl();
 

--- a/presto-main/src/main/java/com/facebook/presto/testing/QueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/QueryRunner.java
@@ -18,7 +18,7 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.QualifiedObjectName;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.sql.planner.iterative.Lookup;
-import com.facebook.presto.sql.planner.iterative.StatelessLookup;
+import com.facebook.presto.sql.planner.iterative.StatsAndCostCalculators;
 import com.facebook.presto.transaction.TransactionManager;
 import org.intellij.lang.annotations.Language;
 
@@ -46,10 +46,10 @@ public interface QueryRunner
      */
     default Lookup getLookup()
     {
-        return getStatelessLookup().createCachingNonResolvingLookup();
+        return getStatsAndCostCalculators().createCachingNonResolvingLookup();
     }
 
-    StatelessLookup getStatelessLookup();
+    StatsAndCostCalculators getStatsAndCostCalculators();
 
     TestingAccessControlManager getAccessControl();
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -325,7 +325,7 @@ public abstract class AbstractTestQueryFramework
                 metadata,
                 queryRunner.getAccessControl(),
                 sqlParser,
-                queryRunner.getStatelessLookup(),
+                queryRunner.getStatsAndCostCalculators(),
                 ImmutableMap.of());
     }
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -325,7 +325,7 @@ public abstract class AbstractTestQueryFramework
                 metadata,
                 queryRunner.getAccessControl(),
                 sqlParser,
-                queryRunner.getLookup(),
+                queryRunner.getStatelessLookup(),
                 ImmutableMap.of());
     }
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
@@ -28,7 +28,7 @@ import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.facebook.presto.sql.planner.Plan;
-import com.facebook.presto.sql.planner.iterative.StatelessLookup;
+import com.facebook.presto.sql.planner.iterative.StatsAndCostCalculators;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.testing.TestingAccessControlManager;
@@ -230,9 +230,9 @@ public class DistributedQueryRunner
     }
 
     @Override
-    public StatelessLookup getStatelessLookup()
+    public StatsAndCostCalculators getStatsAndCostCalculators()
     {
-        return coordinator.getLookup();
+        return coordinator.getStatsAndCostCalculators();
     }
 
     @Override

--- a/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
@@ -28,7 +28,7 @@ import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.facebook.presto.sql.planner.Plan;
-import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.StatelessLookup;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.testing.TestingAccessControlManager;
@@ -230,7 +230,7 @@ public class DistributedQueryRunner
     }
 
     @Override
-    public Lookup getLookup()
+    public StatelessLookup getStatelessLookup()
     {
         return coordinator.getLookup();
     }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/StandaloneQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/StandaloneQueryRunner.java
@@ -23,7 +23,7 @@ import com.facebook.presto.server.testing.TestingPrestoServer;
 import com.facebook.presto.spi.Node;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.sql.parser.SqlParserOptions;
-import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.StatelessLookup;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.testing.TestingAccessControlManager;
@@ -134,7 +134,7 @@ public final class StandaloneQueryRunner
     }
 
     @Override
-    public Lookup getLookup()
+    public StatelessLookup getStatelessLookup()
     {
         return server.getLookup();
     }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/StandaloneQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/StandaloneQueryRunner.java
@@ -23,7 +23,7 @@ import com.facebook.presto.server.testing.TestingPrestoServer;
 import com.facebook.presto.spi.Node;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.sql.parser.SqlParserOptions;
-import com.facebook.presto.sql.planner.iterative.StatelessLookup;
+import com.facebook.presto.sql.planner.iterative.StatsAndCostCalculators;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.testing.TestingAccessControlManager;
@@ -134,9 +134,9 @@ public final class StandaloneQueryRunner
     }
 
     @Override
-    public StatelessLookup getStatelessLookup()
+    public StatsAndCostCalculators getStatsAndCostCalculators()
     {
-        return server.getLookup();
+        return server.getStatsAndCostCalculators();
     }
 
     @Override


### PR DESCRIPTION
Before the change, `explain tpc-ds q78;` was calling `com.facebook.presto.cost.FilterStatsCalculator.FilterExpressionStatsCalculatingVisitor#visitComparisonExpression` 8680 times, after: 19 times.