### PR TITLE
Estimate IN involving expression in left hand side

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/FilterStatsCalculator.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/FilterStatsCalculator.java
@@ -242,8 +242,8 @@ public class FilterStatsCalculator
         @Override
         protected Optional<PlanNodeStatsEstimate> visitInPredicate(InPredicate node, Void context)
         {
-            if (!(node.getValueList() instanceof InListExpression) || !(node.getValue() instanceof SymbolReference)) {
-                return visitExpression(node, context);
+            if (!(node.getValueList() instanceof InListExpression)) {
+                return Optional.empty();
             }
 
             InListExpression inList = (InListExpression) node.getValueList();
@@ -252,7 +252,7 @@ public class FilterStatsCalculator
                     .collect(ImmutableList.toImmutableList());
 
             if (!valuesEqualityStats.stream().allMatch(Optional::isPresent)) {
-                return visitExpression(node, context);
+                return Optional.empty();
             }
 
             PlanNodeStatsEstimate statsSum = valuesEqualityStats.stream()
@@ -260,18 +260,26 @@ public class FilterStatsCalculator
                     .reduce(filterForFalseExpression().get(), PlanNodeStatsEstimateMath::addStatsAndSumDistinctValues);
 
             if (isNaN(statsSum.getOutputRowCount())) {
-                return visitExpression(node, context);
+                return Optional.empty();
             }
 
-            Symbol inValueSymbol = Symbol.from(node.getValue());
-            SymbolStatsEstimate symbolStats = input.getSymbolStatistics(inValueSymbol);
-            double notNullValuesBeforeIn = input.getOutputRowCount() * (1 - symbolStats.getNullsFraction());
+            Optional<Symbol> inValueSymbol = asSymbol(node.getValue());
+            Optional<SymbolStatsEstimate> inValueStatsOptional = getSymbolStatsEstimate(node.getValue());
+            if (!inValueStatsOptional.isPresent()) {
+                return Optional.empty();
+            }
+            SymbolStatsEstimate inValueStats = inValueStatsOptional.get();
 
-            SymbolStatsEstimate newSymbolStats = statsSum.getSymbolStatistics(inValueSymbol)
-                    .mapDistinctValuesCount(newDistinctValuesCount -> min(newDistinctValuesCount, symbolStats.getDistinctValuesCount()));
+            double notNullValuesBeforeIn = input.getOutputRowCount() * (1 - inValueStats.getNullsFraction());
 
-            return Optional.of(input.mapOutputRowCount(rowCount -> min(statsSum.getOutputRowCount(), notNullValuesBeforeIn))
-                    .mapSymbolColumnStatistics(inValueSymbol, oldSymbolStats -> newSymbolStats));
+            PlanNodeStatsEstimate estimate = input.mapOutputRowCount(rowCount -> min(statsSum.getOutputRowCount(), notNullValuesBeforeIn));
+
+            if (inValueSymbol.isPresent()) {
+                SymbolStatsEstimate newSymbolStats = statsSum.getSymbolStatistics(inValueSymbol.get())
+                        .mapDistinctValuesCount(newDistinctValuesCount -> min(newDistinctValuesCount, inValueStats.getDistinctValuesCount()));
+                estimate = estimate.mapSymbolColumnStatistics(inValueSymbol.get(), oldSymbolStats -> newSymbolStats);
+            }
+            return Optional.of(estimate);
         }
 
         @Override

--- a/presto-tpcds/src/test/java/com/facebook/presto/tpcds/statistics/TestTpcdsLocalStats.java
+++ b/presto-tpcds/src/test/java/com/facebook/presto/tpcds/statistics/TestTpcdsLocalStats.java
@@ -123,4 +123,13 @@ public class TestTpcdsLocalStats
         statisticsAssertion.check("SELECT * FROM promotion WHERE p_cost < 2000.0", // p_cost is always 1000.00, so all rows should be left
                 checks -> checks.estimate(OUTPUT_ROW_COUNT, noError()));
     }
+
+    @Test
+    public void testIn()
+    {
+        statisticsAssertion.check("SELECT * FROM item WHERE i_category IN ('Women                                             ')",
+                checks -> checks.estimate(OUTPUT_ROW_COUNT, defaultTolerance()));
+        statisticsAssertion.check("SELECT * FROM ship_mode WHERE sm_carrier IN ('DHL                 ', 'BARIAN              ')",
+                checks -> checks.estimate(OUTPUT_ROW_COUNT, defaultTolerance()));
+    }
 }


### PR DESCRIPTION
`char IN ('a', ...)` involves cast from `char` to `varchar` on the left
hand side of the IN predicate. This commit adds preliminary support for
estimating such comparisons.

**Warning: this is PR to `cbo_1`**