### PR TITLE
Allow incompletely bucketed tables for Hive

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestBackgroundHiveSplitLoader.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestBackgroundHiveSplitLoader.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.apache.hadoop.fs.LocatedFileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static com.facebook.presto.hive.BackgroundHiveSplitLoader.fillInEmptyBuckets;
+import static java.util.Collections.emptySet;
+import static org.testng.Assert.assertEquals;
+
+public class TestBackgroundHiveSplitLoader
+{
+    @Test
+    public void testFillInAllEmptyBuckets()
+    {
+        assertEquals(
+                fillInEmptyBuckets(ImmutableList.of(), 5),
+                ImmutableList.of(emptySet(), emptySet(), emptySet(), emptySet(), emptySet()));
+    }
+
+    @Test
+    public void testFillInInitialEmptyBucket()
+    {
+        List<Set<LocatedFileStatus>> initialBucketList = createBucketList("000001_1", "000002_1", "000003_1", "000004_1");
+        ImmutableList.Builder<Set<LocatedFileStatus>> expectedBucketList = ImmutableList.builder();
+        expectedBucketList.add(emptySet());
+        expectedBucketList.addAll(initialBucketList);
+        assertEquals(
+                fillInEmptyBuckets(initialBucketList, 5),
+                expectedBucketList.build());
+    }
+
+    @Test
+    public void testFillInVariousEmptyBuckets()
+    {
+        List<Set<LocatedFileStatus>> initialBucketList = createBucketList("000000_1", "000003_1");
+        ImmutableList.Builder<Set<LocatedFileStatus>> expectedBucketList = ImmutableList.builder();
+        expectedBucketList.add(initialBucketList.get(0));
+        expectedBucketList.add(emptySet());
+        expectedBucketList.add(emptySet());
+        expectedBucketList.add(initialBucketList.get(1));
+        expectedBucketList.add(emptySet());
+        assertEquals(
+                fillInEmptyBuckets(initialBucketList, 5),
+                expectedBucketList.build());
+    }
+
+    private List<Set<LocatedFileStatus>> createBucketList(String... bucketIds)
+    {
+        ImmutableList.Builder<Set<LocatedFileStatus>> bucketListBuilder = ImmutableList.builder();
+        for (String bucketId : bucketIds) {
+            bucketListBuilder.add(ImmutableSet.of(getLocatedFileStatus(bucketId)));
+        }
+        return bucketListBuilder.build();
+    }
+
+    private LocatedFileStatus getLocatedFileStatus(String bucketId)
+    {
+        return new LocatedFileStatus(0, false, 0, 0L, 0L, 0L, FsPermission.createImmutable((short) 777), "owner", "group", null, new Path("/user/hive/warehouse/" + bucketId), null);
+    }
+}

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveBucketedTables.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveBucketedTables.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.tests.hive;
 
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import com.teradata.tempto.ProductTest;
 import com.teradata.tempto.Requirement;
 import com.teradata.tempto.Requirements;
@@ -25,6 +27,7 @@ import com.teradata.tempto.query.QueryExecutionException;
 import org.testng.annotations.Test;
 
 import java.sql.SQLException;
+import java.util.List;
 import java.util.Optional;
 
 import static com.facebook.presto.tests.TestGroups.HIVE_CONNECTOR;
@@ -195,6 +198,32 @@ public class TestHiveBucketedTables
         enableEmptyBucketedPartitions();
         assertThat(query(format("SELECT count(*) FROM %s", tableName)))
                 .containsExactly(row(0));
+    }
+
+    @Test(groups = {HIVE_CONNECTOR})
+    public void testSelectFromIncompleteBucketedTableEmptyTablesAllowed()
+            throws SQLException
+    {
+        String tableName = mutableTableInstanceOf(BUCKETED_EMPTY_NATION).getNameInDatabase();
+        enableEmptyBucketedPartitions();
+        populateRowToHiveTable(tableName, ImmutableList.of("2", "'name'", "2", "'comment'"), Optional.empty());
+        // insert one row into nation
+        assertThat(query(format("SELECT count(*) from %s", tableName)))
+                .containsExactly(row(1));
+        assertThat(query(format("select n_nationkey from %s where n_regionkey = 2", tableName)))
+                .containsExactly(row(2));
+    }
+
+    private static void populateRowToHiveTable(String destination, List<String> values, Optional<String> partition)
+    {
+        String queryStatement = format("INSERT INTO TABLE %s" +
+                        (partition.isPresent() ? format(" PARTITION (%s) ", partition.get()) : " ") +
+                        "SELECT %s from (select 'foo') x",
+                destination, Joiner.on(",").join(values));
+
+        onHive().executeQuery("set hive.enforce.bucketing = true");
+        onHive().executeQuery("set hive.enforce.sorting = true");
+        onHive().executeQuery(queryStatement);
     }
 
     private static void enableMultiFileBucketing()


### PR DESCRIPTION
If you have a Hive 2 table clustered into more buckets than exist rows in the table, Presto
failed. This patch extends empty bucket support to allow tables that have between 0 and the
number of buckets # of files.